### PR TITLE
Added login check to see if user is verified

### DIFF
--- a/common/dto/StudentEditableInfoDTO.ts
+++ b/common/dto/StudentEditableInfoDTO.ts
@@ -53,6 +53,7 @@ export class StudentEditableInfoDTO {
     wasJufoParticipant?: TutorJufoParticipationIndication;
     hasJufoCertificate?: boolean;
     jufoPastParticipationInfo?: string;
+    verifiedAt: Date;
     official?: {
         hours: number;
         module: TeacherModule;

--- a/common/dto/StudentInfoDTO.ts
+++ b/common/dto/StudentInfoDTO.ts
@@ -24,7 +24,7 @@ export class StudentInfoDTO extends StudentEditableInfoDTO {
         s.wasJufoParticipant = student.wasJufoParticipant;
         s.hasJufoCertificate = student.hasJufoCertificate;
         s.jufoPastParticipationInfo = student.jufoPastParticipationInfo;
-
+        s.verifiedAt = student.verifiedAt;
         //official
         if (student.module && student.moduleHours) {
             s.official = {

--- a/web/controllers/tokenController/index.ts
+++ b/web/controllers/tokenController/index.ts
@@ -15,6 +15,7 @@ import {
     sendFirstScreeningInvitationToProjectCoachingJufoAlumni,
     sendFirstScreeningInvitationToTutor
 } from "../../../common/administration/screening/initial-invitations";
+import { generateToken, sendVerificationMail } from "../../../jobs/periodic/fetch/utils/verification";
 
 const logger = getLogger();
 
@@ -146,6 +147,8 @@ export async function verifyToken(token: string): Promise<string | null> {
  * This endpoint allows requesting a new token send via email to the user.
  * A user can only request a new token, if he doesn't have an unused token from the last 24h.
  *
+ * A 409 'Conflict' HTTP status code indicates that the user isn't verified yet and that a new verification email has been sent.
+ * 
  * @apiName requestNewToken
  * @apiGroup Token
  *
@@ -158,6 +161,7 @@ export async function verifyToken(token: string): Promise<string | null> {
  * @apiUse StatusNoContent
  * @apiUse StatusBadRequest
  * @apiUse StatusUnauthorized
+ * @apiUse StatusConflict
  * @apiUse StatusNotFound
  * @apiUse StatusInternalServerError
  */
@@ -178,7 +182,11 @@ export async function getNewTokenHandler(req: Request, res: Response) {
             }
 
             if (person !== undefined) {
-                if (allowedToRequestToken(person)) {
+                if(person.verifiedAt == null) {
+                    status = 409;
+                    person.verification = generateToken();
+                    await sendVerificationMail(person);
+                } else if (allowedToRequestToken(person)) {
                     if (req.query.redirectTo !== undefined && typeof req.query.redirectTo !== "string")
                         status = 400;
 


### PR DESCRIPTION
This adds a check to the login procedure which checks if the user is verified. If they aren't yet, a new verification email will be sent to [enforce e-mail verification](https://github.com/corona-school/project-user/issues/267)