### PR TITLE
Backend part of interest-confirmation for pupils

### DIFF
--- a/common/administration/match-making/tutoring/index.ts
+++ b/common/administration/match-making/tutoring/index.ts
@@ -70,10 +70,10 @@ export async function matchMakingWithPersons(tutorsToMatch: Student[], tuteesToM
     }
 }
 
-export async function matchMakingOfAllPossibleMatches(manager: EntityManager, options: MatchingOptions = { dryRun: false, notifications: { email: true, sms: false}}) {
+export async function matchMakingOfAllPossibleMatches(manager: EntityManager, restrictToThoseWithConfirmedInterest: boolean, options: MatchingOptions = { dryRun: false, notifications: { email: true, sms: false}}) {
     // get data for matching
     const tutors = await tutorsToMatch(manager);
-    const tutees = await tuteesToMatch(manager);
+    const tutees = await tuteesToMatch(manager, restrictToThoseWithConfirmedInterest);
 
     await matchMakingWithPersons(tutors, tutees, options, manager);
 }

--- a/common/administration/match-making/tutoring/people/tutees.ts
+++ b/common/administration/match-making/tutoring/people/tutees.ts
@@ -29,7 +29,7 @@ export function tuteesToMatchQuery(manager: EntityManager, restrictToThoseWithCo
 
     if (restrictToThoseWithConfirmedInterest) {
         q = q.leftJoinAndSelect("p.tutoringInterestConfirmationRequest", "pticr")
-            .andWhere("(p.registrationSource == (:rs) OR p.tutoringInterestConfirmationRequest.status == (:cs))", { rs: RegistrationSource.COOPERATION, cs: InterestConfirmationStatus.CONFIRMED });
+            .andWhere("(p.registrationSource = (:rs) OR pticr.status = (:cs))", { rs: RegistrationSource.COOPERATION, cs: InterestConfirmationStatus.CONFIRMED });
     }
 
     return q;

--- a/common/administration/match-making/tutoring/people/tutees.ts
+++ b/common/administration/match-making/tutoring/people/tutees.ts
@@ -1,13 +1,17 @@
 import { EntityManager, SelectQueryBuilder } from "typeorm";
+import { RegistrationSource } from "../../../../entity/Person";
 import { Pupil } from "../../../../entity/Pupil";
+import { InterestConfirmationStatus } from "../../../../entity/PupilTutoringInterestConfirmationRequest";
 import { InvalidEmailDomains } from "../../invalid-email-domains";
 
-///Returns true whether the tutee is allowed to get a match
+///Returns true whether the tutee is allowed to get a match (this does not respect interest-confirmation, since that isn't such an important criteria and more acts like a filter for _qualified_ matches)
 export async function tuteeIsAllowedToGetMatch(manager: EntityManager, tutee: Pupil) {
     //basic criteria every tutee that want's a match, must fulfill
     return tutee.active && tutee.verification == null && tutee.isPupil && tutee.openMatchRequestCount > 0;
 }
-export function tuteesToMatchQuery(manager: EntityManager): SelectQueryBuilder<Pupil> {
+/// Returns all *matchableTutees* all, i.e. all who are allowed to get a match in theory, without any further match-quality restrictions like interest-confirmations
+/// (interest-confirmation is only a restriction with respect to match quality, because everyone that registered as "matchable" originally wanted a match and applies to get a match)
+export function matchableTuteesQuery(manager: EntityManager): SelectQueryBuilder<Pupil> {
     return manager.createQueryBuilder()
         .select("p")
         .from(Pupil, "p")
@@ -19,9 +23,23 @@ export function tuteesToMatchQuery(manager: EntityManager): SelectQueryBuilder<P
                 AND split_part(p.email, '@', 2) NOT IN (:...emailDomainExclusions)", { emailDomainExclusions: InvalidEmailDomains});
 }
 
-export async function getNumberOfTuteesToMatch(manager: EntityManager) {
-    return await tuteesToMatchQuery(manager).getCount();
+/// The second parameter indicates whether the tutees to match should include only those with confirmed interest (via an interest-confirmation request or via partner schools) or any matchable tutee
+export function tuteesToMatchQuery(manager: EntityManager, restrictToThoseWithConfirmedInterest: boolean): SelectQueryBuilder<Pupil> {
+    let q = matchableTuteesQuery(manager);
+
+    if (restrictToThoseWithConfirmedInterest) {
+        q = q.leftJoinAndSelect("p.tutoringInterestConfirmationRequest", "pticr")
+            .andWhere("(p.registrationSource == (:rs) OR p.tutoringInterestConfirmationRequest.status == (:cs))", { rs: RegistrationSource.COOPERATION, cs: InterestConfirmationStatus.CONFIRMED });
+    }
+
+    return q;
 }
-export async function tuteesToMatch(manager: EntityManager) {
-    return await tuteesToMatchQuery(manager).getMany();
+
+export async function getNumberOfTuteesToMatch(manager: EntityManager, restrictToThoseWithConfirmedInterest: boolean) {
+    return await tuteesToMatchQuery(manager, restrictToThoseWithConfirmedInterest).getCount();
+}
+/// Return all tutees that should be matched when this function is called
+// (it contains all matchable tutees filtered by those who are coming from a partner school or have explicitly confirmed their interest -> this way, we wanna achieve a higher match quality)
+export async function tuteesToMatch(manager: EntityManager, restrictToThoseWithConfirmedInterest: boolean) {
+    return await tuteesToMatchQuery(manager, restrictToThoseWithConfirmedInterest).getMany();
 }

--- a/common/entity/Pupil.ts
+++ b/common/entity/Pupil.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, EntityManager, Index, ManyToMany, OneToMany, ManyToOne, JoinColumn } from "typeorm";
+import { Column, Entity, EntityManager, Index, ManyToMany, OneToMany, ManyToOne, JoinColumn, OneToOne } from "typeorm";
 import { Match } from "./Match";
 import { Person, RegistrationSource } from "./Person";
 import { Subcourse } from './Subcourse';
@@ -14,6 +14,7 @@ import { Student, DEFAULT_PROJECT_COACH_GRADERESTRICTIONS, DEFAULT_TUTORING_GRAD
 import { parseSubjectString, Subject, toPupilSubjectDatabaseFormat } from "../util/subjectsutils";
 import { LearningGermanSince } from "../daz/learningGermanSince";
 import { Language } from "../daz/language";
+import { PupilTutoringInterestConfirmationRequest } from "./PupilTutoringInterestConfirmationRequest";
 
 @Entity()
 export class Pupil extends Person {
@@ -193,6 +194,12 @@ export class Pupil extends Person {
         default: RegistrationSource.NORMAL
     })
     registrationSource: RegistrationSource;
+
+    @OneToOne((type) => PupilTutoringInterestConfirmationRequest, (pticr) => pticr.pupil, {
+        nullable: true,
+        cascade: true
+    })
+    tutoringInterestConfirmationRequest?: PupilTutoringInterestConfirmationRequest;
 
 
     gradeAsNumber(): number | null {

--- a/common/entity/PupilTutoringInterestConfirmationRequest.ts
+++ b/common/entity/PupilTutoringInterestConfirmationRequest.ts
@@ -1,0 +1,73 @@
+import { Column, CreateDateColumn, Entity, EntityManager, Index, JoinColumn, OneToOne, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
+import { generateToken } from "../../jobs/periodic/fetch/utils/verification";
+import { generateStatusChangeURLFromToken } from "../interest-confirmation/tutoring/notify/urls";
+import { Pupil } from "./Pupil";
+
+
+export enum InterestConfirmationStatus {
+    PENDING = "pending",
+    CONFIRMED = "confirmed",
+    REFUSED = "refused"
+}
+
+@Entity()
+export class PupilTutoringInterestConfirmationRequest {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @CreateDateColumn({ type: "timestamp" })
+    createdAt: Date;
+
+    @UpdateDateColumn({ type: "timestamp" })
+    updatedAt: Date;
+
+    @Column({
+        enum: InterestConfirmationStatus,
+        default: InterestConfirmationStatus.PENDING
+    })
+    status: InterestConfirmationStatus;
+
+    @Index({ unique: true })
+    @Column({
+        nullable: false
+    })
+    token: string;
+
+    @Column({
+        nullable: true,
+        default: null
+    })
+    reminderSentDate?: Date;
+
+    @OneToOne((type) => Pupil, (pupil) => pupil.tutoringInterestConfirmationRequest, {
+        eager: false
+    })
+    @JoinColumn()
+    pupil: Pupil;
+
+    hasSentReminder(): boolean {
+        return this.reminderSentDate != null;
+    }
+
+    constructor(pupil: Pupil, token: string) {
+        this.pupil = pupil;
+        this.token = token;
+    }
+
+    confirmationURL(): string {
+        return generateStatusChangeURLFromToken(this.token, true);
+    }
+    refusalURL(): string {
+        return generateStatusChangeURLFromToken(this.token, false);
+    }
+}
+
+export async function createUniqueToken(manager: EntityManager): Promise<string> {
+    let generatedToken: string;
+    do {
+        generatedToken = generateToken(); //TODO: improve token generation, or at least its import path
+    }
+    while (await manager.findOne(PupilTutoringInterestConfirmationRequest, { token: generatedToken }));
+
+    return generatedToken;
+}

--- a/common/interest-confirmation/tutoring/index.ts
+++ b/common/interest-confirmation/tutoring/index.ts
@@ -1,0 +1,32 @@
+import { EntityManager } from "typeorm";
+import { sendTutoringConfirmationRequestReminders, sendTutoringConfirmationRequests } from "./notify/send";
+import { createTutoringInterestConfirmationRequests } from "./persistence/create";
+import { saveTutoringInterestConfirmationRequestsAsReminded } from "./persistence/remind";
+import { getAllPupilsToBeRemindedOfInterestConfirmationRequest, getAllPupilsToSendInitialInterestConfirmationRequest } from "./receiver";
+
+const DAYS_AFTER_INITIAL_REQUEST = 7;
+
+/// Send out initial interest confirmation requests to all applicable pupils
+export async function requestInterestConfirmationOfNextPupils(manager: EntityManager) {
+    // get pupils to remind
+    const pupils = await getAllPupilsToSendInitialInterestConfirmationRequest(manager);
+
+    // create and save the corresponding PupilTutoringInterestConfirmationRequest in DB
+    const requests = await createTutoringInterestConfirmationRequests(pupils, manager);
+
+    // send out the notifications
+    await sendTutoringConfirmationRequests(requests, manager);
+}
+
+/// Remind all applicable pupils who haven't answered the interest confirmation request yet
+export async function remindNextPupils(manager: EntityManager) {
+    // get pupils to remind
+    const pupils = await getAllPupilsToBeRemindedOfInterestConfirmationRequest(manager, DAYS_AFTER_INITIAL_REQUEST);
+    const requests = pupils.map(p => p.tutoringInterestConfirmationRequest);
+
+    // persist the remind state
+    await saveTutoringInterestConfirmationRequestsAsReminded(requests, manager);
+
+    // send out notifications
+    await sendTutoringConfirmationRequestReminders(requests, manager);
+}

--- a/common/interest-confirmation/tutoring/notify/send.ts
+++ b/common/interest-confirmation/tutoring/notify/send.ts
@@ -1,0 +1,42 @@
+import { EntityManager } from "typeorm";
+import { PupilTutoringInterestConfirmationRequest } from "../../../entity/PupilTutoringInterestConfirmationRequest";
+import { mailjetTemplates, sendTemplateMail } from "../../../mails";
+import { getTransactionLog } from "../../../transactionlog";
+import PupilInterestConfirmationRequestReminderSentEvent from "../../../transactionlog/types/PupilInterestConfirmationRequestReminderSentEvent";
+import PupilInterestConfirmationRequestSentEvent from "../../../transactionlog/types/PupilInterestConfirmationRequestSentEvent";
+
+function createMailFromTemplate(template: typeof mailjetTemplates.PUPILMATCHREQUESTCONFIRMATION | typeof mailjetTemplates.PUPILMATCHREQUESTCONFIRMATIONREMINDER, confirmationRequest: PupilTutoringInterestConfirmationRequest) {
+    return template({
+        firstName: confirmationRequest.pupil.firstname,
+        authToken: confirmationRequest.pupil.authToken,
+        confirmationURL: confirmationRequest.confirmationURL(),
+        refusalURL: confirmationRequest.refusalURL()
+    });
+}
+
+export async function sendTutoringConfirmationRequest(confirmationRequest: PupilTutoringInterestConfirmationRequest, manager: EntityManager) {
+    // send email
+    const mail = createMailFromTemplate(mailjetTemplates.PUPILMATCHREQUESTCONFIRMATION, confirmationRequest);
+    await sendTemplateMail(mail, confirmationRequest.pupil.email);
+
+    // transaction log
+    const transactionLog = getTransactionLog();
+    await transactionLog.log(new PupilInterestConfirmationRequestSentEvent(confirmationRequest));
+}
+
+export async function sendTutoringConfirmationRequestReminder(confirmationRequest: PupilTutoringInterestConfirmationRequest, manager: EntityManager) {
+    // send email
+    const mail = createMailFromTemplate(mailjetTemplates.PUPILMATCHREQUESTCONFIRMATIONREMINDER, confirmationRequest);
+    await sendTemplateMail(mail, confirmationRequest.pupil.email);
+
+    // transaction log
+    const transactionLog = getTransactionLog();
+    await transactionLog.log(new PupilInterestConfirmationRequestReminderSentEvent(confirmationRequest));
+}
+
+export async function sendTutoringConfirmationRequests(confirmationRequests: PupilTutoringInterestConfirmationRequest[], manager: EntityManager) {
+    return await Promise.all(confirmationRequests.map(r => sendTutoringConfirmationRequest(r, manager)));
+}
+export async function sendTutoringConfirmationRequestReminders(confirmationRequests: PupilTutoringInterestConfirmationRequest[], manager: EntityManager) {
+    return await Promise.all(confirmationRequests.map(r => sendTutoringConfirmationRequestReminder(r, manager)));
+}

--- a/common/interest-confirmation/tutoring/notify/urls.ts
+++ b/common/interest-confirmation/tutoring/notify/urls.ts
@@ -1,0 +1,3 @@
+export function generateStatusChangeURLFromToken(token: string, confirmed: boolean) {
+    return `https://my.corona-school.de/confirm?token=${token}&confirmed=${confirmed ? "true" : "false"}`;
+}

--- a/common/interest-confirmation/tutoring/persistence/change-status.ts
+++ b/common/interest-confirmation/tutoring/persistence/change-status.ts
@@ -1,0 +1,30 @@
+import { EntityManager } from "typeorm";
+import { InterestConfirmationStatus, PupilTutoringInterestConfirmationRequest } from "../../../entity/PupilTutoringInterestConfirmationRequest";
+import { getTransactionLog } from "../../../transactionlog";
+import PupilInterestConfirmationRequestStatusChangeEvent from "../../../transactionlog/types/PupilInterestConfirmationRequestStatusChangeEvent";
+
+export async function changeStatus(token: string, status: InterestConfirmationStatus, manager: EntityManager) {
+    //get db confirmation request
+    const confirmationRequest = await manager.findOne(PupilTutoringInterestConfirmationRequest, {
+        token
+    }, {
+        relations: ["pupil"]
+    });
+
+    if (!confirmationRequest) {
+        throw new Error(`Cannot find PupilTutoringInterestConfirmationRequest with token ${token}`);
+    }
+
+    //store previous status for transaction log
+    const previousStatus = confirmationRequest.status;
+
+    //change status
+    confirmationRequest.status = status;
+
+    //save changes
+    await manager.save(confirmationRequest);
+
+    //transaction log
+    const transactionLog = getTransactionLog();
+    transactionLog.log(new PupilInterestConfirmationRequestStatusChangeEvent(confirmationRequest, previousStatus));
+}

--- a/common/interest-confirmation/tutoring/persistence/create.ts
+++ b/common/interest-confirmation/tutoring/persistence/create.ts
@@ -1,0 +1,22 @@
+import { EntityManager } from "typeorm";
+import { Pupil } from "../../../entity/Pupil";
+import { createUniqueToken, PupilTutoringInterestConfirmationRequest } from "../../../entity/PupilTutoringInterestConfirmationRequest";
+
+export async function createTutoringInterestConfirmationRequest(pupil: Pupil, manager: EntityManager) {
+    // create tutoring interest confirmation request
+    const token = await createUniqueToken(manager);
+    const confirmationRequest = new PupilTutoringInterestConfirmationRequest(pupil, token);
+
+    //save confirmation request
+    await manager.save(confirmationRequest);
+
+    return confirmationRequest;
+}
+
+export async function createTutoringInterestConfirmationRequests(pupils: Pupil[], manager: EntityManager) {
+    const requests: PupilTutoringInterestConfirmationRequest[] = [];
+    for (const p of pupils) { //without concurrency, since we're using unique token generation, which isn't necessarily safe.
+        requests.push(await createTutoringInterestConfirmationRequest(p, manager));
+    }
+    return requests;
+}

--- a/common/interest-confirmation/tutoring/persistence/remind.ts
+++ b/common/interest-confirmation/tutoring/persistence/remind.ts
@@ -1,0 +1,14 @@
+import { EntityManager } from "typeorm";
+import { PupilTutoringInterestConfirmationRequest } from "../../../entity/PupilTutoringInterestConfirmationRequest";
+
+export async function saveTutoringInterestConfirmationRequestAsReminded(request: PupilTutoringInterestConfirmationRequest, manager: EntityManager) {
+    //update reminded date
+    request.reminderSentDate = new Date();
+
+    //save confirmation request
+    await manager.save(request);
+}
+
+export async function saveTutoringInterestConfirmationRequestsAsReminded(requests: PupilTutoringInterestConfirmationRequest[], manager: EntityManager) {
+    return await Promise.all(requests.map(p => saveTutoringInterestConfirmationRequestAsReminded(p, manager)));
+}

--- a/common/interest-confirmation/tutoring/receiver/index.ts
+++ b/common/interest-confirmation/tutoring/receiver/index.ts
@@ -1,0 +1,25 @@
+import { EntityManager } from "typeorm";
+import { numberOfPupilsToRemindNow } from "./limit-prediction";
+import { getAllMatchablePupilsWithoutInterestConfirmationRequest, getAllMatchableUnremindedPupilsWithPendingConfirmationRequest } from "./people/pupils";
+
+
+/// Return all pupils that should NOW get the initial request to confirm their interest
+export async function getAllPupilsToSendInitialInterestConfirmationRequest(manager: EntityManager) {
+    //compute a limit on how many people should NOW be able to receive the initial request
+    const limit = await numberOfPupilsToRemindNow(manager);
+
+    //get the pupils
+    const pupils = await getAllMatchablePupilsWithoutInterestConfirmationRequest(manager, limit);
+
+    //return the results
+    return pupils;
+}
+
+
+/// Return all pupils that should NOW get to be reminded of their interest confirmation request
+export async function getAllPupilsToBeRemindedOfInterestConfirmationRequest(manager: EntityManager, daysAfterInitialRequest: number) {
+    //get the pupils
+    const pupils = await getAllMatchableUnremindedPupilsWithPendingConfirmationRequest(manager, daysAfterInitialRequest);
+
+    return pupils;
+}

--- a/common/interest-confirmation/tutoring/receiver/limit-prediction.ts
+++ b/common/interest-confirmation/tutoring/receiver/limit-prediction.ts
@@ -1,0 +1,19 @@
+import { EntityManager } from "typeorm";
+import { numberOfMatchablePupilsWithConfirmedInterest as totalNumberOfMatchablePupilsWithConfirmedInterest } from "./people/pupils";
+import { totalNumberOfAllowedOpenMatchRequestsOfStudents } from "./people/students";
+
+const EXPECTED_PERECENT_OF_COMFIRMATIONS = 0.66;
+
+export async function numberOfPupilsToRemindNow(manager: EntityManager): Promise<number> {
+    //get the number of matches that could be created in theory from an offer-perspective
+    const matchOfferCount = await totalNumberOfAllowedOpenMatchRequestsOfStudents(manager);
+
+    //get number of pupils that have confirmed their interest, but who are still waiting to get a match
+    const matchDemandCount = await totalNumberOfMatchablePupilsWithConfirmedInterest(manager);
+
+    //compute how many pupils to remind now
+    const estimation = Math.floor((matchOfferCount - matchDemandCount)/EXPECTED_PERECENT_OF_COMFIRMATIONS);
+
+    //return either 0 or that result above
+    return Math.max(0, estimation);
+}

--- a/common/interest-confirmation/tutoring/receiver/people/db-queries.ts
+++ b/common/interest-confirmation/tutoring/receiver/people/db-queries.ts
@@ -1,0 +1,56 @@
+import { EntityManager, SelectQueryBuilder } from "typeorm";
+import { tuteesToMatchQuery } from "../../../../administration/match-making/tutoring/people/tutees";
+import { RegistrationSource } from "../../../../entity/Person";
+import { Pupil } from "../../../../entity/Pupil";
+import { InterestConfirmationStatus } from "../../../../entity/PupilTutoringInterestConfirmationRequest";
+
+// Raw Queries:
+// ⎺⎺⎺⎺⎺⎺⎺⎺
+function allMatchablePupilsThatRequireInterestConfirmationQuery(manager: EntityManager) {
+    //only pupils not registered through partner schools require interest confirmation
+    return tuteesToMatchQuery(manager).andWhere("p.registrationSource != (:rs)", { rs: RegistrationSource.COOPERATION});
+}
+function allMatchablePupilsWithoutInterestConfirmationRequestQuery(manager: EntityManager) {
+    //join pupil p2 a second time, to have a relationship from PupilTutoringInterestConfirmationRequest to Pupil which is not undefined
+    return allMatchablePupilsThatRequireInterestConfirmationQuery(manager).leftJoinAndSelect("p.tutoringInterestConfirmationRequest", "pticr").leftJoinAndSelect("pticr.pupil", "p2").andWhere("pticr IS NULL");
+}
+function allMatchablePupilsWithInterestConfirmationRequestQuery(manager: EntityManager) {
+    return allMatchablePupilsThatRequireInterestConfirmationQuery(manager).innerJoinAndSelect("p.tutoringInterestConfirmationRequest", "pticr").leftJoinAndSelect("pticr.pupil", "p2");
+}
+
+
+// Combinable Query-Extensions:
+// ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+export function createOrderedAndLimitedPupilsQueryFrom(qb: SelectQueryBuilder<Pupil>, limitToN?: number) {
+    const q = qb.addOrderBy("p.createdAt", "ASC");
+    if (limitToN) return q.take(limitToN);
+    return q;
+}
+export function createFilterPupilRequestByStatusQueryFrom(qb: SelectQueryBuilder<Pupil>, status: InterestConfirmationStatus) {
+    return qb.andWhere("pticr.status = :status", { status });
+}
+export function createUnremindedPupilRequestQueryFrom(qb: SelectQueryBuilder<Pupil>) {
+    return qb.andWhere("pticr.reminderSentDate IS NULL");
+}
+
+// Combined Queries
+// ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+/// Return all pupils which are matchable, have received the interest-confirmation request and which is in the given status.
+export function allMatchablePupilsWithRequestConfirmationStatusLimitedQuery(manager: EntityManager, status: InterestConfirmationStatus, limitToN?: number) {
+    const pupilsWithConfirmationRequest = allMatchablePupilsWithInterestConfirmationRequestQuery(manager);
+    const filteredPupilsWithConfirmationRequest = createFilterPupilRequestByStatusQueryFrom(pupilsWithConfirmationRequest, status);
+    const orderedLimitedPendingPupilsWithConfirmationRequest = createOrderedAndLimitedPupilsQueryFrom(filteredPupilsWithConfirmationRequest, limitToN);
+
+    return orderedLimitedPendingPupilsWithConfirmationRequest;
+}
+
+export function allMatchablePupilsWithoutInterestConfirmationRequestLimitedQuery(manager: EntityManager, limitToN?: number) {
+    return createOrderedAndLimitedPupilsQueryFrom(allMatchablePupilsWithoutInterestConfirmationRequestQuery(manager), limitToN);
+}
+
+export function allMatchablePupilsUnremindedWithPendingConfirmation(manager: EntityManager) {
+    const allPendingQuery = allMatchablePupilsWithRequestConfirmationStatusLimitedQuery(manager, InterestConfirmationStatus.PENDING);
+    const allUnremindedQuery = createUnremindedPupilRequestQueryFrom(allPendingQuery);
+
+    return allUnremindedQuery;
+}

--- a/common/interest-confirmation/tutoring/receiver/people/db-queries.ts
+++ b/common/interest-confirmation/tutoring/receiver/people/db-queries.ts
@@ -1,5 +1,5 @@
 import { EntityManager, SelectQueryBuilder } from "typeorm";
-import { tuteesToMatchQuery } from "../../../../administration/match-making/tutoring/people/tutees";
+import { matchableTuteesQuery } from "../../../../administration/match-making/tutoring/people/tutees";
 import { RegistrationSource } from "../../../../entity/Person";
 import { Pupil } from "../../../../entity/Pupil";
 import { InterestConfirmationStatus } from "../../../../entity/PupilTutoringInterestConfirmationRequest";
@@ -8,7 +8,7 @@ import { InterestConfirmationStatus } from "../../../../entity/PupilTutoringInte
 // ⎺⎺⎺⎺⎺⎺⎺⎺
 function allMatchablePupilsThatRequireInterestConfirmationQuery(manager: EntityManager) {
     //only pupils not registered through partner schools require interest confirmation
-    return tuteesToMatchQuery(manager).andWhere("p.registrationSource != (:rs)", { rs: RegistrationSource.COOPERATION});
+    return matchableTuteesQuery(manager).andWhere("p.registrationSource != (:rs)", { rs: RegistrationSource.COOPERATION});
 }
 function allMatchablePupilsWithoutInterestConfirmationRequestQuery(manager: EntityManager) {
     //join pupil p2 a second time, to have a relationship from PupilTutoringInterestConfirmationRequest to Pupil which is not undefined

--- a/common/interest-confirmation/tutoring/receiver/people/pupils.ts
+++ b/common/interest-confirmation/tutoring/receiver/people/pupils.ts
@@ -1,0 +1,32 @@
+import { EntityManager } from "typeorm";
+import { InterestConfirmationStatus } from "../../../../entity/PupilTutoringInterestConfirmationRequest";
+import { allMatchablePupilsUnremindedWithPendingConfirmation, allMatchablePupilsWithoutInterestConfirmationRequestLimitedQuery, allMatchablePupilsWithRequestConfirmationStatusLimitedQuery, createFilterPupilRequestByStatusQueryFrom, createOrderedAndLimitedPupilsQueryFrom } from "./db-queries";
+import * as moment from "moment-timezone";
+
+
+/// Return all pupils which are matchable, have received the interest-confirmation request and which is in the given status.
+async function getAllMatchablePupilsWithRequestConfirmationStatus(manager: EntityManager, status: InterestConfirmationStatus, limitToN?: number) {
+    return await allMatchablePupilsWithRequestConfirmationStatusLimitedQuery(manager, status, limitToN).getMany();
+}
+/// All matchable pupils that have confirmed their interest, but only take the first n, ordered by registration date, if given.
+export async function getAllMatchablePupilsWithConfirmedInterest(manager: EntityManager, limitToN?: number) {
+    return getAllMatchablePupilsWithRequestConfirmationStatus(manager, InterestConfirmationStatus.CONFIRMED, limitToN);
+}
+export async function numberOfMatchablePupilsWithConfirmedInterest(manager: EntityManager) {
+    return (await getAllMatchablePupilsWithConfirmedInterest(manager)).length;
+}
+
+/// All matchable pupils that haven't so far received the interest-confirmation mail, but only take the first n, ordered by registration date, if given
+export async function getAllMatchablePupilsWithoutInterestConfirmationRequest(manager: EntityManager, limitToN?: number) {
+    return await allMatchablePupilsWithoutInterestConfirmationRequestLimitedQuery(manager, limitToN).getMany();
+}
+
+/// All matchable pupils that have received the first interest-confirmation request, which they haven't answered on so far – but they weren't reminded until now.
+export async function getAllMatchableUnremindedPupilsWithPendingConfirmationRequest(manager: EntityManager, ndaysAfterInitialSend: number) {
+    const allPendingUnreminded = await allMatchablePupilsUnremindedWithPendingConfirmation(manager).getMany();
+
+    //filter by dates after initial sending
+    return allPendingUnreminded.filter( p => {
+        return moment(p.tutoringInterestConfirmationRequest.createdAt).add(ndaysAfterInitialSend, "days").startOf("day").isBefore(moment());
+    });
+}

--- a/common/interest-confirmation/tutoring/receiver/people/students.ts
+++ b/common/interest-confirmation/tutoring/receiver/people/students.ts
@@ -1,0 +1,6 @@
+import { EntityManager } from "typeorm";
+import { tutorsToMatch } from "../../../../administration/match-making/tutoring/people/tutors";
+
+export async function totalNumberOfAllowedOpenMatchRequestsOfStudents(manager: EntityManager): Promise<number> {
+    return (await tutorsToMatch(manager)).reduce( (acc, s) => acc + s.openMatchRequestCount, 0);
+}

--- a/common/mails/templates.ts
+++ b/common/mails/templates.ts
@@ -465,5 +465,33 @@ export const mailjet = {
             disabled: false,
             variables: variables
         };
+    },
+    PUPILMATCHREQUESTCONFIRMATION: (variables: {
+        firstName: string;
+        authToken: string;
+        confirmationURL: string;
+        refusalURL: string;
+    }) => {
+        return <TemplateMail>{
+            type: "pupilmatchrequestconfirmation",
+            id: 2827881,
+            sender: DEFAULTSENDERS.support,
+            disabled: false,
+            variables: variables
+        };
+    },
+    PUPILMATCHREQUESTCONFIRMATIONREMINDER: (variables: {
+        firstName: string;
+        authToken: string;
+        confirmationURL: string;
+        refusalURL: string;
+    }) => {
+        return <TemplateMail>{
+            type: "pupilmatchrequestconfirmationreminder",
+            id: 2828166,
+            sender: DEFAULTSENDERS.support,
+            disabled: false,
+            variables: variables
+        };
     }
 };

--- a/common/migration/1619642412485-InterestConfirmation.ts
+++ b/common/migration/1619642412485-InterestConfirmation.ts
@@ -1,0 +1,30 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class InterestConfirmation1619642412485 implements MigrationInterface {
+    name = 'InterestConfirmation1619642412485';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "pupil_tutoring_interest_confirmation_request" ("id" SERIAL NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "status" character varying NOT NULL DEFAULT 'pending', "token" character varying NOT NULL, "reminderSentDate" TIMESTAMP DEFAULT null, "pupilId" integer, CONSTRAINT "REL_5928ac6454eee0bfbdb8e538ef" UNIQUE ("pupilId"), CONSTRAINT "PK_5f3515ba0bd182b1cc34f06ef11" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_8108668f1658b14b9db299634e" ON "pupil_tutoring_interest_confirmation_request" ("token") `);
+        await queryRunner.query(`ALTER TYPE "public"."log_logtype_enum" RENAME TO "log_logtype_enum_old"`);
+        await queryRunner.query(`CREATE TYPE "log_logtype_enum" AS ENUM('misc', 'verificationRequets', 'verified', 'matchDissolve', 'projectMatchDissolve', 'fetchedFromWix', 'deActivate', 'updatePersonal', 'updateSubjects', 'updateProjectFields', 'accessedByScreener', 'updatedByScreener', 'updateStudentDescription', 'createdCourse', 'certificateRequest', 'cancelledCourse', 'cancelledSubcourse', 'createdCourseAttendanceLog', 'contactMentor', 'bbbMeeting', 'contactExpert', 'participantJoinedCourse', 'participantLeftCourse', 'participantJoinedWaitingList', 'participantLeftWaitingList', 'userAccessedCourseWhileAuthenticated', 'instructorIssuedCertificate', 'pupilInterestConfirmationRequestSent', 'pupilInterestConfirmationRequestReminderSent', 'pupilInterestConfirmationRequestStatusChange')`);
+        await queryRunner.query(`ALTER TABLE "log" ALTER COLUMN "logtype" DROP DEFAULT`);
+        await queryRunner.query(`ALTER TABLE "log" ALTER COLUMN "logtype" TYPE "log_logtype_enum" USING "logtype"::"text"::"log_logtype_enum"`);
+        await queryRunner.query(`ALTER TABLE "log" ALTER COLUMN "logtype" SET DEFAULT 'misc'`);
+        await queryRunner.query(`DROP TYPE "log_logtype_enum_old"`);
+        await queryRunner.query(`ALTER TABLE "pupil_tutoring_interest_confirmation_request" ADD CONSTRAINT "FK_5928ac6454eee0bfbdb8e538ef8" FOREIGN KEY ("pupilId") REFERENCES "pupil"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "pupil_tutoring_interest_confirmation_request" DROP CONSTRAINT "FK_5928ac6454eee0bfbdb8e538ef8"`);
+        await queryRunner.query(`CREATE TYPE "log_logtype_enum_old" AS ENUM('accessedByScreener', 'bbbMeeting', 'cancelledCourse', 'cancelledSubcourse', 'certificateRequest', 'contactExpert', 'contactMentor', 'createdCourse', 'createdCourseAttendanceLog', 'deActivate', 'fetchedFromWix', 'instructorIssuedCertificate', 'matchDissolve', 'misc', 'participantJoinedCourse', 'participantJoinedWaitingList', 'participantLeftCourse', 'participantLeftWaitingList', 'projectMatchDissolve', 'updatePersonal', 'updateProjectFields', 'updateStudentDescription', 'updateSubjects', 'updatedByScreener', 'userAccessedCourseWhileAuthenticated', 'verificationRequets', 'verified')`);
+        await queryRunner.query(`ALTER TABLE "log" ALTER COLUMN "logtype" DROP DEFAULT`);
+        await queryRunner.query(`ALTER TABLE "log" ALTER COLUMN "logtype" TYPE "log_logtype_enum_old" USING "logtype"::"text"::"log_logtype_enum_old"`);
+        await queryRunner.query(`ALTER TABLE "log" ALTER COLUMN "logtype" SET DEFAULT 'misc'`);
+        await queryRunner.query(`DROP TYPE "log_logtype_enum"`);
+        await queryRunner.query(`ALTER TYPE "log_logtype_enum_old" RENAME TO  "log_logtype_enum"`);
+        await queryRunner.query(`DROP INDEX "IDX_8108668f1658b14b9db299634e"`);
+        await queryRunner.query(`DROP TABLE "pupil_tutoring_interest_confirmation_request"`);
+    }
+
+}

--- a/common/transactionlog/types/LogType.ts
+++ b/common/transactionlog/types/LogType.ts
@@ -26,6 +26,9 @@ enum LogType {
     PARTICIPANT_LEFT_WAITING_LIST = "participantLeftWaitingList",
     ACCESSED_COURSED = "userAccessedCourseWhileAuthenticated",
     INSTRUCTOR_ISSUED_CERTIFICATE = "instructorIssuedCertificate",
+    PUPIL_INTEREST_CONFIRMATION_REQUEST_SENT = "pupilInterestConfirmationRequestSent",
+    PUPIL_INTEREST_CONFIRMATION_REQUEST_REMINDER_SENT = "pupilInterestConfirmationRequestReminderSent",
+    PUPIL_INTEREST_CONFIRMATION_REQUEST_STATUS_CHANGE = "pupilInterestConfirmationRequestStatusChange",
 }
 
 export default LogType;

--- a/common/transactionlog/types/PupilInterestConfirmationRequestReminderSentEvent.ts
+++ b/common/transactionlog/types/PupilInterestConfirmationRequestReminderSentEvent.ts
@@ -1,0 +1,9 @@
+import LogUserEvent from "./LogUserEvent";
+import LogType from "./LogType";
+import { PupilTutoringInterestConfirmationRequest } from "../../entity/PupilTutoringInterestConfirmationRequest";
+
+export default class PupilInterestConfirmationRequestReminderSentEvent extends LogUserEvent {
+    constructor(pticr: PupilTutoringInterestConfirmationRequest) {
+        super(LogType.PUPIL_INTEREST_CONFIRMATION_REQUEST_REMINDER_SENT, pticr.pupil, { sendDate: new Date() });
+    }
+}

--- a/common/transactionlog/types/PupilInterestConfirmationRequestSentEvent.ts
+++ b/common/transactionlog/types/PupilInterestConfirmationRequestSentEvent.ts
@@ -1,0 +1,9 @@
+import LogUserEvent from "./LogUserEvent";
+import LogType from "./LogType";
+import { PupilTutoringInterestConfirmationRequest } from "../../entity/PupilTutoringInterestConfirmationRequest";
+
+export default class PupilInterestConfirmationRequestSentEvent extends LogUserEvent {
+    constructor(pticr: PupilTutoringInterestConfirmationRequest) {
+        super(LogType.PUPIL_INTEREST_CONFIRMATION_REQUEST_SENT, pticr.pupil, { sendDate: new Date() });
+    }
+}

--- a/common/transactionlog/types/PupilInterestConfirmationRequestStatusChangeEvent.ts
+++ b/common/transactionlog/types/PupilInterestConfirmationRequestStatusChangeEvent.ts
@@ -1,0 +1,13 @@
+import LogUserEvent from "./LogUserEvent";
+import LogType from "./LogType";
+import { InterestConfirmationStatus, PupilTutoringInterestConfirmationRequest } from "../../entity/PupilTutoringInterestConfirmationRequest";
+
+export default class PupilInterestConfirmationRequestStatusChangeEvent extends LogUserEvent {
+    constructor(pticr: PupilTutoringInterestConfirmationRequest, previousStatus?: InterestConfirmationStatus) {
+        super(LogType.PUPIL_INTEREST_CONFIRMATION_REQUEST_STATUS_CHANGE, pticr.pupil, {
+            changeDate: pticr.updatedAt,
+            newStatus: pticr.status,
+            previousStatus
+        });
+    }
+}

--- a/common/util/enumReverseMapping.ts
+++ b/common/util/enumReverseMapping.ts
@@ -7,6 +7,7 @@ import { TeacherModule } from "../entity/Student";
 import { RegistrationSource } from "../entity/Person";
 import { Language } from "../daz/language";
 import { LearningGermanSince } from "../daz/learningGermanSince";
+import { InterestConfirmationStatus } from "../entity/PupilTutoringInterestConfirmationRequest";
 
 const EnumReverseMappings = {
     State: caseInsensitive(reverseMappingForStringEnum(State)),
@@ -18,7 +19,8 @@ const EnumReverseMappings = {
     TeacherModule: caseInsensitive(reverseMappingForStringEnum(TeacherModule)),
     RegistrationSource: caseInsensitive(reverseMappingForNumericEnumNames(RegistrationSource)),
     Language: reverseMappingForStringEnum(Language),
-    LearningGermanSince: reverseMappingForStringEnum(LearningGermanSince)
+    LearningGermanSince: reverseMappingForStringEnum(LearningGermanSince),
+    PupilTutoringInterestConfirmationStatus: reverseMappingForStringEnum(InterestConfirmationStatus)
 };
 
 function reverseMappingForStringEnum<E>(e: E): ((s: string) => E[keyof E]) {

--- a/jobs/list.ts
+++ b/jobs/list.ts
@@ -8,6 +8,8 @@ import matchFollowUpJob from "./periodic/match-follow-up";
 import jufoVerificationInfo from "./periodic/jufo-verification-info";
 import projectMatchMaking from "./periodic/project-match-making";
 import tutoringMatchMaking from "./periodic/tutoring-match-making";
+import initialInterestConfirmationRequests from "./periodic/interest-confirmation-requests";
+import interestConfirmationRequestReminders from "./periodic/interest-confirmation-request-reminders";
 
 // A list of all jobs that should be scheduled at the moment
 export const allJobs: CSCronJob[] = [
@@ -23,6 +25,9 @@ export const allJobs: CSCronJob[] = [
     // every afternoon
     { cronTime: "00 35 15 * * *", jobFunction: projectMatchMaking},
     // { cronTime: "00 47 14 * * *", jobFunction: tutoringMatchMaking}, // only scheduled manually, at the moment
+    { cronTime: "00 30 16 * * *", jobFunction: interestConfirmationRequestReminders},
+    // every afternoon, but only on Monday and Thursday
+    { cronTime: "00 15 16 * * 1,4", jobFunction: initialInterestConfirmationRequests},
     // every day at midnight/beginning
     { cronTime: "00 00 00 * * *", jobFunction: jufoVerificationInfo}
 ];

--- a/jobs/periodic/interest-confirmation-request-reminders/index.ts
+++ b/jobs/periodic/interest-confirmation-request-reminders/index.ts
@@ -1,0 +1,11 @@
+import { getLogger } from "log4js";
+import { EntityManager } from "typeorm";
+import { remindNextPupils } from "../../../common/interest-confirmation/tutoring";
+
+const logger = getLogger();
+
+export default async function execute(manager: EntityManager) {
+    logger.info("Pupil Interest Confirmation Request Reminder job will be executed...");
+    //request interest confirmation of "next" pupils
+    await remindNextPupils(manager);
+}

--- a/jobs/periodic/interest-confirmation-requests/index.ts
+++ b/jobs/periodic/interest-confirmation-requests/index.ts
@@ -1,0 +1,11 @@
+import { getLogger } from "log4js";
+import { EntityManager } from "typeorm";
+import { requestInterestConfirmationOfNextPupils } from "../../../common/interest-confirmation/tutoring";
+
+const logger = getLogger();
+
+export default async function execute(manager: EntityManager) {
+    logger.info("Pupil Interest Confirmation Request job will be executed...");
+    //request interest confirmation of "next" pupils
+    await requestInterestConfirmationOfNextPupils(manager);
+}

--- a/jobs/periodic/tutoring-match-making/index.ts
+++ b/jobs/periodic/tutoring-match-making/index.ts
@@ -6,11 +6,13 @@ import { matchMakingOfAllPossibleMatches } from "../../../common/administration/
 const logger = getLogger();
 
 export default async function execute(manager: EntityManager) {
-    if (!await shouldPerformAutomaticTutoringMatching(manager)) {
+    const restrictToThoseWithConfirmedInterest = true; // always restrict to those with confirmed interest, when executing this as a periodic job, to assure high matching quality!
+
+    if (!await shouldPerformAutomaticTutoringMatching(manager, restrictToThoseWithConfirmedInterest)) {
         logger.info("---> Will not try tutoring matching today (too few people waiting for their match)");
         return;
     }
 
     //make all possible matches...
-    await matchMakingOfAllPossibleMatches(manager);
+    await matchMakingOfAllPossibleMatches(manager, restrictToThoseWithConfirmedInterest);
 }

--- a/jobs/periodic/tutoring-match-making/pre-check.ts
+++ b/jobs/periodic/tutoring-match-making/pre-check.ts
@@ -4,14 +4,14 @@ import { latestTutoringMatch } from "../../../common/administration/match-making
 import { getNumberOfTuteesToMatch } from "../../../common/administration/match-making/tutoring/people/tutees";
 import { AUTOMATIC_MATCH_INTERVAL, MIN_TUTEE_COUNT_FOR_MATCH_ATTEMPT } from "./constants";
 
-export async function shouldPerformAutomaticTutoringMatching(manager: EntityManager): Promise<boolean> {
+export async function shouldPerformAutomaticTutoringMatching(manager: EntityManager, restrictToThoseWithConfirmedInterest: boolean): Promise<boolean> {
     //get date of last created tutoring match
     const latestMatch = await latestTutoringMatch(manager);
     const latestMatchDate = latestMatch?.createdAt;
 
     const timeCriterion = !latestMatch ? false : moment(latestMatchDate).add(AUTOMATIC_MATCH_INTERVAL, "days").isSameOrBefore(moment()); //don't respect time criterion if this couldn't be obtained...
 
-    const numberOfTuteesToMatch = await getNumberOfTuteesToMatch(manager);
+    const numberOfTuteesToMatch = await getNumberOfTuteesToMatch(manager, restrictToThoseWithConfirmedInterest);
     const waitingTuteeCriterion = numberOfTuteesToMatch >= MIN_TUTEE_COUNT_FOR_MATCH_ATTEMPT;
 
     return timeCriterion || waitingTuteeCriterion;

--- a/web/controllers/interestConfirmationController/index.ts
+++ b/web/controllers/interestConfirmationController/index.ts
@@ -1,0 +1,63 @@
+import { Request, Response } from 'express';
+import { getLogger } from 'log4js';
+import { getManager } from 'typeorm';
+import { InterestConfirmationStatus } from '../../../common/entity/PupilTutoringInterestConfirmationRequest';
+import { changeStatus } from '../../../common/interest-confirmation/tutoring/persistence/change-status';
+import { EnumReverseMappings } from '../../../common/util/enumReverseMapping';
+
+const logger = getLogger();
+
+
+/**
+ * @api {POST} /interest-confirmation/status ChangePupilInterestConfirmationRequestStatus
+ * @apiVersion 1.1.0
+ * @apiDescription
+ * Changes the status of a pupil interest confirmation as specified by the given token
+ *
+ */
+export async function postInterestConfirmationRequestStatus(req: Request, res: Response) {
+    let status = 200;
+    try {
+        if (typeof req.body.token === "string" && typeof req.body.status === "string") {
+            // Check if status is valid
+            const confirmationStatus = EnumReverseMappings.PupilTutoringInterestConfirmationStatus(req.body.status);
+            if (!confirmationStatus || ![InterestConfirmationStatus.CONFIRMED, InterestConfirmationStatus.REFUSED].includes(confirmationStatus)) {
+                logger.warn(`Invalid interest confirmation status ${req.body.status} specified when trying to change interest-confirmation status!`);
+                status = 400;
+            }
+            //make sure that token is non-empty
+            if (req.body.token.length === 0) {
+                logger.warn(`Empty token specified when trying to change interest-confirmaion status!`);
+                status = 400;
+            }
+
+            if (status < 300) {
+                status = await changeInterestConfirmationRequestStatus(req.body.token, confirmationStatus);
+            }
+        } else {
+            status = 400;
+            logger.warn("Invalid request for POST /interest-confirmation/status");
+            logger.debug(req.body);
+        }
+    } catch (e) {
+        logger.error("Unexpected format of express request: " + e.message);
+        logger.debug(req, e);
+        status = 500;
+    }
+    res.status(status).end();
+}
+
+async function changeInterestConfirmationRequestStatus(token: string, confirmationStatus: InterestConfirmationStatus): Promise<number> {
+    const entityManager = getManager();
+
+    try {
+        await changeStatus(token, confirmationStatus, entityManager);
+
+        logger.info(`Successfully changed interest-confirmation status of pupil (token='${token}') to '${confirmationStatus}'`);
+
+        return 200;
+    } catch (e) {
+        logger.error(`Can't change interest-confirmation status of pupil (token='${token}') to status '${confirmationStatus}', ` + e.message);
+        return 500;
+    }
+}

--- a/web/controllers/matchingController/index.ts
+++ b/web/controllers/matchingController/index.ts
@@ -23,7 +23,7 @@ const logger = getLogger();
 async function performMatchRequest(restrictions: ApiMatchingRestrictions, options: ApiMatchingOptions, manager: EntityManager) {
     // get all matchable students and pupils
     const matchableTutors = await tutorsToMatch(manager);
-    const matchableTutees = await tuteesToMatch(manager);
+    const matchableTutees = await tuteesToMatch(manager, !options.disableInterestConfirmationRestriction);
 
     // filter students and pupils according to matching restrictions (if given, otherwise use all for matching)
     const tutorFilters = restrictions.tutorRestrictions?.map(r => tutorMatchingRestrictionFilter(r));

--- a/web/controllers/matchingController/types/matching-options.ts
+++ b/web/controllers/matchingController/types/matching-options.ts
@@ -12,4 +12,6 @@ export class ApiMatchingOptions {
     dryRun: boolean = false;
     @IsEnum(ApiNotificationOption)
     notifications: ApiNotificationOption = ApiNotificationOption.email;
+    @IsBoolean()
+    disableInterestConfirmationRestriction: boolean = false; //defines what matchable pupils will be, i.e. if only pupils with confirmed interest (or those from partnering schools) are allowed to be part of the matching
 }

--- a/web/controllers/userController/format.ts
+++ b/web/controllers/userController/format.ts
@@ -158,6 +158,7 @@ import { ProjectField } from "../../../common/jufo/projectFields";
  */
 import {ApiSubject} from "../format";
 import {ExpertAllowedIndication} from "../../../common/jufo/expertAllowedIndication";
+import { InterestConfirmationStatus } from "../../../common/entity/PupilTutoringInterestConfirmationRequest";
 
 export class ApiGetUser {
     id: string;
@@ -190,6 +191,7 @@ export class ApiGetUser {
     lastUpdatedSettingsViaBlocker: number;
     registrationDate: number;
     expertData?: ApiExpertData;
+    pupilTutoringInterestConfirmationStatus?: InterestConfirmationStatus;
     //TODO: Um Mentor erweitern
 }
 

--- a/web/controllers/userController/index.ts
+++ b/web/controllers/userController/index.ts
@@ -562,6 +562,7 @@ async function get(wix_id: string, person: Pupil | Student): Promise<ApiGetUser>
         apiResponse.state = person.state;
         apiResponse.schoolType = person.schooltype;
         apiResponse.lastUpdatedSettingsViaBlocker = moment(person.lastUpdatedSettingsViaBlocker).unix();
+        apiResponse.pupilTutoringInterestConfirmationStatus = person.tutoringInterestConfirmationRequest?.status;
 
         let matches = await entityManager.find(Match, {
             pupil: person,

--- a/web/dev.ts
+++ b/web/dev.ts
@@ -30,6 +30,7 @@ import { ExpertiseTag } from "../common/entity/ExpertiseTag";
 import { ExpertAllowedIndication } from "../common/jufo/expertAllowedIndication";
 import { LearningGermanSince } from "../common/daz/learningGermanSince";
 import { Language } from "../common/daz/language";
+import { PupilTutoringInterestConfirmationRequest } from "../common/entity/PupilTutoringInterestConfirmationRequest";
 
 export async function setupDevDB() {
     const conn = getConnection();
@@ -107,6 +108,60 @@ export async function setupDevDB() {
     p.subjects = JSON.stringify([]);
     p.grade = "6. Klasse";
     p.openMatchRequestCount = 0;
+    pupils.push(p);
+
+    p = new Pupil();
+    p.active = true;
+    p.firstname = "Martin";
+    p.lastname = "Ulz";
+    p.isParticipant = false;
+    p.isPupil = true;
+    p.isProjectCoachee = false;
+    p.email = "martinulzs@example.corona-school.de"; //no @example.org, if you wanna test matching
+    p.verification = null;
+    p.verifiedAt = new Date(new Date().getTime() - 200000);
+    p.authToken = sha512("authtokenP5");
+    p.wix_id = "00000000-0000-0001-0003-1b4c4c526368";
+    p.wix_creation_date = new Date(new Date().getTime() - 20000000);
+    p.subjects = JSON.stringify(["Deutsch", "Geschichte"]);
+    p.grade = "13. Klasse";
+    p.openMatchRequestCount = 1;
+    pupils.push(p);
+
+    const p6 = p = new Pupil();
+    p.active = true;
+    p.firstname = "Laurin";
+    p.lastname = "Ipsem";
+    p.isParticipant = false;
+    p.isPupil = true;
+    p.isProjectCoachee = false;
+    p.email = "ipsla@example.org";
+    p.verification = null;
+    p.verifiedAt = new Date(new Date().getTime() - 700000);
+    p.authToken = sha512("authtokenP6");
+    p.wix_id = "00000000-0000-0001-0003-1b4c4c526369";
+    p.wix_creation_date = new Date(new Date().getTime() - 70000000);
+    p.subjects = JSON.stringify(["Englisch", "Latein"]);
+    p.grade = "10. Klasse";
+    p.openMatchRequestCount = 1;
+    pupils.push(p);
+
+    const p7 = p = new Pupil();
+    p.active = true;
+    p.firstname = "Lari";
+    p.lastname = "Fari";
+    p.isParticipant = false;
+    p.isPupil = true;
+    p.isProjectCoachee = false;
+    p.email = "larifari@example.org";
+    p.verification = null;
+    p.verifiedAt = new Date(new Date().getTime() - 800000);
+    p.authToken = sha512("authtokenP7");
+    p.wix_id = "00000000-0000-0001-0003-1b4c4c526370";
+    p.wix_creation_date = new Date(new Date().getTime() - 80000000);
+    p.subjects = JSON.stringify(["Musik", "Latein"]);
+    p.grade = "7. Klasse";
+    p.openMatchRequestCount = 1;
     pupils.push(p);
 
     for (let i = 0; i < pupils.length; i++) {
@@ -1186,6 +1241,21 @@ export async function setupDevDB() {
     for (let i = 0; i < experts.length; i++) {
         await entityManager.save(experts[i]);
         console.log("Inserted Dev Expert " + i);
+    }
+
+    //Insert pupil interest confirmation requests
+    const pticrs: PupilTutoringInterestConfirmationRequest[] = [];
+
+    const pticr1 = new PupilTutoringInterestConfirmationRequest(p6, "interest-confirmation-token-P6");
+    pticrs.push(pticr1);
+
+    const pticr2 = new PupilTutoringInterestConfirmationRequest(p7, "interest-confirmation-token-P7");
+    pticr2.reminderSentDate = new Date( Date.now() - 6.912E+08); // minus 8 days in ms
+    pticrs.push(pticr2);
+
+    for (let i = 0; i < pticrs.length; i++) {
+        await entityManager.save(pticrs[i]);
+        console.log("Inserted Pupil Tutoring Interest Request " + i);
     }
 }
 

--- a/web/index.ts
+++ b/web/index.ts
@@ -15,6 +15,7 @@ import * as courseController from "./controllers/courseController";
 import * as registrationController from "./controllers/registrationController";
 import * as mentoringController from "./controllers/mentoringController";
 import * as expertController from "./controllers/expertController";
+import * as interestConfirmationController from "./controllers/interestConfirmationController";
 import { configure, connectLogger, getLogger } from "log4js";
 import { createConnection, getConnection } from "typeorm";
 import { authCheckFactory, screenerAuthCheck } from "./middleware/auth";
@@ -75,6 +76,7 @@ createConnection().then(setupPDFGenerationEnvironment).then(async () => {
     configureRegistrationAPI();
     configureMentoringAPI();
     configureExpertAPI();
+    configurePupilInterestConfirmationAPI();
     const server = await deployServer();
     configureGracefulShutdown(server);
 
@@ -120,7 +122,7 @@ createConnection().then(setupPDFGenerationEnvironment).then(async () => {
 
     function configureUserAPI() {
         const userApiRouter = express.Router();
-        userApiRouter.use(authCheckFactory());
+        userApiRouter.use(authCheckFactory(false, false, true, [], ["tutoringInterestConfirmationRequest"]));
         userApiRouter.get("/", userController.getSelfHandler);
         userApiRouter.get("/:id", userController.getHandler);
         userApiRouter.put("/:id", userController.putHandler);
@@ -323,6 +325,13 @@ createConnection().then(setupPDFGenerationEnvironment).then(async () => {
         expertRouter.get("/tags", expertController.getUsedTagsHandler);
 
         app.use("/api/expert", expertRouter);
+    }
+
+    function configurePupilInterestConfirmationAPI() {
+        const router = express.Router();
+        router.post("/status", interestConfirmationController.postInterestConfirmationRequestStatus);
+
+        app.use("/api/interest-confirmation", router);
     }
 
     async function deployServer() {

--- a/web/middleware/auth.ts
+++ b/web/middleware/auth.ts
@@ -8,7 +8,7 @@ import { Expertise, Mentor } from "../../common/entity/Mentor";
 
 const logger = getLogger();
 
-export function authCheckFactory(optional = false, useQueryParams = false, loadEagerRelations = true, studentDefaultRelations = []) {
+export function authCheckFactory(optional = false, useQueryParams = false, loadEagerRelations = true, studentDefaultRelations = [], pupilDefaultRelations = []) {
     return async function (req: Request, res: Response, next) {
         if (req.method == "OPTIONS") next();
 
@@ -59,6 +59,7 @@ export function authCheckFactory(optional = false, useQueryParams = false, loadE
                         active: true
                     }
                 ],
+                relations: pupilDefaultRelations,
                 loadEagerRelations
             });
             if (pupil instanceof Pupil) {


### PR DESCRIPTION
This PR will introduce a new (temporary) feature to support a new intermediate step in the tutoring matching process. 

It adds the required new backend APIs and changes to the existing APIs to work with an additional and necessary interest-confirmation before pupils will get assigned a match. 

The idea behind this interest-confirmation: Let pupils confirm their interest before they get a new match, such that Corona School can ensure a higher matching quality. At the moment, our waiting time for pupils is quite long, so it is very likely that not every pupil registered two weeks ago still needs our support. 

Note: this restrictions do not apply for pupils coming from one of our partner schools/organizations. We then always know/assume that they are still interested in our project. 

## TODO
- [x] add database migration