### PR TITLE
Rewrite Screening Queries to Prisma to eventually fix the performance problems

### DIFF
--- a/common/prisma/index.ts
+++ b/common/prisma/index.ts
@@ -1,3 +1,10 @@
 import { PrismaClient } from "@prisma/client";
 
-export const prisma = new PrismaClient();
+/* In the development environment, also log 'query'
+   which is the SQL query sent to the database.
+   Through that, queries can be optimized for performance */
+export const prisma = new PrismaClient(
+    process.env.NODE_ENV === "production"
+        ? undefined
+        : { log: ['query', 'info', `warn`, `error`] }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -729,40 +729,24 @@
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
     },
-    "@prisma/bar": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@prisma/bar/-/bar-0.0.1.tgz",
-      "integrity": "sha512-FVLhwVkbfhXlBhroWfIXMLi+3Jh9IEzYp+9z+MUUiw3ZsbcoAil7CN9/QIjHc4/TcCRyRfuSmT7qCnn4O+TjJw==",
-      "dev": true
-    },
-    "@prisma/cli": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@prisma/cli/-/cli-2.14.0.tgz",
-      "integrity": "sha512-zKYiOGlc/Y0VVRQew0jMR2sGSFnKnNGlgY4ToB5K1JMv7jCg51w+FJe2FwTOF4uWv+0Yp2KC1b0TAP8KUbNJ3A==",
-      "dev": true,
-      "requires": {
-        "@prisma/bar": "^0.0.1",
-        "@prisma/engines": "2.14.0-28.5d491261d382a2a5ffdc71de17072b0e409f1cc1"
-      }
-    },
     "@prisma/client": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-2.14.0.tgz",
-      "integrity": "sha512-0PiiZ2maM9OP/G5mynzftvD4DFrtibeyvZf5U7Be360mtSvgLHQhZ/CHbChb0BVeWeyJuTmAqqni98LcdVgttw==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-2.17.0.tgz",
+      "integrity": "sha512-tzsBxtx9J1epOGCiBeXur1tEz81UIdWg2G/HpDmflXKcv/MJb+KCWSKSsEW49eXcvVwRgxNyxLoCO6CwvjQKcg==",
       "requires": {
-        "@prisma/engines-version": "2.14.0-28.5d491261d382a2a5ffdc71de17072b0e409f1cc1"
+        "@prisma/engines-version": "2.17.0-35.3c463ebd78b1d21d8fdacdd27899e280cf686223"
       }
     },
     "@prisma/engines": {
-      "version": "2.14.0-28.5d491261d382a2a5ffdc71de17072b0e409f1cc1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-2.14.0-28.5d491261d382a2a5ffdc71de17072b0e409f1cc1.tgz",
-      "integrity": "sha512-t5/Mq0VtL7khYQtbap8myr7RwyIvmruCFxsph6oTi8QZaklmuxSp7FAC2DWBz8r/KoZFngMpmliKfDrWN7uwzQ==",
+      "version": "2.17.0-35.3c463ebd78b1d21d8fdacdd27899e280cf686223",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-2.17.0-35.3c463ebd78b1d21d8fdacdd27899e280cf686223.tgz",
+      "integrity": "sha512-FKjVD6NYbGiQhwas3hA2uMpNchz+Mf3tv5qA8Ci9cAkKHGqt3jWjjUAK9juVBqeOcv4OPimQYMrkRX6SvaxBjg==",
       "dev": true
     },
     "@prisma/engines-version": {
-      "version": "2.14.0-28.5d491261d382a2a5ffdc71de17072b0e409f1cc1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-2.14.0-28.5d491261d382a2a5ffdc71de17072b0e409f1cc1.tgz",
-      "integrity": "sha512-Oz3yNV//9UTJ+ral5tF6Ryb/MLfOE3+2F3/bH4waTbNRDd/zXKoS3jTI3ViU8yRQ1AsOQa9/pV/kXSlxgtAh8Q=="
+      "version": "2.17.0-35.3c463ebd78b1d21d8fdacdd27899e280cf686223",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-2.17.0-35.3c463ebd78b1d21d8fdacdd27899e280cf686223.tgz",
+      "integrity": "sha512-9idv5blqPUlvUPVT48eVi3T0RS/NBklUcjrla3jWyV8AYfB2BdaG/Zci7H5ajyYLnfZZHG9tBpP0LcveQCFH8A=="
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
@@ -6258,6 +6242,15 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/prepin/-/prepin-1.0.3.tgz",
       "integrity": "sha512-0XL2hreherEEvUy0fiaGEfN/ioXFV+JpImqIzQjxk6iBg4jQ2ARKqvC4+BmRD8w/pnpD+lbxvh0Ub+z7yBEjvA=="
+    },
+    "prisma": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-2.17.0.tgz",
+      "integrity": "sha512-NypJI7OCXCfDkRKubbVb3nmPeRJ1SjQfg6QAwK06KsreBZl1F96rFz2iB2bl4kIrhLAbIySBjwUJlG87Jsxt7g==",
+      "dev": true,
+      "requires": {
+        "@prisma/engines": "2.17.0-35.3c463ebd78b1d21d8fdacdd27899e280cf686223"
+      }
     },
     "process-nextick-args": {
       "version": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7825,9 +7825,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
+      "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w=="
     },
     "uc.micro": {
       "version": "1.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -730,23 +730,23 @@
       "dev": true
     },
     "@prisma/client": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-2.17.0.tgz",
