### PR TITLE
Add mail templates for courses

### DIFF
--- a/common/mails/config.ts
+++ b/common/mails/config.ts
@@ -15,6 +15,7 @@ const DEFAULTSENDERS = {
     anmeldung: '"Corona School Team" <anmeldung@corona-school.de>',
     noreply: '"Corona School Team" <noreply@corona-school.de>',
     screening: '"Corona School Team" <screening@corona-school.de>',
+    support: '"Corona School Team" <support@corona-school.de>',
 };
 
 export { mailjetSmtp, DEFAULTSENDERS };

--- a/common/mails/templates.ts
+++ b/common/mails/templates.ts
@@ -148,4 +148,19 @@ export const mailjet = {
             variables: variables,
         };
     },
+    COURSESCANCELLED: (variables: {
+        participantFirstname: string;
+        courseName: string;
+        firstLectureDate: string;
+        firstLectureTime: string;
+    }) => {
+        return <TemplateMail>{
+            type: "coursecancelledparticipantnotification",
+            id: 1498806,
+            sender: DEFAULTSENDERS.support,
+            title: "Dein Kurs wurde abgesagt!",
+            disabled: false,
+            variables: variables,
+        };
+    },
 };

--- a/common/mails/templates.ts
+++ b/common/mails/templates.ts
@@ -163,4 +163,34 @@ export const mailjet = {
             variables: variables,
         };
     },
+    COURSESUPCOMINGREMINDERINSTRUCTOR: (variables: {
+        participantFirstname: string;
+        courseName: string;
+        firstLectureDate: string;
+        firstLectureTime: string;
+    }) => {
+        return <TemplateMail>{
+            type: "courseupcomingfirstlecturereminderinstructors",
+            id: 1498911,
+            sender: DEFAULTSENDERS.support,
+            title: "Dein Kurs startet bald!",
+            disabled: false,
+            variables: variables,
+        };
+    },
+    COURSESUPCOMINGREMINDERPARTICIPANT: (variables: {
+        participantFirstname: string;
+        courseName: string;
+        firstLectureDate: string;
+        firstLectureTime: string;
+    }) => {
+        return <TemplateMail>{
+            type: "courseupcomingfirstlecturereminderparticipants",
+            id: 1498899,
+            sender: DEFAULTSENDERS.support,
+            title: "Dein Kurs startet bald!",
+            disabled: false,
+            variables: variables,
+        };
+    },
 };


### PR DESCRIPTION
This pull request will add the required **templates** for mails that were sent in context of Corona School's courses: 
* notify participants that a course was cancelled
* remind an instructor of an upcoming course
* remind a participant of an upcoming course