### PR TITLE
Add notification import and update, improve logging

### DIFF
--- a/common/notification/notification.ts
+++ b/common/notification/notification.ts
@@ -141,7 +141,7 @@ export async function importNotifications(notifications: Notification[], overwri
                 const removed = await prisma.notification.deleteMany({ });
                 log += `Through Overwrite ${removed.count} existing Notifications were removed`;
             }
-            const untouched = await prisma.notification.findMany({
+            const untouched = await prisma.notification.count({
                 where: { id: { notIn: notifications.map(it => it.id) } }
             });
 

--- a/common/notification/notification.ts
+++ b/common/notification/notification.ts
@@ -175,20 +175,15 @@ export async function importNotifications(notifications: Notification[], overwri
                         log += `Activated Notification(${notification.id})\n`;
                     }
                 } else {
-                    const { id, ...creation } = notification;
                     const result = await prisma.notification.create({
-                        data: creation
+                        data: notification
                     });
 
                     log += `Created Notification(${notification.id})\n`;
-                    log += diff({}, creation, 1);
+                    log += diff({}, notification, 1);
 
-                    if (creation.active) {
+                    if (notification.active) {
                         log += `Activated Notification(${notification.id})\n`;
-                    }
-
-                    if (result.id !== id) {
-                        log += `Imported Notification(${id}) was created as Notification(${result.id}), please ensure parity between QA and PROD!\n`;
                     }
                 }
             }

--- a/common/notification/notification.ts
+++ b/common/notification/notification.ts
@@ -198,4 +198,6 @@ function diff(prev: any, curr: any, depth = 0) {
             result += " ".repeat(depth * 2) + `+ ${key}: ${curr[key]}\n`;
         }
     }
+
+    return result;
 }

