### PR TITLE
Allow deactivation reason and feedback

### DIFF
--- a/common/transactionlog/types/DeActivateEvent.ts
+++ b/common/transactionlog/types/DeActivateEvent.ts
@@ -4,9 +4,11 @@ import { Student } from "../../entity/Student";
 import { Pupil } from "../../entity/Pupil";
 
 export default class DeActivateEvent extends LogUserEvent {
-    constructor(user: Pupil | Student, newActiveStatus: boolean) {
+    constructor(user: Pupil | Student, newActiveStatus: boolean, deactivationReason?: string, deactivationFeedback?: string) {
         super(LogType.DEACTIVATE, user, {
-            newStatus: newActiveStatus
+            newStatus: newActiveStatus,
+            deactivationReason,
+            deactivationFeedback
         });
     }
 }

--- a/web/controllers/userController/index.ts
+++ b/web/controllers/userController/index.ts
@@ -1007,7 +1007,6 @@ async function putActive(wix_id: string, active: boolean, person: Pupil | Studen
             person.active = false;
 
             await entityManager.save(type, person);
-            console.log(new DeActivateEvent(person, false, deactivationReason, deactivationFeedback));
             await transactionLog.log(new DeActivateEvent(person, false, deactivationReason, deactivationFeedback));
         }
     } catch (e) {

--- a/web/controllers/userController/index.ts
+++ b/web/controllers/userController/index.ts
@@ -415,7 +415,9 @@ export async function putActiveHandler(req: Request, res: Response) {
                     status = await putActive(
                         req.params.id,
                         active,
-                        res.locals.user
+                        res.locals.user,
+                        req.body.deactivationReason,
+                        req.body.deactivationFeedback
                     );
                 }
             } catch (e) {
@@ -947,7 +949,7 @@ async function putProjectFields(wix_id: string, req: ApiProjectFieldInfo[], pers
     return 204;
 }
 
-async function putActive(wix_id: string, active: boolean, person: Pupil | Student): Promise<number> {
+async function putActive(wix_id: string, active: boolean, person: Pupil | Student, deactivationReason?: string, deactivationFeedback?: string): Promise<number> {
     const entityManager = getManager();
     const transactionLog = getTransactionLog();
 
@@ -1005,7 +1007,8 @@ async function putActive(wix_id: string, active: boolean, person: Pupil | Studen
             person.active = false;
 
             await entityManager.save(type, person);
-            await transactionLog.log(new DeActivateEvent(person, false));
+            console.log(new DeActivateEvent(person, false, deactivationReason, deactivationFeedback));
+            await transactionLog.log(new DeActivateEvent(person, false, deactivationReason, deactivationFeedback));
         }
     } catch (e) {
         logger.error("Can't " + (active ? "" : "de") + "activate user: " + e.message);


### PR DESCRIPTION
With this change, the frontend can provide a deactivation reason as well as additional feedback when the user decides to deactivate their account.
The additional information then gets written to the transaction log as part of the DeActivateEvent.

See https://github.com/corona-school/project-user/issues/302 for more details.