### PR TITLE
Move config variable from NODE_ENV to ENV

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@ MAILJET_PASSWORD=
 MAILJET_LIVE=0
 
 # Run webserver in dev mode on port 5000 (http only)
-NODE_ENV=dev
+ENV=dev
 
 # The auth token for screeners
 SCREENER_AUTH_TOKEN=

--- a/app.json
+++ b/app.json
@@ -22,7 +22,8 @@
     "environments": {
         "review": {
             "env": {
-                "NODE_ENV": "dev",
+                "NODE_ENV": "production",
+                "ENV": "dev",
                 "MAILJET_LIVE": "0"
             },
             "addons": [

--- a/common/courses/certificates.ts
+++ b/common/courses/certificates.ts
@@ -36,7 +36,7 @@ export async function getCourseCertificate(studentUUID: string, pupilUUID: strin
         moment: moment
     });
 
-    const includePaths = process.env.NODE_ENV === 'dev' ? [] : [resolvePath(TEMPLATE_ASSETS_FOLDER)]; //only include assets in production
+    const includePaths = process.env.ENV === 'dev' ? [] : [resolvePath(TEMPLATE_ASSETS_FOLDER)]; //only include assets in production
 
     const buffer = await generatePDFFromHTMLString(htmlString, {
         includePaths

--- a/common/prisma/index.ts
+++ b/common/prisma/index.ts
@@ -4,7 +4,7 @@ import { PrismaClient } from "@prisma/client";
    which is the SQL query sent to the database.
    Through that, queries can be optimized for performance */
 export const prisma = new PrismaClient(
-    process.env.NODE_ENV === "production"
+    process.env.ENV === "production"
         ? undefined
         : { log: ['query', 'info', `warn`, `error`] }
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -2143,7 +2143,6 @@
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-      "dev": true,
       "requires": {
         "object-assign": "^4",
         "vary": "^1"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "db:migration:revert": "npm run typeorm -- migration:revert",
     "db:migration:show": "npm run typeorm -- migration:show",
     "linter": "eslint . --ext .ts",
-    "heroku:release": "if [ \"$NODE_ENV\" = 'production' ]; then npx typeorm migration:run; else echo 'Will only run migration in production...'; fi"
+    "heroku:release": "if [ \"$ENV\" = 'production' ]; then npx typeorm migration:run; else echo 'Will only run migration in production...'; fi"
   },
   "dependencies": {
     "@prisma/client": "^2.26.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "unique-names-generator": "^4.3.1",
     "uuid": "^7.0.3",
     "validator": "^13.5.2",
-    "xml2js": "^0.4.23"
+    "xml2js": "^0.4.23",
+    "cors": "^2.8.5"
   },
   "devDependencies": {
     "typescript": "^4.3.4",
@@ -91,7 +92,6 @@
     "@typescript-eslint/parser": "^3.3.0",
     "apidoc": "^0.22.1",
     "chai": "^4.2.0",
-    "cors": "^2.8.5",
     "eslint": "^7.2.0",
     "faker": "^5.4.0",
     "mocha": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "class-transformer": "^0.4.0",
     "class-validator": "^0.13.1",
     "corona-school-matching": "^1.0.1",
+    "cors": "^2.8.5",
     "cron": "^1.8.2",
     "csv-writer": "^1.6.0",
     "date-holidays": "^1.5.3",
@@ -53,7 +54,7 @@
     "hpp": "^0.2.3",
     "html-pppdf": "^1.0.1",
     "lodash": "^4.17.19",
-    "log4js": "latest",
+    "log4js": "^6.3.0",
     "mime-types": "^2.1.28",
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.31",
@@ -67,8 +68,7 @@
     "unique-names-generator": "^4.3.1",
     "uuid": "^7.0.3",
     "validator": "^13.5.2",
-    "xml2js": "^0.4.23",
-    "cors": "^2.8.5"
+    "xml2js": "^0.4.23"
   },
   "devDependencies": {
     "typescript": "^4.3.4",

--- a/web/controllers/certificateController/index.ts
+++ b/web/controllers/certificateController/index.ts
@@ -516,7 +516,7 @@ async function createPDFBinary(certificate: ParticipationCertificate, link: stri
 
     let name = student.firstname + " " + student.lastname;
 
-    if (process.env.NODE_ENV == 'dev') {
+    if (process.env.ENV == 'dev') {
         name = `[TEST] ${name}`;
     }
 

--- a/web/controllers/notificationController/index.ts
+++ b/web/controllers/notificationController/index.ts
@@ -5,7 +5,7 @@ export const notificationRoute = Express.Router();
 
 /* Internal API endpoint for debugging / manual testing purposes */
 export async function triggerActionHandler(req: Express.Request, res: Express.Response) {
-    if (process.env.NODE_ENV !== "dev") {
+    if (process.env.ENV !== "dev") {
         return res.status(404).send("This endpoint is only accessible in development environments");
     }
 
@@ -26,7 +26,7 @@ export async function triggerActionHandler(req: Express.Request, res: Express.Re
 
 /* Internal API endpoint for debugging / manual testing purposes */
 export async function checkReminders(req: Express.Request, res: Express.Response) {
-    if (process.env.NODE_ENV !== "dev") {
+    if (process.env.ENV !== "dev") {
         return res.status(404).send("This endpoint is only accessible in development environments");
     }
 

--- a/web/index.ts
+++ b/web/index.ts
@@ -93,7 +93,7 @@ createConnection().then(setupPDFGenerationEnvironment)
                 "partnerschule",
                 "drehtuer"
             ];
-            if (process.env.NODE_ENV == "dev") {
+            if (process.env.ENV == "dev") {
                 origins = [
                     "http://localhost:3000",
                     ...allowedSubdomains.map(d => `http://${d}.localhost:3000`),
@@ -352,7 +352,7 @@ createConnection().then(setupPDFGenerationEnvironment)
         }
 
         async function deployServer() {
-            const isDev = process.env.NODE_ENV === "dev";
+            const isDev = process.env.ENV === "dev";
             const port = process.env.PORT || 5000;
             if (isDev) {
                 await setupDevDB();


### PR DESCRIPTION
This way NODE_ENV can be set to production by default (which causes Heroku to drop dev dependencies during build, reducing the slug size to about 400MB, which is 100MB away from the hard limit which we currently run into)