--- a/common/notification/notification.ts
+++ b/common/notification/notification.ts
@@ -139,7 +139,7 @@ export async function importNotifications(notifications: Notification[], overwri
         await prisma.$transaction(async (prisma) => {
             if (overwrite) {
                 const removed = await prisma.notification.deleteMany({ });
-                log += `Through Overwrite ${removed.count} existing Notifications were removed`;
+                log += `Through Overwrite ${removed.count} existing Notifications were removed\n`;
             }
             const untouched = await prisma.notification.count({
                 where: { id: { notIn: notifications.map(it => it.id) } }

--- a/graphql/notification/mutations.ts
+++ b/graphql/notification/mutations.ts
@@ -9,7 +9,7 @@ class NotificationInput { // Notification Model as Input type, see https://githu
   @Field(_type => Int, { nullable: false })
   id!: number;
   @Field(_type => Int, { nullable: false })
-  mailjetTemplateId?: number;
+  mailjetTemplateId: number;
   @Field(_type => String, { nullable: false })
   description!: string;
   @Field(_type => Boolean, { nullable: false })
@@ -23,9 +23,9 @@ class NotificationInput { // Notification Model as Input type, see https://githu
   @Field(_type => [String], { nullable: false })
   cancelledOnAction!: string[];
   @Field(_type => Int, { nullable: true })
-  delay?: number | null;
+  delay: number | null;
   @Field(_type => Int, { nullable: true })
-  interval?: number | null;
+  interval: number | null;
 }
 @Resolver(of => GraphQLModel.Notification)
 export class MutateNotificationResolver {
@@ -57,7 +57,7 @@ export class MutateNotificationResolver {
 
     @Mutation(returns => String)
     @Authorized(Role.ADMIN)
-    async notificationImport(@Arg("notifications", type => [NotificationInput]) notifications: NotificationInput[], @Arg("force", { nullable: true }) force: boolean = false) {
-        return await Notification.importNotifications(notifications, force);
+    async notificationImport(@Arg("notifications", type => [NotificationInput]) notifications: NotificationInput[], @Arg("overwrite", { nullable: true }) overwrite: boolean = false, @Arg("apply", { nullable: true }) apply: boolean = false) {
+        return await Notification.importNotifications(notifications, overwrite, apply);
     }
 }

--- a/graphql/notification/mutations.ts
+++ b/graphql/notification/mutations.ts
@@ -1,11 +1,14 @@
-import { Resolver, Mutation, Root, Arg, Authorized, InputType } from "type-graphql";
+import { Resolver, Mutation, Root, Arg, Authorized, InputType, Field, Int } from "type-graphql";
 import * as GraphQLModel from "../generated/models";
 import { Role } from "../authorizations";
 import * as Notification from "../../common/notification/notification";
 import { NotificationCreateInput, NotificationUpdateInput } from "../generated";
 
 @InputType()
-class NotificationInput extends GraphQLModel.Notification {}
+class NotificationInput extends NotificationCreateInput {
+    @Field(type => Int)
+    id: number;
+}
 @Resolver(of => GraphQLModel.Notification)
 export class MutateNotificationResolver {
 

--- a/graphql/notification/mutations.ts
+++ b/graphql/notification/mutations.ts
@@ -36,7 +36,7 @@ export class MutateNotificationResolver {
 
     @Mutation(returns => String)
     @Authorized(Role.ADMIN)
-    async notificationImport(@Arg("notifications") notifications: NotificationInput[], @Arg("force", { nullable: true }) force: boolean = false) {
+    async notificationImport(@Arg("notifications", type => [NotificationInput]) notifications: NotificationInput[], @Arg("force", { nullable: true }) force: boolean = false) {
         for (const notification of notifications) {
             if (!notification.mailjetTemplateId) {
                 throw new Error("Mailjet Template ID is required");

--- a/graphql/notification/mutations.ts
+++ b/graphql/notification/mutations.ts
@@ -5,9 +5,27 @@ import * as Notification from "../../common/notification/notification";
 import { NotificationCreateInput, NotificationUpdateInput } from "../generated";
 
 @InputType()
-class NotificationInput extends GraphQLModel.Notification {
-    @Field(type => Int)
-    id: number;
+class NotificationInput { // Notification Model as Input type, see https://github.com/MichalLytek/type-graphql/issues/62
+  @Field(_type => Int, { nullable: false })
+  id!: number;
+  @Field(_type => Int, { nullable: true })
+  mailjetTemplateId?: number | null;
+  @Field(_type => String, { nullable: false })
+  description!: string;
+  @Field(_type => Boolean, { nullable: false })
+  active!: boolean;
+  @Field(_type => Int, { nullable: false })
+  recipient!: number;
+  @Field(_type => [String], { nullable: false })
+  onActions!: string[];
+  @Field(_type => [String], { nullable: false })
+  category!: string[];
+  @Field(_type => [String], { nullable: false })
+  cancelledOnAction!: string[];
+  @Field(_type => Int, { nullable: true })
+  delay?: number | null;
+  @Field(_type => Int, { nullable: true })
+  interval?: number | null;
 }
 @Resolver(of => GraphQLModel.Notification)
 export class MutateNotificationResolver {

--- a/graphql/notification/mutations.ts
+++ b/graphql/notification/mutations.ts
@@ -5,7 +5,7 @@ import * as Notification from "../../common/notification/notification";
 import { NotificationCreateInput, NotificationUpdateInput } from "../generated";
 
 @InputType()
-class NotificationInput extends NotificationCreateInput {
+class NotificationInput extends GraphQLModel.Notification {
     @Field(type => Int)
     id: number;
 }

--- a/graphql/notification/mutations.ts
+++ b/graphql/notification/mutations.ts
@@ -31,6 +31,7 @@ export class MutateNotificationResolver {
         }
 
         await Notification.update(notificationId, update as any);
+        return true;
     }
 
     @Mutation(returns => String)

--- a/graphql/notification/mutations.ts
+++ b/graphql/notification/mutations.ts
@@ -8,8 +8,8 @@ import { NotificationCreateInput, NotificationUpdateInput } from "../generated";
 class NotificationInput { // Notification Model as Input type, see https://github.com/MichalLytek/type-graphql/issues/62
   @Field(_type => Int, { nullable: false })
   id!: number;
-  @Field(_type => Int, { nullable: true })
-  mailjetTemplateId?: number | null;
+  @Field(_type => Int, { nullable: false })
+  mailjetTemplateId?: number;
   @Field(_type => String, { nullable: false })
   description!: string;
   @Field(_type => Boolean, { nullable: false })
@@ -58,12 +58,6 @@ export class MutateNotificationResolver {
     @Mutation(returns => String)
     @Authorized(Role.ADMIN)
     async notificationImport(@Arg("notifications", type => [NotificationInput]) notifications: NotificationInput[], @Arg("force", { nullable: true }) force: boolean = false) {
-        for (const notification of notifications) {
-            if (!notification.mailjetTemplateId) {
-                throw new Error("Mailjet Template ID is required");
-            }
-        }
-
-        return await Notification.importNotifications(notifications as any, force);
+        return await Notification.importNotifications(notifications, force);
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -751,11 +751,11 @@
       }
     },
     "@prisma/client": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-2.26.0.tgz",
-      "integrity": "sha512-iwhjdUV/MEQZ7RzTEcZ/D+ewxx/pGExWJ2LypfHioJIvEMyK0saPiR0tjMvMT2I2SVzrIM5dXGhBHWi2JksWrQ==",
+      "version": "2.30.3",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-2.30.3.tgz",
+      "integrity": "sha512-Ey2miZ+Hne12We3rA8XrlPoAF0iuKEhw5IK2nropaelSt0Ju3b2qSz9Qt50a/1Mx3+7yRSu/iSXt8y9TUMl/Yw==",
       "requires": {
-        "@prisma/engines-version": "2.26.0-23.9b816b3aa13cc270074f172f30d6eda8a8ce867d"
+        "@prisma/engines-version": "2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20"
       }
     },
     "@prisma/debug": {
@@ -877,9 +877,9 @@
       "dev": true
     },
     "@prisma/engines-version": {
-      "version": "2.26.0-23.9b816b3aa13cc270074f172f30d6eda8a8ce867d",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-2.26.0-23.9b816b3aa13cc270074f172f30d6eda8a8ce867d.tgz",
-      "integrity": "sha512-8tygPkPxag3myF5fgNQ60zwnNSZzFf4J+DXGKykXaBLLt9W2FLkaE5sVL8/OqAGhLAnVsKj83CqPms35bKrTKw=="
+      "version": "2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20.tgz",
+      "integrity": "sha512-/iDRgaoSQC77WN2oDsOM8dn61fykm6tnZUAClY+6p+XJbOEgZ9gy4CKuKTBgrjSGDVjtQ/S2KGcYd3Ring8xaw=="
     },
     "@prisma/fetch-engine": {
       "version": "2.26.0",
@@ -8050,12 +8050,20 @@
       "dev": true
     },
     "prisma": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-2.26.0.tgz",
-      "integrity": "sha512-MXTQlF8X9mabkdTRb9x5nF6jvo1kT85d9hqIpYjLLZy+5tlvEaCaLBj+ok8GINdfYBS7gwQERZ9MHx0tb5dCdg==",
+      "version": "2.30.3",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-2.30.3.tgz",
+      "integrity": "sha512-48qYba2BIyUmXuosBZs0g3kYGrxKvo4VkSHYOuLlDdDirmKyvoY2hCYMUYHSx3f++8ovfgs+MX5KmNlP+iAZrQ==",
       "dev": true,
       "requires": {
-        "@prisma/engines": "2.26.0-23.9b816b3aa13cc270074f172f30d6eda8a8ce867d"
+        "@prisma/engines": "2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20"
+      },
+      "dependencies": {
+        "@prisma/engines": {
+          "version": "2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20",
+          "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-2.30.1-2.b8c35d44de987a9691890b3ddf3e2e7effb9bf20.tgz",
+          "integrity": "sha512-WPnA/IUrxDihrRhdP6+8KAVSwsc0zsh8ioPYsLJjOhzVhwpRbuFH2tJDRIAbc+qFh+BbTIZbeyBYt8fpNXaYQQ==",
+          "dev": true
+        }
       }
     },
     "process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "heroku:release": "if [ \"$ENV\" = 'production' ]; then npx typeorm migration:run; else echo 'Will only run migration in production...'; fi"
   },
   "dependencies": {
-    "@prisma/client": "^2.26.0",
+    "@prisma/client": "^2.30.3",
     "address-rfc2821": "^1.1.3",
     "apollo-server-express": "^2.25.1",
     "apollo-server-plugin-base": "^3.0.1",
@@ -104,16 +104,16 @@
     "apidoc": "^0.22.1",
     "chai": "^4.2.0",
     "eslint": "^7.2.0",
+    "eslint-plugin-lernfair-lint": "./linter/",
     "faker": "^5.4.0",
     "mocha": "^8.0.1",
     "nyc": "^15.1.0",
-    "prisma": "^2.26.0",
+    "prisma": "^2.30.3",
     "sinon": "^9.0.2",
     "tape": "^4.7.0",
     "ts-node": "^8.10.1",
     "typegraphql-prisma": "^0.14.6",
-    "typescript": "^4.3.5",
-    "eslint-plugin-lernfair-lint": "./linter/"
+    "typescript": "^4.3.5"
   },
   "repository": {
     "type": "git",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
   provider = "prisma-client-js"
+  previewFeatures = ["interactiveTransactions"]
 }
 
 // generator typegraphql {

--- a/web/dev.ts
+++ b/web/dev.ts
@@ -1344,61 +1344,6 @@ export async function setupDevDB() {
         await entityManager.save(pticrs[i]);
         console.log("Inserted Pupil Tutoring Interest Request " + i);
     }
-
-    /* NOTIFICATION SYSTEM */
-
-    await prisma.notification.createMany({
-        data: [
-            {
-                mailjetTemplateId: 3026265, /* notification_system_test */
-                active: true,
-                description: 'TEST: Instant notification on registration',
-                recipient: NotificationRecipient.USER,
-                cancelledOnAction: [],
-                category: [],
-                onActions: ["test_start"]
-            },
-            {
-                active: false,
-                description: 'TEST: Disabled notification - If you see this, something is wrong',
-                recipient: NotificationRecipient.USER,
-                cancelledOnAction: [],
-                category: [],
-                onActions: ["test_start"]
-            },
-            {
-                mailjetTemplateId: 3026840, /* notification_system_test_reminder */
-                active: true,
-                description: 'TEST: One Minute delayed notification on registration',
-                recipient: NotificationRecipient.USER,
-                cancelledOnAction: ["test_cancel"],
-                category: [],
-                onActions: ["test_start"],
-                delay: 60_000 /*ms*/,
-            },
-            {
-                active: false,
-                description: 'TEST: Delayed disabled notification - If you see this, something is wrong',
-                recipient: NotificationRecipient.USER,
-                cancelledOnAction: ["test_cancel"],
-                category: [],
-                onActions: ["test_start"],
-                delay: 60_000 /*ms*/,
-            },
-            {
-                mailjetTemplateId: 3026840, /* notification_system_test_reminder */
-                active: true,
-                description: 'TEST: One Minute delayed notification on registration, repeated',
-                recipient: NotificationRecipient.USER,
-                cancelledOnAction: ["test_cancel"],
-                category: [],
-                onActions: ["test_start"],
-                delay: 60_000 /*ms*/,
-                interval: 60_000 /*ms*/
-            },
-
-        ]
-    });
 }
 
 function sha512(input: string): string {


### PR DESCRIPTION
Apart from improved logging, this provides means to import notifications into a system. Through that we can easily replicate the Notification configuration from QA and PROD and  vice versa. Through a "dry run", we can check whether the configuration can be applied and what it does. This way we can add such functionality to Retool and let content admins manage those (less work for the Tech Team). 

In theory we could also replicate the PROD configuration every time the QA environment is rebuilt