### PR TITLE
API for user certificates & Cleanup

### DIFF
--- a/assets/certificateTemplate.html
+++ b/assets/certificateTemplate.html
@@ -14,7 +14,7 @@
     Text Schüler: %SCHUELERFREITEXT%<br/>
     Stunden pro Woche: %SCHUELERPROWOCHE%<br/>
     Stunden gesamt: %SCHUELERGESAMT%<br/>
-    Mium: %MEDIUM%<br/>
+    Medium: %MEDIUM%<br/>
     Screnningdatum: %SCREENINGDATUM%<br/>
 </body>
 </html>

--- a/assets/certificateTemplate.html
+++ b/assets/certificateTemplate.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>[TEST] Corona School Bescheinigung</title>
+</head>
+<body>
+    Name des Studenten: %NAMESTUDENT%<br/>
+    Name des Schülers: %NAMESCHUELER%<br/>
+    Heutiges Datum: %DATUMHEUTE%<br/>
+    Startdatum: %SCHUELERSTART%<br/>
+    Enddatum: %SCHUELERENDE%<br/>
+    Fächer: %SCHUELERFAECHER%<br/>
+    Text Schüler: %SCHUELERFREITEXT%<br/>
+    Stunden pro Woche: %SCHUELERPROWOCHE%<br/>
+    Stunden gesamt: %SCHUELERGESAMT%<br/>
+    Mium: %MEDIUM%<br/>
+    Screnningdatum: %SCREENINGDATUM%<br/>
+</body>
+</html>

--- a/assets/verifiedCertificatePage.html
+++ b/assets/verifiedCertificatePage.html
@@ -16,6 +16,7 @@
     Stunden pro Woche: %SCHUELERPROWOCHE%<br/>
     Stunden gesamt: %SCHUELERGESAMT%<br/>
     Medium: %MEDIUM%<br/>
-    Screnningdatum: %SCREENINGDATUM%<br/>
+    Certificate Link: %CERTLINK%<br/>
+    Link Text: %CERTLINKTEXT%<br/>
 </body>
 </html>

--- a/assets/verifiedCertificatePage.html
+++ b/assets/verifiedCertificatePage.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no">
+    <title>[TEST] Corona School Bescheinigung</title>
+</head>
+<body>
+    Name des Studenten: %NAMESTUDENT%<br/>
+    Name des Schülers: %NAMESCHUELER%<br/>
+    Heutiges Datum: %DATUMHEUTE%<br/>
+    Startdatum: %SCHUELERSTART%<br/>
+    Enddatum: %SCHUELERENDE%<br/>
+    Fächer: %SCHUELERFAECHER%<br/>
+    Text Schüler: %SCHUELERFREITEXT%<br/>
+    Stunden pro Woche: %SCHUELERPROWOCHE%<br/>
+    Stunden gesamt: %SCHUELERGESAMT%<br/>
+    Medium: %MEDIUM%<br/>
+    Screnningdatum: %SCREENINGDATUM%<br/>
+</body>
+</html>

--- a/web/index.ts
+++ b/web/index.ts
@@ -127,6 +127,7 @@ createConnection().then(() => {
         certificateRouter.use(authCheckFactory());
         certificateRouter.get("/:student/:pupil", certificateController.certificateHandler);
         app.use("/api/certificate", certificateRouter);
+        app.get("/api/certificates", authCheckFactory(), certificateController.getCertificates);
     }
 
     function configureCourseAPI() {


### PR DESCRIPTION
As we start working on the frontend tomorrow, I'd like to deploy this to dev today. 

The added API /api/certificates exposes all certificates the user is involved in (either as a student or pupil). 