### PR TITLE
Project Coaching User API endpoints

### DIFF
--- a/common/entity/ProjectMatch.ts
+++ b/common/entity/ProjectMatch.ts
@@ -1,0 +1,57 @@
+import {
+    Column,
+    CreateDateColumn,
+    Entity,
+    Index,
+    JoinColumn,
+    ManyToOne,
+    PrimaryGeneratedColumn,
+    Unique,
+    UpdateDateColumn
+} from "typeorm";
+import { Student } from "./Student";
+import { Pupil } from "./Pupil";
+
+@Entity()
+@Unique("UQ_PJ_MATCH", ["student", "pupil"])
+export class ProjectMatch {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Index({ unique: true })
+    @Column()
+    uuid: string;
+
+    @CreateDateColumn({ type: "timestamp" })
+    createdAt: Date;
+
+    @UpdateDateColumn({ type: "timestamp" })
+    updatedAt: Date;
+
+    @ManyToOne((type) => Student, (student) => student.projectMatches, {
+        eager: true
+    })
+    @JoinColumn()
+    student: Student;
+
+    @ManyToOne((type) => Pupil, (pupil) => pupil.projectMatches, {
+        eager: true
+    })
+    @JoinColumn()
+    pupil: Pupil;
+
+    @Column({
+        default: false
+    })
+    dissolved: boolean;
+
+    @Column({
+        default: null,
+        nullable: true
+    })
+    dissolveReason: number;
+
+    jitsiLink(): string {
+        return `https://meet.jit.si/CoronaSchool-ProjectCoaching-${encodeURIComponent(this.uuid)}`;
+    }
+}

--- a/common/entity/Pupil.ts
+++ b/common/entity/Pupil.ts
@@ -8,6 +8,8 @@ import {CourseAttendanceLog} from "./CourseAttendanceLog";
 import { SchoolType } from "./SchoolType";
 import { ProjectField } from "../jufo/projectFields";
 import { TuteeJufoParticipationIndication } from "../jufo/participationIndication";
+import { ProjectMatch } from "./ProjectMatch";
+import { gradeAsInt } from "../util/gradestrings";
 
 @Entity()
 export class Pupil extends Person {
@@ -127,6 +129,9 @@ export class Pupil extends Person {
     })
     projectMemberCount: number;
 
+    @OneToMany(type => ProjectMatch, match => match.pupil, { nullable: true })
+    projectMatches: Promise<ProjectMatch[]>;
+
     /*
      * Other data
      */
@@ -163,6 +168,11 @@ export class Pupil extends Person {
         default: RegistrationSource.NORMAL
     })
     registrationSource: RegistrationSource;
