### PR TITLE
fix sending of feedback requests

### DIFF
--- a/jobs/periodic/feedback-request/index.ts
+++ b/jobs/periodic/feedback-request/index.ts
@@ -65,7 +65,7 @@ function filterMatches(matches: Match[]): Match[] {
 async function sendFeedbackRequestsToStudents(manager: EntityManager, matches: Match[]) {
     try {
         for (const m of matches) {
-            sendFeedbackRequestStudent(m.student, m.pupil);
+            await sendFeedbackRequestStudent(m.student, m.pupil);
             m.feedbackToStudentMail = true;
             await manager.save(Match, m);
         }
@@ -82,7 +82,7 @@ async function sendFeedbackRequestsToStudents(manager: EntityManager, matches: M
 async function sendFeedbackRequestsToPupils(manager: EntityManager, matches: Match[]) {
     try {
         for (const m of matches) {
-            sendFeedbackRequestPupil(m.student, m.pupil);
+            await sendFeedbackRequestPupil(m.student, m.pupil);
             m.feedbackToPupilMail = true;
             await manager.save(Match, m);
         }


### PR DESCRIPTION
adds an await to wait for the mail to be sent before saving having the mail sent. This was mentioned by @geroembser in #92. Otherwise matches will have information of mails having been sent, that have not been, if the sending had an error