### PR TITLE
Refactor Course Controller

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7870,9 +7870,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.9",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
-      "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w=="
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
+      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw=="
     },
     "uc.micro": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "sequelize": "^5.21.5",
     "textversionjs": "^1.1.3",
     "typeorm": "^0.2.29",
-    "typescript": "^3.9.9",
+    "typescript": "^4.3.2",
     "unique-names-generator": "^4.3.1",
     "uuid": "^7.0.3",
     "validator": "^13.5.2",

--- a/tests/integration/screeningInvitation.int.test.ts
+++ b/tests/integration/screeningInvitation.int.test.ts
@@ -45,40 +45,37 @@ describe("Screening Invitation", function() {
         testStudent.verification = verificationToken;
 
         // save test student
-        return new Promise((resolve) => {
-            manager.save(testStudent).then(() => {
-                //setup mailjetStub
-                const mailjetStub = sandbox.spy(mailjet, "sendTemplate");
+        return manager.save(testStudent).then(() => {
+            //setup mailjetStub
+            const mailjetStub = sandbox.spy(mailjet, "sendTemplate");
 
-                // Act
-                verifyToken(verificationToken).then(() => {
+            // Act
+            verifyToken(verificationToken).then(() => {
 
-                    // Assert
-                    assert.strictEqual(mailjetStub.callCount, 2);
+                // Assert
+                assert.strictEqual(mailjetStub.callCount, 2);
 
-                    const dashboardURLUUIDMatchRegex = new RegExp(
-                        /^https:\/\/my.lern-fair.de\/login\?token=[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}/i
-                    );
+                const dashboardURLUUIDMatchRegex = new RegExp(
+                    /^https:\/\/my.lern-fair.de\/login\?token=[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}/i
+                );
 
-                    assert.strictEqual(mailjetStub.getCall(0).args[0], "Lern-Fair - Dein Account");
-                    assert.strictEqual(mailjetStub.getCall(0).args[1], DEFAULTSENDERS.support);
-                    assert.strictEqual(mailjetStub.getCall(0).args[2], testStudent.email);
-                    assert.strictEqual(mailjetStub.getCall(0).args[3], 1337159);
-                    assert.strictEqual(mailjetStub.getCall(0).args[4].personFirstname, testStudent.firstname);
-                    assert.ok(dashboardURLUUIDMatchRegex.test(mailjetStub.getCall(0).args[4].dashboardURL));
-                    assert.strictEqual(mailjetStub.getCall(0).args[5], false);
+                assert.strictEqual(mailjetStub.getCall(0).args[0], "Lern-Fair - Dein Account");
+                assert.strictEqual(mailjetStub.getCall(0).args[1], DEFAULTSENDERS.support);
+                assert.strictEqual(mailjetStub.getCall(0).args[2], testStudent.email);
+                assert.strictEqual(mailjetStub.getCall(0).args[3], 1337159);
+                assert.strictEqual(mailjetStub.getCall(0).args[4].personFirstname, testStudent.firstname);
+                assert.ok(dashboardURLUUIDMatchRegex.test(mailjetStub.getCall(0).args[4].dashboardURL));
+                assert.strictEqual(mailjetStub.getCall(0).args[5], false);
 
-                    assert.strictEqual(mailjetStub.getCall(1).args[0], "Wir möchten dich kennenlernen!");
-                    assert.strictEqual(mailjetStub.getCall(1).args[1], DEFAULTSENDERS.support);
-                    assert.strictEqual(mailjetStub.getCall(1).args[2], testStudent.email);
-                    assert.strictEqual(mailjetStub.getCall(1).args[3], 1362938);
-                    assert.strictEqual(mailjetStub.getCall(1).args[4].personFirstname, testStudent.firstname);
-                    assert.strictEqual(mailjetStub.getCall(1).args[4].confirmationURL, testStudent.screeningURL());
-                    assert.strictEqual(mailjetStub.getCall(1).args[5], false);
-
-                    resolve();
-                });
+                assert.strictEqual(mailjetStub.getCall(1).args[0], "Wir möchten dich kennenlernen!");
+                assert.strictEqual(mailjetStub.getCall(1).args[1], DEFAULTSENDERS.support);
+                assert.strictEqual(mailjetStub.getCall(1).args[2], testStudent.email);
+                assert.strictEqual(mailjetStub.getCall(1).args[3], 1362938);
+                assert.strictEqual(mailjetStub.getCall(1).args[4].personFirstname, testStudent.firstname);
+                assert.strictEqual(mailjetStub.getCall(1).args[4].confirmationURL, testStudent.screeningURL());
+                assert.strictEqual(mailjetStub.getCall(1).args[5], false);
             });
         });
     });
+
 });

--- a/tests/unit/common/mails/screening/screening.test.ts
+++ b/tests/unit/common/mails/screening/screening.test.ts
@@ -12,7 +12,7 @@ describe("The screening invitation mails", function() {
         this.TestStudent.firstname = "Max";
         this.TestStudent.lastname = "Musterfrau";
         this.sendTemplateMailStub = sinon.stub(mailHandler, "sendTemplateMail").returns(
-            new Promise(resolve => {
+            new Promise<void>(resolve => {
                 resolve();
             })
         );

--- a/web/controllers/courseController/index.ts
+++ b/web/controllers/courseController/index.ts
@@ -661,7 +661,7 @@ export async function postCourseHandler(req: Request, res: Response) {
     handleError(res, async () => {
         Validation.isStudent(res);
 
-        Validation.hasBody(req, { instructors: "string[]", name: "string", outline: "string", description: "string", category: "string", tags: "string[]", submit: "boolean", allowContact: "boolean", correspondentID: "boolean?" });
+        Validation.hasBody(req, { instructors: "string[]", name: "string", outline: "string", description: "string", category: "string", tags: "string[]", submit: "boolean", allowContact: "boolean", correspondentID: "string?" });
 
         const course = await postCourse(res.locals.user, req.body);
         res.json(course);

--- a/web/controllers/courseController/index.ts
+++ b/web/controllers/courseController/index.ts
@@ -1768,7 +1768,7 @@ export async function leaveSubcourseHandler(req: Request, res: Response) {
     });
 }
 
-async function leaveSubcourse(pupil: Pupil, courseId: number, subcourseId: number, userId: string): Promise<number> {
+async function leaveSubcourse(pupil: Pupil, courseId: number, subcourseId: number, userId: string): Promise<void | never> {
     const entityManager = getManager();
     //TODO: Implement transactionLog
 
@@ -2236,7 +2236,7 @@ export async function postAddCourseInstructorHandler(req: Request, res: Response
     });
 }
 
-async function postAddCourseInstructor(student: Student, courseID: number, apiInstructorToAdd: ApiInstructorID): Promise<number> {
+async function postAddCourseInstructor(student: Student, courseID: number, apiInstructorToAdd: ApiInstructorID): Promise<void | never> {
     const entityManager = getManager();
     //TODO: Implement transactionLog
 

--- a/web/controllers/courseController/index.ts
+++ b/web/controllers/courseController/index.ts
@@ -978,12 +978,7 @@ export async function putCourseHandler(req: Request, res: Response) {
         Validation.isStudent(res);
 
         Validation.hasParams(req, "id");
-        Validation.hasBody(req, { instructors: "string[]", description: "string", allowedContact: "boolean", name: "string?", outline: "string?", correspondentID: "string?", tags: "string[]" });
-        if (
-            (req.body.outline !== undefined && typeof req.body.category !== 'string') ||
-            (req.body.outline !== undefined && typeof req.body.submit !== 'boolean')) {
-            throw new HTTPError(400, "Invalid request for PUT /course");
-        }
+        Validation.hasBody(req, { instructors: "string[]", description: "string", allowedContact: "boolean", name: "string?", outline: "string?", correspondentID: "string?", tags: "string[]", category: "string?", submit: "boolean?" });
 
         await putCourse(res.locals.user, Number.parseInt(req.params.id, 10), req.body);
 

--- a/web/controllers/error.ts
+++ b/web/controllers/error.ts
@@ -1,0 +1,27 @@
+import { getLogger } from 'log4js';
+import { Request, Response } from 'express';
+
+const logger = getLogger();
+
+/* Throw somewhere inside handleError to abort the request and respond with an error code
+   WARN: Be careful what you put into message, this is sent to the client. innerError stays private */
+export class HTTPError extends Error {
+    constructor(public code: number, message: string, public innerError?: Error) {
+        super(message);
+    }
+}
+
+/* Wrap an API endpoint into this to handle all HTTPErrors and uncatched errors gracefully and consistently */
+export async function handleError(res: Response, handler: () => Promise<void | never>) {
+    try {
+        await handler();
+    } catch (error) {
+        if (error instanceof HTTPError) {
+            logger.warn(error.message, error.innerError);
+            return res.status(error.code).send(error.message);
+        } else {
+            logger.error(error);
+            return res.status(500).send("Internal Server error");
+        }
+    }
+}

--- a/web/controllers/validation.ts
+++ b/web/controllers/validation.ts
@@ -8,6 +8,11 @@ export function isStudent(res: Response): void | never {
         throw new HTTPError(403, "This endpoint can only be acessed by Students");
 }
 
+export function isPupil(res: Response): void | never {
+    if (!(res.locals.user instanceof Student))
+        throw new HTTPError(403, "This endpoint can only be acessed by Pupils");
+}
+
 // ATTENTION: This is asynchronous, don't forget to await!
 export async function isAcceptedInstructor(student: Student): Promise<void | never> {
     if (!student.isInstructor || await student.instructorScreeningStatus() != ScreeningStatus.Accepted) {

--- a/web/controllers/validation.ts
+++ b/web/controllers/validation.ts
@@ -7,12 +7,12 @@ import { Course } from "../../common/entity/Course";
 
 export function isStudent(res: Response): void | never {
     if (!(res.locals.user instanceof Student))
-        throw new HTTPError(403, "This endpoint can only be acessed by Students");
+        throw new HTTPError(403, "This endpoint can only be accessed by Students");
 }
 
 export function isPupil(res: Response): void | never {
     if (!(res.locals.user instanceof Student))
-        throw new HTTPError(403, "This endpoint can only be acessed by Pupils");
+        throw new HTTPError(403, "This endpoint can only be accessed by Pupils");
 }
 
 // ATTENTION: This is asynchronous, don't forget to await!
@@ -36,8 +36,8 @@ export function isInstructorOf(student: Student, course: Course) {
 
 export function hasParams(req: Request, ...params: string[]): void | never {
     for (const param of params) {
-        if (!(param in req.params) || ! req.params[param]) {
-            throw new HTTPError(400, `Missing parameter '${param}' in path`);
+        if (!(param in req.params) || !req.params[param] || Number.isNaN(Number.parseInt(req.params[param], 10))) {
+            throw new HTTPError(400, `Missing integer parameter '${param}' in path`);
         }
     }
 }

--- a/web/controllers/validation.ts
+++ b/web/controllers/validation.ts
@@ -74,7 +74,7 @@ export function isInIntegerRange<K extends string>(value: { [k in K]: number }, 
         throw new HTTPError(400, `Expected '${key}' to be an integer was ${value[key]} instead`);
 
     if (value[key] < minInclusive || maxInclusive < value[key])
-        throw new HTTPError(400, `Expected '${key}' to be inbetween ${min} and ${max}, was outside with ${value[key]}`);
+        throw new HTTPError(400, `Expected '${key}' to be inbetween ${minInclusive} and ${maxInclusive}, was outside with ${value[key]}`);
 }
 
 export function hasLength<K extends string>(value: { [k in K]?: string }, key: K, minInclusive: number, maxInclusive: number) {

--- a/web/controllers/validation.ts
+++ b/web/controllers/validation.ts
@@ -36,7 +36,7 @@ export function isInstructorOf(student: Student, course: Course) {
 
 export function hasParams(req: Request, ...params: string[]): void | never {
     for (const param of params) {
-        if (!(param in req.params)) {
+        if (!(param in req.params) || ! req.params[param]) {
             throw new HTTPError(400, `Missing parameter '${param}' in path`);
         }
     }

--- a/web/controllers/validation.ts
+++ b/web/controllers/validation.ts
@@ -1,0 +1,84 @@
+import { HTTPError } from "./error";
+import { Request, Response } from "express";
+import { ScreeningStatus, Student } from "../../common/entity/Student";
+import { Course } from "../../common/entity/Course";
+
+export function isStudent(res: Response): void | never {
+    if (!(res.locals.user instanceof Student))
+        throw new HTTPError(403, "This endpoint can only be acessed by Students");
+}
+
+// ATTENTION: This is asynchronous, don't forget to await!
+export async function isAcceptedInstructor(student: Student): Promise<void | never> {
+    if (!student.isInstructor || await student.instructorScreeningStatus() != ScreeningStatus.Accepted) {
+        throw new HTTPError(403, `Student (ID ${student.id}) tried to add a lecture, but is no instructor.`);
+    }
+}
+
+export async function isInstructorOf(student: Student, course: Course) {
+    const authorized = course.instructors.some(it => it.id === student.id);
+
+    if (!authorized) {
+        throw new HTTPError(403, `User tried to edit lecture, but has no access rights (ID ${course.id})`);
+    }
+}
+
+export function hasParams(req: Request, ...params: string[]): void | never {
+    for (const param of params) {
+        if (!(param in req.params)) {
+            throw new HTTPError(400, `Missing parameter '${param}' in path`);
+        }
+    }
+}
+
+type BasicType = "string" | "boolean" | "number";
+
+interface TypeMap {
+    [key: string]: BasicType | `${BasicType}[]` | `${BasicType}?`;
+}
+
+export function hasBody(req: Request, body: TypeMap): void | never {
+    for (const [key, type] of Object.entries(body)) {
+        if (type.endsWith("[]")) {
+            const innerType = { "string[]": "string", "number[]": "number", "boolean[]": "boolean" }[type];
+
+            if (!(key in req.body))
+                throw new HTTPError(400, `'${key}' is missing in the request body`);
+
+            const value = req.body[key];
+
+            if (!Array.isArray(value))
+                throw new HTTPError(400, `Expected '${key}' to be an array, found ${typeof value} instead`);
+
+            if (value.some(it => typeof it !== innerType))
+                throw new HTTPError(400, `Expected elements of '${key}' to be of type ${innerType}, found something else instead`);
+        } else if (type.endsWith("?")) {
+            const innerType = { "boolean?": "boolean", "string?": "string", "number?": "number" }[type];
+
+            if (key in req.body && typeof req.body[key] !== innerType)
+                throw new HTTPError(400, `optional '${key}' in request body has invalid type ${typeof req.body[key]}, expected ${innerType}`);
+
+        } else if (typeof req.body[key] !== type) {
+            throw new HTTPError(400, `'${key}' in request body has invalid type ${typeof req.body[key]}, expected ${type}`);
+        }
+    }
+}
+
+export function isInIntegerRange<K extends string>(value: { [k in K]: number }, key: K, minInclusive: number, maxInclusive: number) {
+    if (!Number.isInteger(value[key]))
+        throw new HTTPError(400, `Expected '${key}' to be an integer was ${value[key]} instead`);
+
+    if (value[key] < minInclusive || maxInclusive < value[key])
+        throw new HTTPError(400, `Expected '${key}' to be inbetween ${min} and ${max}, was outside with ${value[key]}`);
+}
+
+export function hasLength<K extends string>(value: { [k in K]?: string }, key: K, minInclusive: number, maxInclusive: number) {
+    if (!(key in value))
+        throw new HTTPError(400, `'${key}' is missing in the request body`);
+
+    if (typeof value[key] !== "string")
+        throw new HTTPError(400, `Expected '${key}' to be a string, found a ${typeof value[key]}  instead`);
+
+    if (value[key].length < minInclusive || value[key].length > maxInclusive)
+        throw new HTTPError(400, `'${key}' must be longer than ${minInclusive} and shorter than ${maxInclusive}. Instead it hat ${value[key].length} chars`);
+}

--- a/web/controllers/validation.ts
+++ b/web/controllers/validation.ts
@@ -69,8 +69,12 @@ export function hasBody(req: Request, body: TypeMap): void | never {
             if (key in req.body && typeof req.body[key] !== innerType)
                 throw new HTTPError(400, `optional '${key}' in request body has invalid type ${typeof req.body[key]}, expected ${innerType}`);
 
-        } else if (typeof req.body[key] !== type) {
-            throw new HTTPError(400, `'${key}' in request body has invalid type ${typeof req.body[key]}, expected ${type}`);
+        } else {
+            if (!(key in req.body))
+                throw new HTTPError(400, `'${key}' is missing in the request body`);
+
+            if (typeof req.body[key] !== type)
+                throw new HTTPError(400, `'${key}' in request body has invalid type ${typeof req.body[key]}, expected ${type}`);
         }
     }
 }

--- a/web/controllers/validation.ts
+++ b/web/controllers/validation.ts
@@ -3,6 +3,8 @@ import { Request, Response } from "express";
 import { ScreeningStatus, Student } from "../../common/entity/Student";
 import { Course } from "../../common/entity/Course";
 
+/* ----------- User Validation ---------------------------------------------------------------------------- */
+
 export function isStudent(res: Response): void | never {
     if (!(res.locals.user instanceof Student))
         throw new HTTPError(403, "This endpoint can only be acessed by Students");
@@ -20,13 +22,17 @@ export async function isAcceptedInstructor(student: Student): Promise<void | nev
     }
 }
 
-export async function isInstructorOf(student: Student, course: Course) {
+export function isInstructorOf(student: Student, course: Course) {
     const authorized = course.instructors.some(it => it.id === student.id);
 
     if (!authorized) {
         throw new HTTPError(403, `User tried to edit lecture, but has no access rights (ID ${course.id})`);
     }
 }
+
+
+
+/* ----------- Request Validation ---------------------------------------------------------------------------- */
 
 export function hasParams(req: Request, ...params: string[]): void | never {
     for (const param of params) {


### PR DESCRIPTION
While looking for whatever keeps the backend crashing, I came across the beautiful course controller and had the urgent need to start refactoring it ... Do whatever you like with this PR (once it's ready)

What I did:
- Removed unnecessary index based loops and replaced them with for...of loops
- Unnested nested if..elses 
- Moved Validation of parameters and body into a reusable function
- Removed all "returns an error code as number or the result" and replaced with a thrown HTTPError or returned result
- Updated Typescript to be able to use string template types

This reduced the file size of the course controller by ~30%.

What I did not (but noticed):
- Inside the transactions a lot of logic gets processed. If a lot of users join the same course, this will lead to rollback / retries, which means that all the queries will potentially happen multiple times. This seems very inefficient. Locking per user / lecture on serverside should be sufficient instead
- The retrieval of Courses / Subcourses / Lectures could be moved into reusable functions
- The validation of entities could be moved into the entity (or directly use a framework that embeds it, e.g. some GraphQL stuff), just like most of the logic, only keeping input validation / authorization in the endpoint itself