-      "integrity": "sha512-tzsBxtx9J1epOGCiBeXur1tEz81UIdWg2G/HpDmflXKcv/MJb+KCWSKSsEW49eXcvVwRgxNyxLoCO6CwvjQKcg==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-2.16.1.tgz",
+      "integrity": "sha512-g4zXwC9PRtlrad/CBu+lXHRhvkEz4QW9tDn7bJGwCVNeLi+gLzSbEHjo3xLZgI3+Jp+40flOzrJrYP0bkNCpdQ==",
       "requires": {
-        "@prisma/engines-version": "2.17.0-35.3c463ebd78b1d21d8fdacdd27899e280cf686223"
+        "@prisma/engines-version": "2.16.1-1.8b74ad57aaf2cc6c155f382a18a8e3ba95aceb03"
       }
     },
     "@prisma/engines": {
-      "version": "2.17.0-35.3c463ebd78b1d21d8fdacdd27899e280cf686223",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-2.17.0-35.3c463ebd78b1d21d8fdacdd27899e280cf686223.tgz",
-      "integrity": "sha512-FKjVD6NYbGiQhwas3hA2uMpNchz+Mf3tv5qA8Ci9cAkKHGqt3jWjjUAK9juVBqeOcv4OPimQYMrkRX6SvaxBjg==",
+      "version": "2.16.1-1.8b74ad57aaf2cc6c155f382a18a8e3ba95aceb03",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-2.16.1-1.8b74ad57aaf2cc6c155f382a18a8e3ba95aceb03.tgz",
+      "integrity": "sha512-GZ1huP5KC6TPf9u8pYGFklUkGVTKFel6k4wL4iMr8AQ6MeSV4GDJX3lEtEJLb0ayj6je/hDEyQG9iMp/BysFYg==",
       "dev": true
     },
     "@prisma/engines-version": {
-      "version": "2.17.0-35.3c463ebd78b1d21d8fdacdd27899e280cf686223",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-2.17.0-35.3c463ebd78b1d21d8fdacdd27899e280cf686223.tgz",
-      "integrity": "sha512-9idv5blqPUlvUPVT48eVi3T0RS/NBklUcjrla3jWyV8AYfB2BdaG/Zci7H5ajyYLnfZZHG9tBpP0LcveQCFH8A=="
+      "version": "2.16.1-1.8b74ad57aaf2cc6c155f382a18a8e3ba95aceb03",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-2.16.1-1.8b74ad57aaf2cc6c155f382a18a8e3ba95aceb03.tgz",
+      "integrity": "sha512-BkqxSWOc9aNYXjtmRtaLy2fKIeJ3+NKimRL1gKWXMjtxhKS5E3wvyxwZamtfIpEaZELGAO3x5+gqwoR9kS2oZA=="
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
@@ -6244,12 +6244,12 @@
       "integrity": "sha512-0XL2hreherEEvUy0fiaGEfN/ioXFV+JpImqIzQjxk6iBg4jQ2ARKqvC4+BmRD8w/pnpD+lbxvh0Ub+z7yBEjvA=="
     },
     "prisma": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-2.17.0.tgz",
