### PR TITLE
Create MatchDissolveReasons.md

### DIFF
--- a/common/match/MatchDissolveReasons.md
+++ b/common/match/MatchDissolveReasons.md
@@ -1,0 +1,19 @@
+# Match dissolve reasons
+
+These are the match dissolve reasons broken down by their number. These numbers are e.g. used in the transaction log. 
+
+Student POV:
+
+1. Match partner didn't get back to me
+2. Match partner doesn't need support anymore
+3. Wasn't able to support match partner
+4. Insufficient time to support match partner
+5. Personal difficulties
+6. Wasn't able to find mutual dates
+7. Technical difficulties
+8. Miscellaneous/other
+9. Language difficulties
+10. Match partner had criminal record and their account got deactivated*
+
+
+*) this is not a choice in the cancel dialog on the frontend.


### PR DESCRIPTION
I created this readme to keep track of all match dissolve reasons. 
I think it'd be good if we had a central place where these are documented, as e.g. the [criminal record reason](https://github.com/corona-school/project-user/issues/382) won't be selectable from the frontend and is only set when the backend finds a user violating the criminal record policy.