+
+
+    gradeAsNumber(): number {
+        return gradeAsInt(this.grade);
+    }
 }
 
 export function getPupilWithEmail(manager: EntityManager, email: string) {

--- a/common/entity/Student.ts
+++ b/common/entity/Student.ts
@@ -15,6 +15,7 @@ import { parseSubjectString, Subject, toStudentSubjectDatabaseFormat } from "../
 import { ScreeningInfo } from "../util/screening";
 import { Screener } from "./Screener";
 import { JufoVerificationTransmission } from "./JufoVerificationTransmission";
+import { ProjectMatch } from "./ProjectMatch";
 
 export enum TeacherModule {
     INTERNSHIP = "internship",
@@ -203,6 +204,9 @@ export class Student extends Person {
         cascade: true
     })
     jufoVerificationTransmission: JufoVerificationTransmission;
+
+    @OneToMany(type => ProjectMatch, match => match.student, { nullable: true })
+    projectMatches: Promise<ProjectMatch[]>;
 
     /*
      * Other data

--- a/common/mails/templates.ts
+++ b/common/mails/templates.ts
@@ -361,5 +361,31 @@ export const mailjet = {
                 base64Content: csvBase64
             }]
         };
+    },
+    PROJECTCOACHEEMATCHDISSOLVED: (variables: {
+        coacheeFirstname: string;
+        coachFirstname: string;
+    }) => {
+        return <TemplateMail>{
+            type: 'projectcoacheematchdissolved',
+            id: 1894606,
+            sender: DEFAULTSENDERS.noreply,
+            title: "Deine Zuteilung wurde aufgelöst",
+            disabled: false,
+            variables: variables
+        };
+    },
+    PROJECTCOACHMATCHDISSOLVED: (variables: {
+        coachFirstname: string;
+        coacheeFirstname: string;
+    }) => {
+        return <TemplateMail>{
+            type: 'projectcoachmatchdissolved',
+            id: 1894653,
+            sender: DEFAULTSENDERS.noreply,
+            title: "Deine Zuteilung wurde aufgelöst",
+            disabled: false,
+            variables: variables
+        };
     }
 };

--- a/common/migration/1605738493568-JufoUserAPI.ts
+++ b/common/migration/1605738493568-JufoUserAPI.ts
@@ -1,0 +1,32 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class JufoUserAPI1605738493568 implements MigrationInterface {
+    name = 'JufoUserAPI1605738493568';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "project_match" ("id" SERIAL NOT NULL, "uuid" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "dissolved" boolean NOT NULL DEFAULT false, "dissolveReason" integer DEFAULT null, "studentId" integer, "pupilId" integer, CONSTRAINT "UQ_PJ_MATCH" UNIQUE ("studentId", "pupilId"), CONSTRAINT "PK_14902d121cc871092943b3857e5" PRIMARY KEY ("id"))`, undefined);
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_58dbaf83a377f347d9fab47fc5" ON "project_match" ("uuid") `, undefined);
+        await queryRunner.query(`ALTER TYPE "public"."log_logtype_enum" RENAME TO "log_logtype_enum_old"`, undefined);
+        await queryRunner.query(`CREATE TYPE "log_logtype_enum" AS ENUM('misc', 'verificationRequets', 'verified', 'matchDissolve', 'projectMatchDissolve', 'fetchedFromWix', 'deActivate', 'updatePersonal', 'updateSubjects', 'updateProjectFields', 'accessedByScreener', 'updatedByScreener', 'updateStudentDescription', 'createdCourse', 'certificateRequest', 'cancelledCourse', 'cancelledSubcourse', 'createdCourseAttendanceLog', 'contactMentor', 'bbbMeeting')`, undefined);
+        await queryRunner.query(`ALTER TABLE "log" ALTER COLUMN "logtype" DROP DEFAULT`, undefined);
+        await queryRunner.query(`ALTER TABLE "log" ALTER COLUMN "logtype" TYPE "log_logtype_enum" USING "logtype"::"text"::"log_logtype_enum"`, undefined);
+        await queryRunner.query(`ALTER TABLE "log" ALTER COLUMN "logtype" SET DEFAULT 'misc'`, undefined);
+        await queryRunner.query(`DROP TYPE "log_logtype_enum_old"`, undefined);
+        await queryRunner.query(`ALTER TABLE "project_match" ADD CONSTRAINT "FK_ec8c8527004e4b21fa92dfde9f4" FOREIGN KEY ("studentId") REFERENCES "student"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`, undefined);
+        await queryRunner.query(`ALTER TABLE "project_match" ADD CONSTRAINT "FK_2f269fd77a19a301eb7c9aaa6b6" FOREIGN KEY ("pupilId") REFERENCES "pupil"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`, undefined);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "project_match" DROP CONSTRAINT "FK_2f269fd77a19a301eb7c9aaa6b6"`, undefined);
+        await queryRunner.query(`ALTER TABLE "project_match" DROP CONSTRAINT "FK_ec8c8527004e4b21fa92dfde9f4"`, undefined);
+        await queryRunner.query(`CREATE TYPE "log_logtype_enum_old" AS ENUM('accessedByScreener', 'bbbMeeting', 'cancelledCourse', 'cancelledSubcourse', 'certificateRequest', 'contactMentor', 'createdCourse', 'createdCourseAttendanceLog', 'deActivate', 'fetchedFromWix', 'matchDissolve', 'misc', 'updatePersonal', 'updateStudentDescription', 'updateSubjects', 'updatedByScreener', 'verificationRequets', 'verified')`, undefined);
+        await queryRunner.query(`ALTER TABLE "log" ALTER COLUMN "logtype" DROP DEFAULT`, undefined);
+        await queryRunner.query(`ALTER TABLE "log" ALTER COLUMN "logtype" TYPE "log_logtype_enum_old" USING "logtype"::"text"::"log_logtype_enum_old"`, undefined);
+        await queryRunner.query(`ALTER TABLE "log" ALTER COLUMN "logtype" SET DEFAULT 'misc'`, undefined);
+        await queryRunner.query(`DROP TYPE "log_logtype_enum"`, undefined);
+        await queryRunner.query(`ALTER TYPE "log_logtype_enum_old" RENAME TO  "log_logtype_enum"`, undefined);
+        await queryRunner.query(`DROP INDEX "IDX_58dbaf83a377f347d9fab47fc5"`, undefined);
+        await queryRunner.query(`DROP TABLE "project_match"`, undefined);
+    }
+
+}

--- a/common/transactionlog/types/LogType.ts
+++ b/common/transactionlog/types/LogType.ts
@@ -8,6 +8,7 @@ enum LogType {
     DEACTIVATE = "deActivate",
     UPDATE_PERSONAL = "updatePersonal",
     UPDATE_SUBJECTS = "updateSubjects",
+    UPDATE_PROJECTFIELDS = "updateProjectFields",
     ACCESSED_BY_SCREENER = "accessedByScreener",
     UPDATED_BY_SCREENER = "updatedByScreener",
     UPDATE_STUDENT_DESCRIPTION = "updateStudentDescription",

--- a/common/transactionlog/types/LogType.ts
+++ b/common/transactionlog/types/LogType.ts
@@ -3,6 +3,7 @@ enum LogType {
     VERIFICATION_REQUEST = "verificationRequets",
     VERIFIED = "verified",
     MATCH_DISSOLVE = "matchDissolve",
+    PROJECT_MATCH_DISSOLVE = "projectMatchDissolve",
     FETCHED_FROM_WIX = "fetchedFromWix",
     DEACTIVATE = "deActivate",
     UPDATE_PERSONAL = "updatePersonal",

--- a/common/transactionlog/types/ProjectMatchDissolveEvent.ts
+++ b/common/transactionlog/types/ProjectMatchDissolveEvent.ts
@@ -1,0 +1,13 @@
+import LogUserEvent from "./LogUserEvent";
+import LogType from "./LogType";
+import { Student } from "../../entity/Student";
+import { Pupil } from "../../entity/Pupil";
+import { ProjectMatch } from "../../entity/ProjectMatch";
+
+export default class ProjectMatchDissolveEvent extends LogUserEvent {
+    constructor(user: Pupil | Student, projectMatch: ProjectMatch) {
+        super(LogType.PROJECT_MATCH_DISSOLVE, user, {
+            projectMatchId: projectMatch.id
+        });
+    }
+}

--- a/common/transactionlog/types/UpdateProjectFieldsEvent.ts
+++ b/common/transactionlog/types/UpdateProjectFieldsEvent.ts
@@ -1,0 +1,12 @@
+import LogUserEvent from "./LogUserEvent";
+import LogType from "./LogType";
+import { Student } from "../../entity/Student";
+import { Pupil } from "../../entity/Pupil";
+
+export default class UpdateProjectFieldsEvent extends LogUserEvent {
+    constructor(user: Pupil | Student, oldProjectFields: Array<any>) {
+        super(LogType.UPDATE_PROJECTFIELDS, user, {
+            oldProjectFields
+        });
+    }
+}

--- a/web/controllers/projectMatchController/format.ts
+++ b/web/controllers/projectMatchController/format.ts
@@ -1,0 +1,14 @@
+/**
+ * @apiDefine ProjectMatchDissolveReason
+ * @apiVersion 1.0.1
+ *
+ * @apiSuccess (ProjectMatchDissolveReason Object) {number} reason Reason for dissolving. Should be an integer between 1 and the maximum allowed reason.
+ *
+ * @apiSuccessExample {json} Pupil / Student
+ *      {
+ *          "reason": 1
+ *      }
+ */
+export class ApiProjectMatchDissolveReason {
+    reason: number;
+}

--- a/web/controllers/projectMatchController/index.ts
+++ b/web/controllers/projectMatchController/index.ts
@@ -1,0 +1,165 @@
+import { getLogger } from "log4js";
+import { Request, Response } from "express";
+import { getManager } from "typeorm";
+import { Person } from "../../../common/entity/Person";
+import { Student } from "../../../common/entity/Student";
+import { Pupil } from "../../../common/entity/Pupil";
+import { sendTemplateMail, mailjetTemplates } from "../../../common/mails";
+import { TemplateMail } from "../../../common/mails/templates";
+import { getTransactionLog } from "../../../common/transactionlog";
+import { ProjectMatch } from "../../../common/entity/ProjectMatch";
+import ProjectMatchDissolveEvent from "../../../common/transactionlog/types/ProjectMatchDissolveEvent";
+
+const logger = getLogger();
+
+/**
+ * @api {DELETE} /user/:id/projectMatches/:uuid dissolveProjectMatch
+ * @apiVersion 1.1.0
+ * @apiDescription
+ * Dissolve the specified ProjectMatch.
+ *
+ * This endpoint can be used to signal, that a user wants to dissolve his project match.
+ * The matched partner will be notified of this action.
+ * Both students and pupils are only authorized to dissolve project matches, where they are a part of.
+ * @apiName deleteProjectMatch
+ * @apiGroup ProjectMatch
+ *
+ * @apiUse Authentication
+ *
+ * @apiExample {curl} Curl
+ * curl -k -i -X DELETE -H "Token: <AUTHTOKEN>"-H "Content-Type: application/json"  https://api.corona-school.de/api/user/<ID>/projectMatches/<UUID>
+ *
+ * @apiParam (URL Parameter) {string} id User Id
+ * @apiParam (URL Parameter) {string} uuid UUID of the Project Match
+ *
+ * @apiUse ProjectMatchDissolveReason
+ *
+ * @apiUse StatusNoContent
+ * @apiUse StatusBadRequest
+ * @apiUse StatusUnauthorized
+ * @apiUse StatusInternalServerError
+ *
+ */
+export async function deleteHandler(req: Request, res: Response) {
+    let status;
+
+    const maxReason = 8;
+
+    try {
+        let b = req.body;
+        if (req.params.id != undefined &&
+            req.params.uuid != undefined &&
+            res.locals.user instanceof Person &&
+            typeof b.reason == "number" &&
+            Number.isInteger(b.reason) &&
+            b.reason >= -1 &&
+            b.reason <= maxReason) {
+            try {
+                status = await del(req.params.id, req.params.uuid, b.reason, res.locals.user);
+            } catch (e) {
+                logger.warn("Error DELETE /match: " + e.message);
+                logger.debug(e);
+                status = 500;
+            }
+        } else {
+            status = 400;
+        }
+    } catch (e) {
+        logger.error("Unexpected format of express request: " + e.message);
+        logger.debug(req, e);
+        status = 500;
+    }
+    res.status(status).end();
+}
+
+async function del(wix_id: string, uuid: string, reason: number, person: Pupil | Student): Promise<number> {
+    const entityManager = getManager();
+    const transactionLog = getTransactionLog();
+
+    if (person == null) {
+        logger.error("No authenticated user.");
+        return 500;
+    }
+    // Authorization
+    if (person.wix_id != wix_id) {
+        logger.warn("Person with id " + person.id + " tried to access data from id " + wix_id);
+        return 403;
+    }
+
+    let options;
+    if (person instanceof Student) {
+        options = {
+            uuid: uuid,
+            student: person,
+            dissolved: false
+        };
+    } else if (person instanceof Pupil) {
+        options = {
+            uuid: uuid,
+            pupil: person,
+            dissolved: false
+        };
+    } else {
+        logger.error("Unknown type of person: " + typeof person);
+        logger.debug(person);
+        return 500;
+    }
+    try {
+        let matches = await entityManager.find(ProjectMatch, options);
+        if (matches.length == 0) {
+            logger.warn("Person with id " + person.id + " tried to dissolve project match (UUID " + uuid + "), " + "but he has no access or it doesn't exist or it was already dissolved.");
+            return 403;
+        }
+        if (matches.length > 1) {
+            logger.warn("Caution: Multiple project matches with uuid " + uuid + " found. Using first");
+        }
+
+        await dissolveProjectMatch(matches[0], reason, person);
+        await transactionLog.log(new ProjectMatchDissolveEvent(person, matches[0]));
+    } catch (e) {
+        logger.error("Can't use entity manager to find and delete: " + e.message);
+        logger.debug(e);
+        return 500;
+    }
+
+    return 204;
+}
+
+export async function dissolveProjectMatch(projectMatch: ProjectMatch, reason: number, dissolver: Person) {
+    const entityManager = getManager();
+
+    projectMatch.dissolved = true;
+    projectMatch.dissolveReason = reason;
+    await entityManager.save(ProjectMatch, projectMatch);
+
+    // Send notification mail to partner
+    if (dissolver instanceof Student) {
+        await sendProjectMatchDissolvedMail(projectMatch.pupil, projectMatch.student);
+    } else {
+        await sendProjectMatchDissolvedMail(projectMatch.student, projectMatch.pupil);
+    }
+}
+
+export async function sendProjectMatchDissolvedMail(to: Person, dissolver: Person) {
+    try {
+        let mail: TemplateMail;
+        if (to instanceof Pupil) {
+            // Send mail to (remaining) coachee
+            mail = mailjetTemplates.PROJECTCOACHEEMATCHDISSOLVED({
+                coacheeFirstname: to.firstname,
+                coachFirstname: dissolver.firstname
+            });
+        } else {
+            // Send mail to (remaining) coach
+            mail = mailjetTemplates.PROJECTCOACHMATCHDISSOLVED({
+                coachFirstname: to.firstname,
+                coacheeFirstname: dissolver.firstname
+            });
+        }
+        //send out mail...
+        await sendTemplateMail(mail, to.email);
+    } catch (e) {
+        logger.error("Can't send project match dissolved mail: ", e.message);
+        logger.debug(e);
+    }
+}

--- a/web/controllers/userController/format.ts
+++ b/web/controllers/userController/format.ts
@@ -185,6 +185,7 @@ export class ApiGetUser {
  * @apiParam (User Personal) {string} lastname Last name
  * @apiParam (User Personal) {number} grade <i>Only for pupils:</i> Grade of the pupil
  * @apiParam (User Personal) {number} matchesRequested <i>Only for students:</i> Number of total match requests. A student may request at most 2 matches at a time and may have at most a total of 4 matches at the same time
+ * @apiParam (User Personal) {number} [projectMatchesRequested] Number of total project match requests. A student may request at most 2 matches at a time and may have at most a total of 4 matches at the same time
  * @apiParam (User Personal) {string} state the student's/pupil's state
  * @apiParam (User Personal) {string} university <i>Only for students:</i> student's university
  * @apiParam (User Personal) {string} schoolType <i>Only for pupils:</i> School Type of the pupil
@@ -226,6 +227,7 @@ export class ApiPutUser {
     lastname: string;
     grade?: number;
     matchesRequested?: number;
+    projectMatchesRequested?: number;
     state?: string;
     university?: string;
     schoolType?: string;

--- a/web/controllers/userController/format.ts
+++ b/web/controllers/userController/format.ts
@@ -14,10 +14,12 @@ import { ProjectField } from "../../../common/jufo/projectFields";
  * @apiSuccess (User Object) {boolean} active An inactive user is not considered for new matches.
  * @apiSuccess (User Object) {number} grade <i>Only available for pupils:</i> Grade of the pupil
  * @apiSuccess (User Object) {number} matchesRequested <i>Only available for students:</i> Number of matches requested by the user
+ * @apiSuccess (User Object) {number} projectMatchesRequested Number of project matches requested by the user
  * @apiSuccess (User Object) {string} screeningStatus <i>Only available for students:</i> <code>"ACCEPTED"</code> if the user was screened with success, <code>"REJECTED"</code> if the user was rejected, <code>"UNSCREENED"</code> if the user wasn't screened yet
  * @apiSuccess (User Object) {string} instructorScreeningStatus <i>Only available for students:</i> <code>"ACCEPTED"</code> if the user was screened for group courses with success, <code>"REJECTED"</code> if the user was rejected, <code>"UNSCREENED"</code> if the user wasn't screened yet
  * @apiSuccess (User Object) {Subject[]} subjects List of subjects
  * @apiSuccess (User Object) {Match[]} matches List of current matches
+ * @apiSuccess (User Object) {ProjectMatch[]} projectMatches List of current project matches
  * @apiSuccess (User Object) {Match[]} dissolvedMatches List of dissolved (past) matches
  * @apiSuccess (User Object) {number} lastUpdatedSettingsViaBlocker The unix timestamp of when some settings were last updated by a blocking popup (aka "blocker") in the frontend
  * @apiSuccess (User Object) {number} registrationDate The unix timestamp of when the user registered
@@ -83,6 +85,7 @@ import { ProjectField } from "../../../common/jufo/projectFields";
  *          "instructorScreeningStatus": "ACCEPTED",
  *          "projectCoachingScreeningStatus": "ACCEPTED",
  *          "matchesRequested": 1,
+ *          "projectMatchesRequested": 1,
  *          "subjects": [
  *              {
  *                  "name": "Chinesisch",
@@ -119,7 +122,25 @@ import { ProjectField } from "../../../common/jufo/projectFields";
  *                  "jitsilink": "https://meet.jit.si/CoronaSchool-24a93ed5-4bfe-4969-adae-b6cceaf0d1a0",
  *                  "date": 1590834509
  *              }
- *          ]
+ *          ],
+ *          "projectMatches": [
+ *              {
+ *                  "firstname": "John",
+ *                  "lastname": "Doe",
+ *                  "email": "john.doe@example.com",
+ *                  "uuid": "af7392d74-8d7f-9083-0973-fda9b8e0f9f",
+ *                  "grade": 6,
+ *                  "projectFields": [
+ *                      "Arbeitswelt",
+ *                      "Chemie"
+ *                  ]
+ *                  "jitsilink": "https://meet.jit.si/CoronaSchool-ProjectCoaching-adl792d76-8d7f-9083-0973-a8d9b8e0d2j",
+ *                  "date": 1590834509,
+ *                  "projectMemberCount": 2,
+ *                  "jufoParticipation": "yes",
+ *                  "dissolved": false
+ *              }
+ *          ],
  *      }
  */
 import {ApiSubject} from "../format";
@@ -139,6 +160,7 @@ export class ApiGetUser {
     active: boolean;
     grade?: number;
     matchesRequested?: number;
+    projectMatchesRequested?: number;
     screeningStatus?: string;
     instructorScreeningStatus?: string;
     projectCoachingScreeningStatus?: string;
@@ -146,6 +168,7 @@ export class ApiGetUser {
     projectFields: ApiProjectFieldInfo[];
     matches: ApiMatch[];
     dissolvedMatches: ApiMatch[];
+    projectMatches: ApiProjectMatch[];
     state?: string;
     university?: string;
     schoolType?: string;
@@ -339,6 +362,35 @@ export class ApiMatch {
     subjects: string[];
     jitsilink: string;
     date: number;
+}
+
+/**
+ * @apiDefine ProjectMatch
+ * @apiVersion 1.1.0
+ *
+ * @apiSuccess (Match Object) {string} uuid Unique identifier for the Match
+ * @apiSuccess (Match Object) {string} firstname First name of the matched partner
+ * @apiSuccess (Match Object) {string} lastname Last name of the matched partner
+ * @apiSuccess (Match Object) {string} email E-Mail address of the matched partner
+ * @apiSuccess (Match Object) {string} [grade] <i>only available for students:</i> Grade of the pupil
+ * @apiSuccess (Match Object) {string[]} projectFields The array of project fields of the matching partner
+ * @apiSuccess (Match Object) {string} jitsilink Link to the Jitsi session for the match
+ * @apiSuccess (Match Object) {number} date Unix timestamp of when these persons were matched
+ * @apiSuccess (Match Object) {string} jufoParticipation For students one of <code>"yes", "no", "unsure", "neverheard"</code>, for pupils one of <code>"yes", "no", "idk"</code>
+ * @apiSuccess (Match Object) {number} [projectMemberCount] <i>only available for students:</i> Number of team members of the matching partner's project
+ */
+export class ApiProjectMatch {
+    dissolved: boolean;
+    firstname: string;
+    lastname: string;
+    email: string;
+    uuid: string;
+    grade?: number;
+    projectFields: ProjectField[];
+    jitsilink: string;
+    date: number;
+    jufoParticipation: TutorJufoParticipationIndication | TuteeJufoParticipationIndication;
+    projectMemberCount?: number;
 }
 
 export function checkSubject(s: string): boolean {

--- a/web/dev.ts
+++ b/web/dev.ts
@@ -20,6 +20,7 @@ import { SchoolType } from "../common/entity/SchoolType";
 import { ProjectField } from "../common/jufo/projectFields";
 import { ProjectFieldWithGradeRestriction } from "../common/entity/ProjectFieldWithGradeRestriction";
 import { TuteeJufoParticipationIndication } from "../common/jufo/participationIndication";
+import { ProjectMatch } from "../common/entity/ProjectMatch";
 
 export async function setupDevDB() {
     const conn = getConnection();
@@ -258,6 +259,19 @@ export async function setupDevDB() {
     for (let i = 0; i < matches.length; i++) {
         await entityManager.save(Match, matches[i]);
         console.log("Inserted Dev Match " + i);
+    }
+
+    const projectMatches: ProjectMatch[] = [];
+
+    let pm = new ProjectMatch();
+    pm.uuid = "000000001-0000-0000-0001-2c5d5d637475";
+    pm.pupil = pupils[3];
+    pm.student = students[5];
+    projectMatches.push(pm);
+
+    for (let i = 0; i < projectMatches.length; i++) {
+        await entityManager.save(ProjectMatch, projectMatches[i]);
+        console.log("Inserted Dev ProjectMatch " + i);
     }
 
     let pc = new ParticipationCertificate();

--- a/web/index.ts
+++ b/web/index.ts
@@ -9,6 +9,7 @@ import * as cors from "cors";
 import * as userController from "./controllers/userController";
 import * as tokenController from "./controllers/tokenController";
 import * as matchController from "./controllers/matchController";
+import * as projectMatchController from "./controllers/projectMatchController";
 import * as screeningController from "./controllers/screeningController";
 import * as certificateController from "./controllers/certificateController";
 import * as courseController from "./controllers/courseController";
@@ -105,6 +106,7 @@ createConnection().then(() => {
         userApiRouter.put("/:id/subjects", userController.putSubjectsHandler);
         userApiRouter.put("/:id/active/:active", userController.putActiveHandler);
         userApiRouter.delete("/:id/matches/:uuid", matchController.deleteHandler);
+        userApiRouter.delete("/:id/projectMatches/:uuid", projectMatchController.deleteHandler);
         userApiRouter.post("/:id/role/instructor", userController.postUserRoleInstructorHandler);
         userApiRouter.post("/:id/role/tutor", userController.postUserRoleTutorHandler);
         userApiRouter.post("/:id/role/projectCoach", userController.postUserRoleProjectCoachHandler);

--- a/web/index.ts
+++ b/web/index.ts
@@ -104,6 +104,7 @@ createConnection().then(() => {
         userApiRouter.get("/:id", userController.getHandler);
         userApiRouter.put("/:id", userController.putHandler);
         userApiRouter.put("/:id/subjects", userController.putSubjectsHandler);
+        userApiRouter.put("/:id/projectFields", userController.putProjectFieldsHandler);
         userApiRouter.put("/:id/active/:active", userController.putActiveHandler);
         userApiRouter.delete("/:id/matches/:uuid", matchController.deleteHandler);
         userApiRouter.delete("/:id/projectMatches/:uuid", projectMatchController.deleteHandler);


### PR DESCRIPTION
This will add several API endpoints for users that are intended to enable the project coaching part of our user section.
This includes: 
- [x] getting user info (`getUser`)
- [x] changing user info, including the open project match request count (`putUser`)
- [x] editing project fields (`putProjectFields`)
- [x] dissolving project matches (`projectMatchDissolve`)

What still needs to be done.
- [x] write database migration