-      "integrity": "sha512-NypJI7OCXCfDkRKubbVb3nmPeRJ1SjQfg6QAwK06KsreBZl1F96rFz2iB2bl4kIrhLAbIySBjwUJlG87Jsxt7g==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-2.16.1.tgz",
+      "integrity": "sha512-TniTihl4xwWY7Hy+1UUpZ6jxHyriRDUW4i7TChZNBZM88IG8kvR5cSX+/JY/lzWGMUR4ZDBzoIuNcdPx/7eWag==",
       "dev": true,
       "requires": {
-        "@prisma/engines": "2.17.0-35.3c463ebd78b1d21d8fdacdd27899e280cf686223"
+        "@prisma/engines": "2.16.1-1.8b74ad57aaf2cc6c155f382a18a8e3ba95aceb03"
       }
     },
     "process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "heroku:release": "if [ \"$NODE_ENV\" = 'production' ]; then npx typeorm migration:run; else echo 'Will only run migration in production...'; fi"
   },
   "dependencies": {
-    "@prisma/client": "^2.17.0",
+    "@prisma/client": "^2.16.1",
     "@types/bcrypt": "^3.0.0",
     "@types/ejs": "^3.0.5",
     "@types/express": "^4.17.4",
@@ -101,7 +101,7 @@
     "libsodium-wrappers": "^0.7.6",
     "mocha": "^8.0.1",
     "nyc": "^15.1.0",
-    "prisma": "^2.17.0",
+    "prisma": "^2.16.1",
     "request": "^2.81.0",
     "rewire": "^5.0.0",
     "sinon": "^9.0.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "heroku:release": "if [ \"$NODE_ENV\" = 'production' ]; then npx typeorm migration:run; else echo 'Will only run migration in production...'; fi"
   },
   "dependencies": {
-    "@prisma/client": "^2.14.0",
+    "@prisma/client": "^2.17.0",
     "@types/bcrypt": "^3.0.0",
     "@types/ejs": "^3.0.5",
     "@types/express": "^4.17.4",
@@ -83,7 +83,6 @@
     "xml2js": "^0.4.23"
   },
   "devDependencies": {
-    "@prisma/cli": "^2.14.0",
     "@types/chai": "^4.2.13",
     "@types/cron": "^1.7.2",
     "@types/lodash": "^4.14.155",
@@ -102,6 +101,7 @@
     "libsodium-wrappers": "^0.7.6",
     "mocha": "^8.0.1",
     "nyc": "^15.1.0",
+    "prisma": "^2.17.0",
     "request": "^2.81.0",
     "rewire": "^5.0.0",
     "sinon": "^9.0.2",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "sequelize": "^5.21.5",
     "textversionjs": "^1.1.3",
     "typeorm": "^0.2.29",
-    "typescript": "^3.9.7",
+    "typescript": "^3.9.9",
     "unique-names-generator": "^4.3.1",
     "uuid": "^7.0.3",
     "validator": "^13.5.2",

--- a/web/controllers/screeningController/index.ts
+++ b/web/controllers/screeningController/index.ts
@@ -846,7 +846,7 @@ export async function getInstructors(req: Request, res: Response) {
         const screeningQuery = {
             [ScreeningStatus.Accepted]: { success: true },
             [ScreeningStatus.Rejected]: { success: false },
-            [ScreeningStatus.Unscreened]: { none: {} } // no screening exists
+            [ScreeningStatus.Unscreened]: null // no screening exists
         }[screeningStatus as ScreeningStatus];
 
         const instructors = await prisma.student.findMany({

--- a/web/controllers/screeningController/index.ts
+++ b/web/controllers/screeningController/index.ts
@@ -849,7 +849,7 @@ export async function getInstructors(req: Request, res: Response) {
             [ScreeningStatus.Unscreened]: null
         }[screeningStatus];
 
-        const instructors = prisma.student.findMany({
+        const instructors = await prisma.student.findMany({
             where: {
                 isInstructor: true,
                 instructor_screening: {

--- a/web/controllers/screeningController/index.ts
+++ b/web/controllers/screeningController/index.ts
@@ -463,11 +463,11 @@ export async function getCourses(req: Request, res: Response) {
             OR: [
                 {
                     courseState,
-                    name: search && { contains: search, mode: "insensitive" as const }
+                    name: search ? { contains: search, mode: "insensitive" as const } : undefined
                 },
                 {
                     courseState,
-                    description: search && { contains: search, mode: "insensitive" as const }
+                    description: search ? { contains: search, mode: "insensitive" as const } : undefined
                 }
             ]
         } : undefined;

--- a/web/controllers/screeningController/index.ts
+++ b/web/controllers/screeningController/index.ts
@@ -502,18 +502,16 @@ export async function getCourses(req: Request, res: Response) {
                 },
                 include: {
                     courses: {
+                        where: { courseState },
+                        orderBy: { updatedAt: 'desc' },
+                        take: 20,
+                        skip: (+page || 0) * 20,
                         include: courseInclude
                     }
-                }
             });
 
             if (student) {
-                // This should really be done on the database, but TypeORM currently has no nice way to express this:
-                // https://github.com/typeorm/typeorm/blob/master/docs/many-to-many-relations.md
-                courses = student.courses
-                    .filter(it => !courseState || it.courseState === courseState)
-                    .sort((a, b) => +b.updatedAt - +a.updatedAt)
-                    .slice((+page || 0) * 20, (+page + 1 || 1) * 20);
+                courses = student.courses;
             }
         }
 

--- a/web/controllers/screeningController/index.ts
+++ b/web/controllers/screeningController/index.ts
@@ -459,7 +459,7 @@ export async function getCourses(req: Request, res: Response) {
         if (page && (Number.isNaN(+page) || !Number.isInteger(+page)))
             return res.status(400).send("Invalid value for parameter 'page', must be integer.");
 
-        const where = (!!courseState || !!search) && {
+        const where = (courseState || search) ? {
             OR: [
                 {
                     courseState,
@@ -470,7 +470,7 @@ export async function getCourses(req: Request, res: Response) {
                     description: search && { contains: search, mode: "insensitive" as const }
                 }
             ]
-        };
+        } : undefined;
 
         /* eslint camelcase: 'off' */
         const courseInclude = {

--- a/web/controllers/screeningController/index.ts
+++ b/web/controllers/screeningController/index.ts
@@ -498,7 +498,6 @@ export async function getCourses(req: Request, res: Response) {
             }
         } as const;
 
-        console.log("Running the following where query", where);
 
         let courses = await prisma.course.findMany({
             where,

--- a/web/controllers/screeningController/index.ts
+++ b/web/controllers/screeningController/index.ts
@@ -843,19 +843,16 @@ export async function getInstructors(req: Request, res: Response) {
         */
         let [lastname, firstname] = search.split(" ").reverse();
 
-        const screeningSuccess = {
-            [ScreeningStatus.Accepted]: true,
-            [ScreeningStatus.Rejected]: false,
-            [ScreeningStatus.Unscreened]: null
-        }[screeningStatus];
+        const screeningQuery = {
+            [ScreeningStatus.Accepted]: { success: true },
+            [ScreeningStatus.Rejected]: { success: false },
+            [ScreeningStatus.Unscreened]: { none: {} } // no screening exists
+        }[screeningStatus as ScreeningStatus];
 
         const instructors = await prisma.student.findMany({
             where: {
                 isInstructor: true,
-                instructor_screening: {
-                    // TODO: Does this work with NULL?
-                    success: screeningSuccess
-                },
+                instructor_screening: screeningQuery,
                 OR: [
                     {
                         email: { contains: search, mode: "insensitive" as const }

--- a/web/controllers/screeningController/index.ts
+++ b/web/controllers/screeningController/index.ts
@@ -508,6 +508,7 @@ export async function getCourses(req: Request, res: Response) {
                         skip: (+page || 0) * 20,
                         include: courseInclude
                     }
+                }
             });
 
             if (student) {

--- a/web/controllers/screeningController/index.ts
+++ b/web/controllers/screeningController/index.ts
@@ -459,7 +459,7 @@ export async function getCourses(req: Request, res: Response) {
         if (page && (Number.isNaN(+page) || !Number.isInteger(+page)))
             return res.status(400).send("Invalid value for parameter 'page', must be integer.");
 
-        const where = {
+        const where = (!!courseState || !!search) && {
             OR: [
                 {
                     courseState,

--- a/web/index.ts
+++ b/web/index.ts
@@ -247,26 +247,26 @@ createConnection().then(setupPDFGenerationEnvironment).then(async () => {
             "/screener/:email",
             screeningController.updateScreenerByMailHandler
         );
-        // screenerApiRouter.get(
-        //     "/courses",
-        //     screeningController.getCourses
-        // );
-        // screenerApiRouter.get(
-        //     "/courses/tags",
-        //     screeningController.getCourseTags
-        // );
-        // screenerApiRouter.post(
-        //     "/courses/tags/create",
-        //     screeningController.postCreateCourseTag
-        // );
-        // screenerApiRouter.post(
-        //     "/course/:id/update",
-        //     screeningController.updateCourse
-        // );
-        // screenerApiRouter.get(
-        //     "/instructors",
-        //     screeningController.getInstructors
-        // );
+        screenerApiRouter.get(
+            "/courses",
+            screeningController.getCourses
+        );
+        screenerApiRouter.get(
+            "/courses/tags",
+            screeningController.getCourseTags
+        );
+        screenerApiRouter.post(
+            "/courses/tags/create",
+            screeningController.postCreateCourseTag
+        );
+        screenerApiRouter.post(
+            "/course/:id/update",
+            screeningController.updateCourse
+        );
+        screenerApiRouter.get(
+            "/instructors",
+            screeningController.getInstructors
+        );
 
         app.use("/api/screening", screenerApiRouter);
     }


### PR DESCRIPTION
From the logs this seems to return reasonable queries, so the performance issues should be gone. I'm fairly confident that the behavior did not change. 

Had to upgrade Prisma to perform all the filtering on the database, according to the [changelog](https://github.com/prisma/prisma/releases) none of the breaking changes should affect us. For some reason the newest 2.17 produces invalid Typescript types, so I went for 2.16.2 instead. 