### PR TITLE
Mutations and Resolvers for Interest Confirmation

### DIFF
--- a/graphql/index.ts
+++ b/graphql/index.ts
@@ -16,6 +16,7 @@ import { ExtendedFieldsProjectMatchResolver } from "./project_match/fields";
 import { MutateNotificationResolver } from "./notification/mutations";
 import { complexityEnhanceMap } from "./complexity";
 import { MutateMatchResolver } from "./match/mutations";
+import { MutateTutoringInterestConfirmationResolver } from "./tutoring_interest_confirmation/mutations";
 
 applyResolversEnhanceMap(authorizationEnhanceMap);
 applyResolversEnhanceMap(complexityEnhanceMap);
@@ -48,7 +49,10 @@ const schema = buildSchemaSync({
         /* Notifications */
         FindManyNotificationResolver,
         MutateNotificationResolver,
-        FindManyConcrete_notificationResolver
+        FindManyConcrete_notificationResolver,
+
+        /* TutoringInterestConfirmation */
+        MutateTutoringInterestConfirmationResolver
     ],
     authChecker
 });

--- a/graphql/pupil/fields.ts
+++ b/graphql/pupil/fields.ts
@@ -67,6 +67,6 @@ export class ExtendFieldsPupilResolver {
     async tutoringInterestConfirmation(@Root() pupil: Required<Pupil>) {
         return await prisma.pupil_tutoring_interest_confirmation_request.findFirst({
             where: { pupilId: pupil.id }
-        })
+        });
     }
 }

--- a/graphql/pupil/fields.ts
+++ b/graphql/pupil/fields.ts
@@ -1,4 +1,4 @@
-import { Subcourse, Pupil, Concrete_notification, Log } from "../generated";
+import { Subcourse, Pupil, Concrete_notification, Log, Pupil_tutoring_interest_confirmation_request as TutoringInterestConfirmation } from "../generated";
 import { Authorized, Field, FieldResolver, Resolver, Root } from "type-graphql";
 import { prisma } from "../../common/prisma";
 import { Role } from "../authorizations";
@@ -60,5 +60,13 @@ export class ExtendFieldsPupilResolver {
     @Authorized(Role.ADMIN)
     async subjectsFormatted(@Root() pupil: Required<Pupil>) {
         return parseSubjectString(pupil.subjects);
+    }
+
+    @FieldResolver(type => TutoringInterestConfirmation)
+    @Authorized(Role.ADMIN)
+    async tutoringInterestConfirmation(@Root() pupil: Required<Pupil>) {
+        return await prisma.pupil_tutoring_interest_confirmation_request.findFirst({
+            where: { pupilId: pupil.id }
+        })
     }
 }

--- a/graphql/pupil/fields.ts
+++ b/graphql/pupil/fields.ts
@@ -62,7 +62,7 @@ export class ExtendFieldsPupilResolver {
         return parseSubjectString(pupil.subjects);
     }
 
-    @FieldResolver({ nullable: true }, type => TutoringInterestConfirmation)
+    @FieldResolver(type => TutoringInterestConfirmation, { nullable: true })
     @Authorized(Role.ADMIN)
     async tutoringInterestConfirmation(@Root() pupil: Required<Pupil>) {
         return await prisma.pupil_tutoring_interest_confirmation_request.findFirst({

--- a/graphql/pupil/fields.ts
+++ b/graphql/pupil/fields.ts
@@ -62,7 +62,7 @@ export class ExtendFieldsPupilResolver {
         return parseSubjectString(pupil.subjects);
     }
 
-    @FieldResolver(type => TutoringInterestConfirmation)
+    @FieldResolver({ nullable: true }, type => TutoringInterestConfirmation)
     @Authorized(Role.ADMIN)
     async tutoringInterestConfirmation(@Root() pupil: Required<Pupil>) {
         return await prisma.pupil_tutoring_interest_confirmation_request.findFirst({

--- a/graphql/tutoring_interest_confirmation/mutations.ts
+++ b/graphql/tutoring_interest_confirmation/mutations.ts
@@ -1,0 +1,23 @@
+import { changeStatus } from "../../common/interest-confirmation/tutoring/persistence/change-status";
+import { Resolver, Mutation, Root, Arg, Authorized, Ctx } from "type-graphql";
+import { Pupil_tutoring_interest_confirmation_request as TutoringInterestConfirmation } from "../generated";
+import { InterestConfirmationStatus } from "../../common/entity/PupilTutoringInterestConfirmationRequest";
+import { getManager } from "typeorm";
+import { Role } from "../authorizations";
+
+@Resolver(of => TutoringInterestConfirmation)
+export class MutateTutoringInterestConfirmationResolver {
+    @Mutation(returns => Boolean)
+    @Authorized(Role.ADMIN)
+    async tutoringInterestConfirm(@Arg("token") token: string) {
+        await changeStatus(token, InterestConfirmationStatus.CONFIRMED, getManager());
+        return true;
+    }
+
+    @Mutation(returns => Boolean)
+    @Authorized(Role.ADMIN)
+    async tutoringInterestRefuse(@Arg("token") token: string) {
+        await changeStatus(token, InterestConfirmationStatus.REFUSED, getManager());
+        return true;
+    }
+}


### PR DESCRIPTION
Adds the following subquery to pupils:

```gql
query {
  pupils {
    tutoringInterestConfirmation {
       status 
       token
       reminderSentDate
    }
  }
}
```

Also adds two mutations to confirm or deny the interest:
```gql
mutation { tutoringInterestConfirm(token: "abc") }
mutation { tutoringInterestRefuse(token: "abc") }
```