### PR TITLE
GraphQL: Participation Certificates

### DIFF
--- a/common/certificate/index.ts
+++ b/common/certificate/index.ts
@@ -16,7 +16,7 @@ import { pupil as PrismaPupil, student as PrismaStudent } from "@prisma/client";
 import { getManager } from 'typeorm';
 import { Match } from '../entity/Match';
 import { ParticipationCertificate } from '..//entity/ParticipationCertificate';
-import { assert } from 'console';
+import assert from 'assert';
 
 // TODO: Replace TypeORM operations with Prisma
 
@@ -257,10 +257,11 @@ function loadTemplate(name, lang: Language, fallback: boolean = true): EJS.Clien
         return _templates[name][lang];
     }
 
-    let path = `./assets/${name}.${lang}.html`;
+    let file = path.join(__dirname, `/assets/${name}.${lang}.html`);
+    console.log("Loading template from ", file);
 
-    if (existsSync(path)) {
-        const result = readFileSync(path, "utf8");
+    if (existsSync(file)) {
+        const result = readFileSync(file, "utf8");
         if (!_templates[name]) {
             _templates[name] = {};
         }

--- a/common/certificate/index.ts
+++ b/common/certificate/index.ts
@@ -1,0 +1,319 @@
+
+import { readFileSync, existsSync } from 'fs';
+import { generatePDFFromHTMLString } from 'html-pppdf';
+import path from 'path';
+import moment from "moment";
+import CertificateRequestEvent from '../transactionlog/types/CertificateRequestEvent';
+import { getTransactionLog } from '../transactionlog';
+import { randomBytes } from "crypto";
+import EJS from "ejs";
+import { mailjetTemplates, sendTemplateMail } from '../mails';
+import { createAutoLoginLink } from '../../web/controllers/utils';
+import * as Notification from "../notification";
+import { Pupil } from '../entity/Pupil';
+import { Student } from '../entity/Student';
+import { getManager } from 'typeorm';
+import { Match } from '../entity/Match';
+import { ParticipationCertificate } from '..//entity/ParticipationCertificate';
+import { assert } from 'console';
+
+export const VALID_BASE64 = /^data\:image\/(png|jpeg)\;base64\,([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/g;
+
+// supported certificate languages:
+export const LANGUAGES = ["de", "en"] as const;
+export type Language = (typeof LANGUAGES)[number];
+export const DefaultLanguage = "de";
+
+
+export const CERTIFICATE_MEDIUMS = ['Video-Chat', 'E-Mail', 'Telefon', 'Chat-Nachrichten'] as const;
+
+export enum CertificateState {
+    manual = "manual", // student did not request approval
+    awaitingApproval = "awaiting-approval", // pupil needs to sign certificate
+    approved = "approved" // signed by pupil
+}
+
+export interface IExposedCertificate {
+    userIs: "pupil" | "student",
+    pupil: { firstname: string, lastname: string },
+    student: { firstname: string, lastname: string },
+    subjects: string,
+    categories: string,
+    certificateDate: Date,
+    startDate: Date,
+    endDate: Date,
+    uuid: string,
+    hoursPerWeek: number,
+    hoursTotal: number,
+    medium: string,
+    state: CertificateState,
+}
+
+// CertificateErrors can safely be shown to users (they have readable error messages which do not contain secrets)
+export class CertificateError extends Error { }
+
+/* Pupils can retrieve certificates of their students, students can retrieve theirs */
+export async function getCertificatesFor(user: Pupil | Student) {
+    const entityManager = getManager();
+
+    const certificatesData = await entityManager.find(ParticipationCertificate, {
+        where: user instanceof Pupil ? { pupil: user.id } : { student: user.id },
+        relations: ["student", "pupil"]
+    });
+
+    return certificatesData.map(cert => exposeCertificate(cert, /*to*/ user));
+}
+
+/* Students can download their certificates as PDF */
+export async function getCertificatePDF(certificateId: string, requestor: Student, lang: Language): Promise<Buffer> {
+    const entityManager = getManager();
+
+    /* Retrieve the certificate and also get the signature columns that are usually hidden for performance reasons */
+    const certificate = await entityManager.findOne(ParticipationCertificate, { uuid: certificateId.toUpperCase(), student: requestor }, {
+        relations: ["student", "pupil"],
+        /* Unfortunately there is no "*" option which would also select the signatures. The query builder also does not cover this case */
+        select: ["uuid", "categories", "certificateDate", "endDate", "hoursPerWeek", "hoursTotal", "id", "medium", "ongoingLessons", "signatureParent", "signaturePupil", "signatureDate", "signatureLocation", "startDate", "state", "subjects"]
+    });
+
+    if (!certificate) {
+        throw new CertificateError("Certificate not found");
+    }
+
+    const pdf = await createPDFBinary(
+        certificate,
+        getCertificateLink(certificate, lang),
+        lang as Language
+    );
+
+    return pdf;
+}
+
+export interface ICertificateCreationParams {
+    endDate: number,
+    subjects: string,
+    hoursPerWeek: number,
+    hoursTotal: number,
+    medium: string,
+    activities: string,
+    ongoingLessons: boolean,
+    state: CertificateState.manual | CertificateState.awaitingApproval
+}
+
+/* Students can create certificates, which pupils can then sign */
+export async function createCertificate(requestor: Student, pupil: Pupil, params: ICertificateCreationParams): Promise<ParticipationCertificate> {
+    const entityManager = getManager();
+    const transactionLog = getTransactionLog();
+
+    const match = await entityManager.findOne(Match, { student: requestor, pupil: pupil });
+    if (match == undefined) {
+        throw new CertificateError(`No Match found with uuid '${pupil}'`);
+    }
+
+    let pc = new ParticipationCertificate();
+    pc.pupil = pupil;
+    pc.student = requestor;
+    pc.subjects = params.subjects;
+    pc.categories = params.activities;
+    pc.hoursPerWeek = params.hoursPerWeek;
+    pc.hoursTotal = params.hoursTotal;
+    pc.medium = params.medium;
+    pc.startDate = match.createdAt;
+    pc.endDate = moment(params.endDate, "X").toDate();
+    pc.ongoingLessons = params.ongoingLessons;
+    pc.state = params.state;
+
+    do {
+        pc.uuid = randomBytes(5).toString('hex')
+            .toUpperCase();
+    } while (await entityManager.findOne(ParticipationCertificate, { uuid: pc.uuid }));
+
+    await entityManager.save(ParticipationCertificate, pc);
+    await transactionLog.log(new CertificateRequestEvent(requestor, match.uuid));
+
+    if (params.state === "awaiting-approval") {
+        const certificateLink = createAutoLoginLink(pc.pupil, `/settings?sign=${pc.uuid}`);
+        const mail = mailjetTemplates.CERTIFICATEREQUEST({
+            certificateLink,
+            pupilFirstname: pc.pupil.firstname,
+            studentFirstname: pc.student.firstname
+        });
+        await sendTemplateMail(mail, pc.pupil.email);
+        await Notification.actionTaken(pc.pupil, "pupil_certificate_approval", {
+            uniqueId: `${pc.id}`,
+            certificateLink,
+            student: pc.student
+        });
+    }
+
+    return pc;
+}
+
+/* Everybody who sees a certificate can verify it's authenticity through a public endpoint, which shows the confirmation page */
+export async function getConfirmationPage(certificateId: string, lang: Language) {
+    const entityManager = getManager();
+
+    const certificate = await entityManager.findOne(ParticipationCertificate, { uuid: certificateId.toUpperCase() }, { relations: ["student", "pupil"] });
+
+    if (!certificate) {
+        throw new CertificateError(`Certificate not found`);
+    }
+
+    let verificationTemplate = loadTemplate("verifiedCertificatePage", lang);
+
+    const screeningDate = (await certificate.student?.screening)?.createdAt;
+
+    return verificationTemplate({
+        NAMESTUDENT: certificate.student?.firstname + " " + certificate.student?.lastname,
+        NAMESCHUELER: certificate.pupil?.firstname + " " + certificate.pupil?.lastname,
+        DATUMHEUTE: moment(certificate.certificateDate).format("D.M.YYYY"),
+        SCHUELERSTART: moment(certificate.startDate).format("D.M.YYYY"),
+        SCHUELERENDE: moment(certificate.endDate).format("D.M.YYYY"),
+        SCHUELERFAECHER: certificate.subjects.split(","),
+        SCHUELERFREITEXT: certificate.categories.split(/(?:\r\n|\r|\n)/g),
+        SCHUELERPROWOCHE: certificate.hoursPerWeek,
+        SCHUELERGESAMT: certificate.hoursTotal,
+        MEDIUM: certificate.medium,
+        SCREENINGDATUM: screeningDate ? moment(screeningDate).format("D.M.YYYY") : "[UNBEKANNTES DATUM]",
+        ONGOING: certificate.ongoingLessons
+    });
+}
+
+/* Pupils can sign certificates for their students through a webinterface */
+export async function signCertificate(certificateId: string, signer: Pupil, signatureParent: string | undefined, signaturePupil: string | undefined, signatureLocation: string) {
+    assert(signaturePupil || signatureParent, "Parent or Pupil signs certificate");
+    assert(!signaturePupil || signaturePupil.match(VALID_BASE64), "Pupil Signature is valid Base 64");
+    assert(!signatureParent || signatureParent.match(VALID_BASE64), "Parent Signature is valid Base 64");
+    assert(signatureLocation, "Singature location must be set");
+
+    const entityManager = getManager();
+    const certificate = await entityManager.findOne(ParticipationCertificate, { pupil: signer, uuid: certificateId.toUpperCase() }, { relations: ["student", "pupil"] });
+
+    if (!certificate) {
+        throw new CertificateError("Missing certificateID or the pupil is not allowed to sign this certificate");
+    }
+
+    if (certificate.state === "approved") {
+        throw new CertificateError("Certificate was already signed");
+    }
+
+    if (certificate.state === "manual") {
+        throw new CertificateError("Certificate cannot be signed as it is a manual one");
+    }
+
+    if (signatureParent) {
+        certificate.signatureParent = Buffer.from(signatureParent, "utf-8");
+    }
+
+    if (signaturePupil) {
+        certificate.signaturePupil = Buffer.from(signaturePupil, "utf-8");
+    }
+
+    certificate.signatureDate = new Date();
+    certificate.signatureLocation = signatureLocation;
+    certificate.state = "approved";
+
+    await getManager().save(ParticipationCertificate, certificate);
+
+    const rendered = await createPDFBinary(certificate, getCertificateLink(certificate, "de"), "de");
+
+    const certificateLink = createAutoLoginLink(certificate.student, `/settings`);
+    const mail = mailjetTemplates.CERTIFICATESIGNED({
+        certificateLink,
+        pupilFirstname: certificate.pupil.firstname,
+        studentFirstname: certificate.student.firstname
+    }, rendered.toString("base64"));
+    await sendTemplateMail(mail, certificate.student.email);
+    await Notification.actionTaken(certificate.student, "student_certificate_sign", {
+        uniqueId: `${certificate.id}`,
+        certificateLink,
+        pupil: certificate.pupil
+    });
+
+}
+
+/* ------------------------- INTERNAL CERTIFICATE UTILITIES --------------------------------------- */
+
+const _templates: { [name: string]: { [key in Language | "default"]?: EJS.ClientFunction } } = {};
+
+/* Loads the template from the /assets folder, falls back to the default language if fallback is true */
+function loadTemplate(name, lang: Language, fallback: boolean = true): EJS.ClientFunction {
+    if (_templates[name] && _templates[name][lang]) {
+        return _templates[name][lang];
+    }
+
+    let path = `./assets/${name}.${lang}.html`;
+
+    if (existsSync(path)) {
+        const result = readFileSync(path, "utf8");
+        if (!_templates[name]) {
+            _templates[name] = {};
+        }
+
+        const compiled = EJS.compile(result);
+
+        _templates[name][lang] = compiled;
+        return compiled;
+    } else {
+        if (!fallback || lang === DefaultLanguage) {
+            throw new Error(`Cannot find template '${path}`);
+        }
+
+        return loadTemplate(name, DefaultLanguage, /*fallback:*/ false);
+    }
+}
+
+/* Map the certificate data to something the frontend can work with while keeping user data secret */
+function exposeCertificate({ student, pupil, state, ...cert }: ParticipationCertificate, to: Student | Pupil): IExposedCertificate {
+    return {
+        ...cert,
+        // NOTE: user.id is NOT unique, as Students and Pupils can have the same id
+        userIs: pupil.wix_id === to.wix_id ? "pupil" : "student",
+        pupil: { firstname: pupil.firstname, lastname: pupil.lastname },
+        student: { firstname: student.firstname, lastname: student.lastname },
+        state: state as CertificateState
+    };
+}
+
+function getCertificateLink(certificate: ParticipationCertificate, lang: Language) {
+    return "http://verify.corona-school.de/" + certificate.uuid + "?lang=" + lang;
+}
+
+async function createPDFBinary(certificate: ParticipationCertificate, link: string, lang: Language): Promise<Buffer> {
+    const { student, pupil } = certificate;
+
+    const template = loadTemplate("certificateTemplate", lang);
+
+    let name = student.firstname + " " + student.lastname;
+
+    if (process.env.ENV == 'dev') {
+        name = `[TEST] ${name}`;
+    }
+
+    const result = template({
+        NAMESTUDENT: name,
+        NAMESCHUELER: pupil.firstname + " " + pupil.lastname,
+        DATUMHEUTE: moment().format("D.M.YYYY"),
+        SCHUELERSTART: moment(certificate.startDate, "X").format("D.M.YYYY"),
+        SCHUELERENDE: moment(certificate.endDate, "X").format("D.M.YYYY"),
+        SCHUELERFAECHER: certificate.subjects.split(","),
+        SCHUELERFREITEXT: certificate.categories.split(/(?:\r\n|\r|\n)/g),
+        SCHUELERPROWOCHE: certificate.hoursPerWeek,
+        SCHUELERGESAMT: certificate.hoursTotal,
+        MEDIUM: certificate.medium,
+        CERTLINK: link,
+        CERTLINKTEXT: link,
+        ONGOING: certificate.ongoingLessons,
+        SIGNATURE_PARENT: certificate.signatureParent?.toString("utf-8"),
+        SIGNATURE_PUPIL: certificate.signaturePupil?.toString("utf-8"),
+        SIGNATURE_LOCATION: certificate.signatureLocation,
+        SIGNATURE_DATE: certificate.signatureDate && moment(certificate.signatureDate).format("D.M.YYYY")
+    });
+
+    const ASSETS = __dirname + "/../../../../assets";
+    return await generatePDFFromHTMLString(result, {
+        includePaths: [
+            path.resolve(ASSETS)
+        ]
+    });
+}
+

--- a/common/certificate/index.ts
+++ b/common/certificate/index.ts
@@ -257,7 +257,7 @@ function loadTemplate(name, lang: Language, fallback: boolean = true): EJS.Clien
         return _templates[name][lang];
     }
 
-    let file = path.join(__dirname, `/assets/${name}.${lang}.html`);
+    let file = path.join(__dirname, `../../assets/${name}.${lang}.html`);
     console.log("Loading template from ", file);
 
     if (existsSync(file)) {
@@ -272,7 +272,7 @@ function loadTemplate(name, lang: Language, fallback: boolean = true): EJS.Clien
         return compiled;
     } else {
         if (!fallback || lang === DefaultLanguage) {
-            throw new Error(`Cannot find template '${path}`);
+            throw new Error(`Cannot find template '${file}`);
         }
 
         return loadTemplate(name, DefaultLanguage, /*fallback:*/ false);

--- a/common/certificate/index.ts
+++ b/common/certificate/index.ts
@@ -20,6 +20,8 @@ import assert from 'assert';
 
 // TODO: Replace TypeORM operations with Prisma
 
+const ASSETS = path.join(__dirname, `../../../assets/`);
+
 export const VALID_BASE64 = /^data\:image\/(png|jpeg)\;base64\,([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/g;
 
 // supported certificate languages:
@@ -257,7 +259,7 @@ function loadTemplate(name, lang: Language, fallback: boolean = true): EJS.Clien
         return _templates[name][lang];
     }
 
-    let file = path.join(__dirname, `../../../assets/${name}.${lang}.html`);
+    let file = path.join(ASSETS, `${name}.${lang}.html`);
     console.log("Loading template from ", file);
 
     if (existsSync(file)) {
@@ -326,7 +328,6 @@ async function createPDFBinary(certificate: ParticipationCertificate, link: stri
         SIGNATURE_DATE: certificate.signatureDate && moment(certificate.signatureDate).format("D.M.YYYY")
     });
 
-    const ASSETS = __dirname + "/../../../../assets";
     return await generatePDFFromHTMLString(result, {
         includePaths: [
             path.resolve(ASSETS)

--- a/common/certificate/index.ts
+++ b/common/certificate/index.ts
@@ -112,7 +112,7 @@ export async function createCertificate(_requestor: Student | PrismaStudent, pup
     const requestor = await entityManager.findOneOrFail(Student, { id: _requestor.id });
     const pupil = await entityManager.findOne(Pupil, { id: pupilId });
 
-    if(!pupil) {
+    if (!pupil) {
         throw new CertificateError(`Pupil not found`);
     }
 

--- a/common/certificate/index.ts
+++ b/common/certificate/index.ts
@@ -257,7 +257,7 @@ function loadTemplate(name, lang: Language, fallback: boolean = true): EJS.Clien
         return _templates[name][lang];
     }
 
-    let file = path.join(__dirname, `../../assets/${name}.${lang}.html`);
+    let file = path.join(__dirname, `../../../assets/${name}.${lang}.html`);
     console.log("Loading template from ", file);
 
     if (existsSync(file)) {

--- a/common/certificate/index.ts
+++ b/common/certificate/index.ts
@@ -121,7 +121,7 @@ export async function createCertificate(_requestor: Student | PrismaStudent, pup
     const match = await entityManager.findOne(Match, { student: requestor, pupil: pupil });
 
     if (!match) {
-        throw new CertificateError(`No Match found with uuid '${pupil}'`);
+        throw new CertificateError(`No Match found with pupil '${pupilId}'`);
     }
 
     let pc = new ParticipationCertificate();

--- a/graphql/authorizations.ts
+++ b/graphql/authorizations.ts
@@ -22,7 +22,9 @@ export enum Role {
     /* Accessible to everyone */
     UNAUTHENTICATED = "UNAUTHENTICATED",
     /* User owns the entity as defined in graphql/ownership */
-    OWNER = "OWNER"
+    OWNER = "OWNER",
+    /* No one should have access */
+    NOBODY = "NOBODY"
 }
 
 const authLogger = getLogger("GraphQL Authentication");
@@ -99,6 +101,7 @@ async function accessCheck(context: GraphQLContext, requiredRoles: Role[], model
 const allAdmin = { _all: [Authorized(Role.ADMIN)] };
 const adminOrOwner = [Authorized(Role.ADMIN, Role.OWNER)];
 const onlyOwner = [Authorized(Role.OWNER)];
+const nobody = [Authorized(Role.NOBODY)];
 
 /* Although we do not expose all Prisma entities, we make sure authorization is present for all queries and mutations
    We use query and mutation authorizations as our main authorization strategy,
@@ -165,5 +168,12 @@ export const authorizationModelEnhanceMap: ModelsEnhanceMap = {
             email: adminOrOwner
         }
 
+    },
+    Participation_certificate: {
+        fields: {
+            // these are Buffers and are not supposed to be retrieved directly by anyone (only rendered into a PDF)
+            signatureParent: nobody,
+            signaturePupil: nobody
+        }
     }
 };

--- a/graphql/certificate/fields.ts
+++ b/graphql/certificate/fields.ts
@@ -10,7 +10,7 @@ export class ExtendedFieldsParticipationCertificateResolver {
     @FieldResolver(returns => String)
     @Authorized(Role.STUDENT)
     async pdf(@Ctx() context, @Root() certificate: participation_certificate, @Arg("language") language: string) {
-        if(!LANGUAGES.includes(language as Language))
+        if (!LANGUAGES.includes(language as Language))
             throw new Error(`Unknown language '${language}'`);
 
         const student = await getSessionStudent(context);

--- a/graphql/certificate/fields.ts
+++ b/graphql/certificate/fields.ts
@@ -1,23 +1,10 @@
 import * as GraphQLModel from "../generated/models";
 import { Role } from "../authorizations";
-import { Arg, Authorized, Ctx, FieldResolver, Resolver, Root } from "type-graphql";
+import { Authorized, FieldResolver, Resolver, Root } from "type-graphql";
 import { participation_certificate as ParticipationCertificate } from "@prisma/client";
-import { getCertificatePDF, Language, LANGUAGES } from "../../common/certificate";
-import { getSessionStudent } from "../authentication";
 
 @Resolver(of => GraphQLModel.Participation_certificate)
 export class ExtendedFieldsParticipationCertificateResolver {
-    @FieldResolver(returns => String)
-    @Authorized(Role.STUDENT)
-    async pdf(@Ctx() context, @Root() certificate: ParticipationCertificate, @Arg("language") language: string) {
-        if (!LANGUAGES.includes(language as Language)) {
-            throw new Error(`Unknown language '${language}'`);
-        }
-
-        const student = await getSessionStudent(context);
-        return await getCertificatePDF(certificate.uuid, student, language as Language);
-    }
-
     @FieldResolver(returns => [String])
     @Authorized(Role.ADMIN, Role.STUDENT)
     subjectsFormatted(@Root() certificate: ParticipationCertificate) {

--- a/graphql/certificate/fields.ts
+++ b/graphql/certificate/fields.ts
@@ -10,8 +10,9 @@ export class ExtendedFieldsParticipationCertificateResolver {
     @FieldResolver(returns => String)
     @Authorized(Role.STUDENT)
     async pdf(@Ctx() context, @Root() certificate: participation_certificate, @Arg("language") language: string) {
-        if (!LANGUAGES.includes(language as Language))
+        if (!LANGUAGES.includes(language as Language)) {
             throw new Error(`Unknown language '${language}'`);
+        }
 
         const student = await getSessionStudent(context);
         return await getCertificatePDF(certificate.uuid, student, language as Language);

--- a/graphql/certificate/fields.ts
+++ b/graphql/certificate/fields.ts
@@ -1,7 +1,7 @@
 import * as GraphQLModel from "../generated/models";
 import { Role } from "../authorizations";
 import { Arg, Authorized, Ctx, FieldResolver, Resolver, Root } from "type-graphql";
-import { participation_certificate } from "@prisma/client";
+import { participation_certificate as ParticipationCertificate } from "@prisma/client";
 import { getCertificatePDF, Language, LANGUAGES } from "../../common/certificate";
 import { getSessionStudent } from "../authentication";
 
@@ -9,12 +9,18 @@ import { getSessionStudent } from "../authentication";
 export class ExtendedFieldsParticipationCertificateResolver {
     @FieldResolver(returns => String)
     @Authorized(Role.STUDENT)
-    async pdf(@Ctx() context, @Root() certificate: participation_certificate, @Arg("language") language: string) {
+    async pdf(@Ctx() context, @Root() certificate: ParticipationCertificate, @Arg("language") language: string) {
         if (!LANGUAGES.includes(language as Language)) {
             throw new Error(`Unknown language '${language}'`);
         }
 
         const student = await getSessionStudent(context);
         return await getCertificatePDF(certificate.uuid, student, language as Language);
+    }
+
+    @FieldResolver(returns => [String])
+    @Authorized(Role.ADMIN, Role.STUDENT)
+    subjectsFormatted(@Root() certificate: ParticipationCertificate) {
+        return certificate.subjects.split(",");
     }
 }

--- a/graphql/certificate/fields.ts
+++ b/graphql/certificate/fields.ts
@@ -1,0 +1,19 @@
+import * as GraphQLModel from "../generated/models";
+import { Role } from "../authorizations";
+import { Arg, Authorized, Ctx, FieldResolver, Resolver, Root } from "type-graphql";
+import { participation_certificate } from "@prisma/client";
+import { getCertificatePDF, Language, LANGUAGES } from "../../common/certificate";
+import { getSessionStudent } from "../authentication";
+
+@Resolver(of => GraphQLModel.Participation_certificate)
+export class ExtendedFieldsParticipationCertificateResolver {
+    @FieldResolver(returns => String)
+    @Authorized(Role.STUDENT)
+    async pdf(@Ctx() context, @Root() certificate: participation_certificate, @Arg("language") language: string) {
+        if(!LANGUAGES.includes(language as Language))
+            throw new Error(`Unknown language '${language}'`);
+
+        const student = await getSessionStudent(context);
+        return await getCertificatePDF(certificate.uuid, student, language as Language);
+    }
+}

--- a/graphql/certificate/mutations.ts
+++ b/graphql/certificate/mutations.ts
@@ -42,7 +42,7 @@ export class MutateParticipationCertificateResolver {
 
         const pupil = await getSessionPupil(context);
 
-        if(!signaturePupil && !signatureParent)
+        if (!signaturePupil && !signatureParent)
             throw new Error(`Either signatureParent or signaturePupil must be present`);
 
         await signCertificate(certificateId, pupil, signatureParent, signaturePupil, signatureLocation);

--- a/graphql/certificate/mutations.ts
+++ b/graphql/certificate/mutations.ts
@@ -51,7 +51,7 @@ export class MutateParticipationCertificateResolver {
     }
 
     @Mutation(returns => Boolean)
-    @Authorized(Role.ADMIN)
+    @Authorized(Role.STUDENT)
     async participationCertificateCreate(@Ctx() context: GraphQLContext, @Arg("pupilId") pupilId: number, @Arg("certificateData") certificateData: CertificateCreationInput): Promise<boolean> {
         const requestor = await getSessionStudent(context);
         await createCertificate(requestor, pupilId, certificateData);

--- a/graphql/certificate/mutations.ts
+++ b/graphql/certificate/mutations.ts
@@ -1,0 +1,59 @@
+import { prisma } from "../../common/prisma";
+import { Resolver, Mutation, Root, Arg, Authorized, Ctx, InputType, Field } from "type-graphql";
+import * as GraphQLModel from "../generated/models";
+import { Role } from "../authorizations";
+import { createCertificate, signCertificate, ICertificateCreationParams, CertificateState } from "../../common/certificate";
+import { GraphQLContext } from "../context";
+import { getSessionPupil, getSessionStudent } from "../authentication";
+import { IsIn } from "class-validator";
+
+@InputType()
+class CertificateCreationInput implements ICertificateCreationParams {
+    @Field()
+    endDate: number;
+    @Field()
+    subjects: string;
+    @Field()
+    hoursPerWeek: number;
+    @Field()
+    hoursTotal: number;
+    @Field()
+    medium: string;
+    @Field()
+    activities: string;
+    @Field()
+    ongoingLessons: boolean;
+    @Field()
+    @IsIn([CertificateState.manual, CertificateState.awaitingApproval])
+    state: CertificateState.manual | CertificateState.awaitingApproval;
+}
+
+@Resolver(of => GraphQLModel.Participation_certificate)
+export class MutateParticipationCertificateResolver {
+
+    @Mutation(returns => Boolean)
+    @Authorized(Role.STUDENT)
+    async participationCertificateSign(
+        @Ctx() context: GraphQLContext,
+        @Arg("certificateId") certificateId: string,
+        @Arg("signaturePupil", { nullable: true }) signaturePupil: string | null,
+        @Arg("signatureParent", { nullable: true }) signatureParent: string | null,
+        @Arg("signatureLocation") signatureLocation: string): Promise<boolean> {
+
+        const pupil = await getSessionPupil(context);
+
+        if(!signaturePupil && !signatureParent)
+            throw new Error(`Either signatureParent or signaturePupil must be present`);
+
+        await signCertificate(certificateId, pupil, signatureParent, signaturePupil, signatureLocation);
+        return true;
+    }
+
+    @Mutation(returns => Boolean)
+    @Authorized(Role.ADMIN)
+    async participationCertificateCreate(@Ctx() context: GraphQLContext, @Arg("pupilId") pupilId: number, @Arg("certificateData") certificateData: CertificateCreationInput): Promise<boolean> {
+        const requestor = await getSessionStudent(context);
+        await createCertificate(requestor, pupilId, certificateData);
+        return true;
+    }
+}

--- a/graphql/certificate/mutations.ts
+++ b/graphql/certificate/mutations.ts
@@ -42,8 +42,9 @@ export class MutateParticipationCertificateResolver {
 
         const pupil = await getSessionPupil(context);
 
-        if (!signaturePupil && !signatureParent)
+        if (!signaturePupil && !signatureParent) {
             throw new Error(`Either signatureParent or signaturePupil must be present`);
+        }
 
         await signCertificate(certificateId, pupil, signatureParent, signaturePupil, signatureLocation);
         return true;

--- a/graphql/certificate/mutations.ts
+++ b/graphql/certificate/mutations.ts
@@ -32,7 +32,7 @@ class CertificateCreationInput implements ICertificateCreationParams {
 export class MutateParticipationCertificateResolver {
 
     @Mutation(returns => Boolean)
-    @Authorized(Role.STUDENT)
+    @Authorized(Role.PUPIL)
     async participationCertificateSign(
         @Ctx() context: GraphQLContext,
         @Arg("certificateId") certificateId: string,

--- a/graphql/index.ts
+++ b/graphql/index.ts
@@ -69,7 +69,7 @@ const schema = buildSchemaSync({
 
         /* ParticipationCertificate */
         ExtendedFieldsParticipationCertificateResolver,
-        MutateParticipationCertificateResolver,
+        MutateParticipationCertificateResolver
     ],
     authChecker
 });

--- a/graphql/index.ts
+++ b/graphql/index.ts
@@ -19,6 +19,9 @@ import { AuthenticationResolver } from "./authentication";
 import { FieldMeResolver } from "./me/fields";
 import { MutateMatchResolver } from "./match/mutations";
 import { MutateTutoringInterestConfirmationResolver } from "./tutoring_interest_confirmation/mutations";
+import { MutateParticipationCertificateResolver } from "./certificate/mutations";
+import { ExtendedFieldsParticipationCertificateResolver } from "./certificate/fields";
+import { ExtendFieldsStudentResolver } from "./student/fields";
 
 applyResolversEnhanceMap(authorizationEnhanceMap);
 applyResolversEnhanceMap(complexityEnhanceMap);
@@ -44,6 +47,9 @@ const schema = buildSchemaSync({
         ExtendFieldsPupilResolver,
         MutatePupilResolver,
 
+        /* Student */
+        ExtendFieldsStudentResolver,
+
         /* Match */
         FindManyMatchResolver,
         ExtendedFieldsMatchResolver,
@@ -59,7 +65,11 @@ const schema = buildSchemaSync({
         FindManyConcrete_notificationResolver,
 
         /* TutoringInterestConfirmation */
-        MutateTutoringInterestConfirmationResolver
+        MutateTutoringInterestConfirmationResolver,
+
+        /* ParticipationCertificate */
+        ExtendedFieldsParticipationCertificateResolver,
+        MutateParticipationCertificateResolver,
     ],
     authChecker
 });

--- a/graphql/pupil/fields.ts
+++ b/graphql/pupil/fields.ts
@@ -1,4 +1,4 @@
-import { Subcourse, Pupil, Concrete_notification, Log, Pupil_tutoring_interest_confirmation_request as TutoringInterestConfirmation } from "../generated";
+import { Subcourse, Pupil, Concrete_notification, Log, Pupil_tutoring_interest_confirmation_request as TutoringInterestConfirmation, Participation_certificate as ParticipationCertificate } from "../generated";
 import { Authorized, Field, FieldResolver, Resolver, Root } from "type-graphql";
 import { prisma } from "../../common/prisma";
 import { Role } from "../authorizations";
@@ -66,6 +66,14 @@ export class ExtendFieldsPupilResolver {
     @Authorized(Role.ADMIN)
     async tutoringInterestConfirmation(@Root() pupil: Required<Pupil>) {
         return await prisma.pupil_tutoring_interest_confirmation_request.findFirst({
+            where: { pupilId: pupil.id }
+        });
+    }
+
+    @FieldResolver(type => [ParticipationCertificate])
+    @Authorized(Role.ADMIN, Role.OWNER)
+    async participationCertificatesToSign(@Root() pupil: Required<Pupil>) {
+        return await prisma.participation_certificate.findMany({
             where: { pupilId: pupil.id }
         });
     }

--- a/graphql/pupil/fields.ts
+++ b/graphql/pupil/fields.ts
@@ -43,7 +43,7 @@ export class ExtendFieldsPupilResolver {
     @Authorized(Role.ADMIN)
     @LimitEstimated(100)
     async concreteNotifications(@Root() pupil: Required<Pupil>) {
-        return await prisma.concrete_notification.findMany({ where: { userId: getUserId(pupil) }});
+        return await prisma.concrete_notification.findMany({ where: { userId: getUserId(pupil) } });
     }
 
     @FieldResolver(type => [Log])

--- a/graphql/student/fields.ts
+++ b/graphql/student/fields.ts
@@ -1,0 +1,16 @@
+import { Student, Participation_certificate as ParticipationCertificate } from "../generated";
+import { Authorized, Field, FieldResolver, Resolver, Root } from "type-graphql";
+import { prisma } from "../../common/prisma";
+import { Role } from "../authorizations";
+
+@Resolver(of => Student)
+export class ExtendFieldsStudentResolver {
+
+    @FieldResolver(type => [ParticipationCertificate])
+    @Authorized(Role.ADMIN, Role.OWNER)
+    async participationCertificates(@Root() student: Required<Student>) {
+        return await prisma.participation_certificate.findMany({
+            where: { studentId: student.id }
+        });
+    }
+}

--- a/web/controllers/certificateController/index.ts
+++ b/web/controllers/certificateController/index.ts
@@ -2,32 +2,12 @@ import { getLogger } from 'log4js';
 import { Request, Response } from 'express';
 import { Pupil } from '../../../common/entity/Pupil';
 import { Student } from '../../../common/entity/Student';
-import { getTransactionLog } from '../../../common/transactionlog';
-import { getManager } from 'typeorm';
-import { Match } from '../../../common/entity/Match';
-import { readFileSync, existsSync } from 'fs';
-import { generatePDFFromHTMLString } from 'html-pppdf';
-import path from 'path';
-import moment from "moment";
-import CertificateRequestEvent from '../../../common/transactionlog/types/CertificateRequestEvent';
-import { ParticipationCertificate } from '../../../common/entity/ParticipationCertificate';
-import { randomBytes } from "crypto";
-import { parseDomain, ParseResultType } from "parse-domain";
 import { assert } from 'console';
-import { Person } from '../../../common/entity/Person';
-import EJS from "ejs";
-import { mailjetTemplates, sendTemplateMail } from '../../../common/mails';
-import { createAutoLoginLink } from '../utils';
-import * as Notification from "../../../common/notification";
+import { CERTIFICATE_MEDIUMS, CertificateState, ICertificateCreationParams, createCertificate, DefaultLanguage, LANGUAGES, Language, signCertificate, VALID_BASE64, getCertificatePDF, getConfirmationPage, getCertificatesFor, CertificateError } from '../../../common/certificate';
 
 const logger = getLogger();
 
-// supported certificate languages:
-const LANGUAGES = ["de", "en"] as const;
-type Language = (typeof LANGUAGES)[number];
-const DefaultLanguage = "de";
 
-const MEDIUMS = ['Video-Chat', 'E-Mail', 'Telefon', 'Chat-Nachrichten'] as const;
 
 /**
  * @api {POST} /certificate/create getCertificate
@@ -61,8 +41,6 @@ const MEDIUMS = ['Video-Chat', 'E-Mail', 'Telefon', 'Chat-Nachrichten'] as const
  * @apiUse StatusInternalServerError
  */
 export async function createCertificateEndpoint(req: Request, res: Response) {
-    const entityManager = getManager();
-
     try {
         assert(res.locals.user, "Must be logged in");
 
@@ -97,8 +75,8 @@ export async function createCertificateEndpoint(req: Request, res: Response) {
             return res.status(400).send("hoursTotal must be a positive number");
         }
 
-        if (!MEDIUMS.includes(medium)) {
-            return res.status(400).send(`medium must be one of ${MEDIUMS}`);
+        if (!CERTIFICATE_MEDIUMS.includes(medium)) {
+            return res.status(400).send(`medium must be one of ${CERTIFICATE_MEDIUMS}`);
         }
 
         if (!Array.isArray(activities) || activities.some(it => typeof it !== "string")) {
@@ -109,9 +87,9 @@ export async function createCertificateEndpoint(req: Request, res: Response) {
             return res.status(400).send("ongoingLessons must be boolean");
         }
 
-        let state = automatic ? State.awaitingApproval : State.manual;
+        let state = automatic ? CertificateState.awaitingApproval : CertificateState.manual;
 
-        let params: IParams = {
+        let params: ICertificateCreationParams = {
             endDate,
             subjects: subjects.join(","),
             hoursPerWeek,
@@ -123,17 +101,17 @@ export async function createCertificateEndpoint(req: Request, res: Response) {
         };
 
         // Students may only request for their matches
-        let match = await entityManager.findOne(Match, { student: requestor, uuid: pupil });
-        if (match == undefined) {
-            return res.status(400).send(`No Match found with uuid '${pupil}'`);
-        }
 
-        const certificate = await createCertificate(requestor, match.pupil, match, params);
+        const certificate = await createCertificate(requestor, pupil, params);
 
         return res.json({ uuid: certificate.uuid, automatic });
-    } catch (e) {
-        logger.error("Unexpected format of express request: " + e.message);
-        logger.debug(req, e);
+    } catch (error) {
+        if(error instanceof CertificateError) {
+            return res.status(400).send(error.message);
+        }
+
+        logger.error("Unexpected format of express request: " + error.message);
+        logger.debug(req, error);
         return res.status(500).send("Internal server error");
     }
 }
@@ -169,8 +147,6 @@ export async function getCertificateEndpoint(req: Request, res: Response) {
         const requestor = res.locals.user as Student;
         assert(requestor, "No user set");
 
-        const entityManager = getManager();
-
         if (lang === undefined) {
             lang = DefaultLanguage;
         }
@@ -183,22 +159,7 @@ export async function getCertificateEndpoint(req: Request, res: Response) {
             return res.status(400).send("Missing parameter certificateId");
         }
 
-        /* Retrieve the certificate and also get the signature columsn that are usually hidden for performance reasons */
-        const certificate = await entityManager.findOne(ParticipationCertificate, { uuid: certificateId.toUpperCase(), student: requestor }, {
-            relations: ["student", "pupil"],
-            /* Unfortunately there is no "*" option which would also select the signatures. The query builder also does not cover this case */
-            select: ["uuid", "categories", "certificateDate", "endDate", "hoursPerWeek", "hoursTotal", "id", "medium", "ongoingLessons", "signatureParent", "signaturePupil", "signatureDate", "signatureLocation", "startDate", "state", "subjects"]
-        });
-
-        if (!certificate) {
-            return res.status(404).send("<h1>Zertifikatslink nicht valide.</h1>");
-        }
-
-        const pdf = await createPDFBinary(
-            certificate,
-            getCertificateLink(req, certificate, lang as Language),
-            lang as Language
-        );
+        const pdf = await getCertificatePDF(certificateId, requestor, lang as Language);
 
         res.writeHead(200, {
             'Content-Type': 'application/pdf',
@@ -206,6 +167,10 @@ export async function getCertificateEndpoint(req: Request, res: Response) {
         });
         return res.end(pdf);
     } catch (error) {
+        if(error instanceof CertificateError) {
+            return res.status(400).send(error.message);
+        }
+
         logger.error("Failed to generate certificate confirmation", error);
         return res.status(500).send("<h1>Ein Fehler ist aufgetreten... 😔</h1>");
     }
@@ -239,8 +204,6 @@ export async function getCertificateConfirmationEndpoint(req: Request, res: Resp
         const { certificateId } = req.params;
         let { lang } = req.query;
 
-        const entityManager = getManager();
-
         if (lang === undefined) {
             lang = DefaultLanguage;
         }
@@ -253,21 +216,19 @@ export async function getCertificateConfirmationEndpoint(req: Request, res: Resp
             return res.status(400).send("Missing parameter certificateId");
         }
 
-        const certificate = await entityManager.findOne(ParticipationCertificate, { uuid: certificateId.toUpperCase() }, { relations: ["student", "pupil"] });
+        const confirmation = await getConfirmationPage(certificateId, lang as Language);
 
-        if (!certificate) {
-            return res.status(404).send("<h1>Zertifikatslink nicht valide.</h1>");
+        return res.send(confirmation);
+    } catch (error) {
+        if(error instanceof CertificateError) {
+            return res.status(400).send(error.message);
         }
 
-
-        return res.send(await viewParticipationCertificate(certificate, lang as Language));
-    } catch (error) {
         logger.error("Failed to generate certificate confirmation", error);
         return res.status(500).send("<h1>Ein Fehler ist aufgetreten... 😔</h1>");
     }
 }
 
-const VALID_BASE64 = /^data\:image\/(png|jpeg)\;base64\,([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/g;
 
 /**
  * @api {POST} /certificate/:certificateId/sign
@@ -294,8 +255,6 @@ export async function signCertificateEndpoint(req: Request, res: Response) {
     const { signaturePupil, signatureParent, signatureLocation } = req.body;
     const { certificateId } = req.params;
 
-    const entityManager = getManager();
-
     if (typeof certificateId !== "string") {
         return res.status(400).send("Missing parameter certificateId");
     }
@@ -316,24 +275,15 @@ export async function signCertificateEndpoint(req: Request, res: Response) {
         return res.status(400).send("Parameter signatureLocation must be a string");
     }
 
-    const certificate = await entityManager.findOne(ParticipationCertificate, { pupil: signer, uuid: certificateId.toUpperCase() }, { relations: ["student", "pupil"] });
-
-    if (!certificate) {
-        return res.status(400).send("Missing certificateID or the pupil is not allowed to sign this certificate");
-    }
-
-    if (certificate.state === "approved") {
-        return res.status(400).send("Certificate was already signed");
-    }
-
-    if (certificate.state === "manual") {
-        return res.status(400).send("Certificate cannot be signed as it is a manual one");
-    }
 
     try {
-        await signCertificate(req, certificate, signatureParent, signaturePupil, signatureLocation);
+        await signCertificate(certificateId, signer, signatureParent, signaturePupil, signatureLocation);
         return res.send("Certificate signed");
     } catch (error) {
+        if(error instanceof CertificateError) {
+            return res.status(400).send(error.message);
+        }
+
         logger.error("Failed to sign certificate", error);
         return res.status(500).send("<h1>Ein Fehler ist aufgetreten... 😔</h1>");
     }
@@ -363,250 +313,14 @@ export async function signCertificateEndpoint(req: Request, res: Response) {
  * @returns {Response}
  */
 export async function getCertificatesEndpoint(req: Request, res: Response) {
-    const entityManager = getManager();
-
     assert(res.locals.user, "No user set");
 
-    const userid = (res.locals.user as Person).id;
 
     try {
-        const certificatesData = await entityManager.find(ParticipationCertificate, {
-            where: res.locals.user instanceof Pupil ? { pupil: userid } : { student: userid },
-            relations: ["student", "pupil"]
-        });
-        const certificates = certificatesData.map(cert => exposeCertificate(cert, /*to*/ res.locals.user));
+        const certificates = getCertificatesFor(res.locals.user);
         return res.json({ certificates });
     } catch (error) {
         logger.error("Retrieving certificates for user failed with", error);
         return res.status(500).send("Internal Server error");
     }
-}
-
-
-
-enum State {
-    manual = "manual", // student did not request approval
-    awaitingApproval = "awaiting-approval", // pupil needs to sign certificate
-    approved = "approved" // signed by pupil
-}
-
-interface IExposedCertificate {
-    userIs: "pupil" | "student",
-    pupil: { firstname: string, lastname: string },
-    student: { firstname: string, lastname: string },
-    subjects: string,
-    categories: string,
-    certificateDate: Date,
-    startDate: Date,
-    endDate: Date,
-    uuid: string,
-    hoursPerWeek: number,
-    hoursTotal: number,
-    medium: string,
-    state: State,
-}
-
-/* Map the certificate data to something the frontend can work with while keeping user data secret */
-function exposeCertificate({ student, pupil, state, ...cert }: ParticipationCertificate, to: Student | Pupil): IExposedCertificate {
-    return {
-        ...cert,
-        // NOTE: user.id is NOT unique, as Students and Pupils can have the same id
-        userIs: pupil.wix_id === to.wix_id ? "pupil" : "student",
-        pupil: { firstname: pupil.firstname, lastname: pupil.lastname },
-        student: { firstname: student.firstname, lastname: student.lastname },
-        state: state as State
-    };
-}
-
-
-interface IParams {
-    endDate: number,
-    subjects: string,
-    hoursPerWeek: number,
-    hoursTotal: number,
-    medium: string,
-    activities: string,
-    ongoingLessons: boolean,
-    state: State.manual | State.awaitingApproval
-}
-
-async function createCertificate(requestor: Student, pupil: Pupil, match: Match, params: IParams): Promise<ParticipationCertificate> {
-    const entityManager = getManager();
-    const transactionLog = getTransactionLog();
-
-    let pc = new ParticipationCertificate();
-    pc.pupil = pupil;
-    pc.student = requestor;
-    pc.subjects = params.subjects;
-    pc.categories = params.activities;
-    pc.hoursPerWeek = params.hoursPerWeek;
-    pc.hoursTotal = params.hoursTotal;
-    pc.medium = params.medium;
-    pc.startDate = match.createdAt;
-    pc.endDate = moment(params.endDate, "X").toDate();
-    pc.ongoingLessons = params.ongoingLessons;
-    pc.state = params.state;
-
-    do {
-        pc.uuid = randomBytes(5).toString('hex')
-            .toUpperCase();
-    } while (await entityManager.findOne(ParticipationCertificate, { uuid: pc.uuid }));
-
-    await entityManager.save(ParticipationCertificate, pc);
-    await transactionLog.log(new CertificateRequestEvent(requestor, match.uuid));
-
-    if (params.state === "awaiting-approval") {
-        const certificateLink = createAutoLoginLink(pc.pupil, `/settings?sign=${pc.uuid}`);
-        const mail = mailjetTemplates.CERTIFICATEREQUEST({
-            certificateLink,
-            pupilFirstname: pc.pupil.firstname,
-            studentFirstname: pc.student.firstname
-        });
-        await sendTemplateMail(mail, pc.pupil.email);
-        await Notification.actionTaken(pc.pupil, "pupil_certificate_approval", {
-            uniqueId: `${pc.id}`,
-            certificateLink,
-            student: pc.student });
-    }
-
-    return pc;
-}
-
-const _templates: { [name: string]: { [key in Language | "default"]?: EJS.ClientFunction } } = {};
-
-/* Loads the template from the /assets folder, falls back to the default language if fallback is true */
-function loadTemplate(name, lang: Language, fallback: boolean = true): EJS.ClientFunction {
-    if (_templates[name] && _templates[name][lang]) {
-        return _templates[name][lang];
-    }
-
-    let path = `./assets/${name}.${lang}.html`;
-
-    if (existsSync(path)) {
-        const result = readFileSync(path, "utf8");
-        if (!_templates[name]) {
-            _templates[name] = {};
-        }
-
-        const compiled = EJS.compile(result);
-
-        _templates[name][lang] = compiled;
-        return compiled;
-    } else {
-        if (!fallback || lang === DefaultLanguage) {
-            throw new Error(`Cannot find template '${path}`);
-        }
-
-        return loadTemplate(name, DefaultLanguage, /*fallback:*/ false);
-    }
-}
-
-function getCertificateLink(req: Request, certificate: ParticipationCertificate, lang: Language) {
-    //parse hostname, to determine the base url which should be used for certificate links -> TODO: improve the link handling (with all that static links in various parts of the code...)
-    const parseResult = parseDomain(req.hostname);
-    let baseDomain = "corona-school.de"; //default
-    if (parseResult.type === ParseResultType.Listed) {
-        const { domain, topLevelDomains } = parseResult;
-        baseDomain = [domain, ...topLevelDomains].join(".");
-    }
-
-    return "http://verify." + baseDomain + "/" + certificate.uuid + "?lang=" + lang;
-}
-
-async function createPDFBinary(certificate: ParticipationCertificate, link: string, lang: Language): Promise<Buffer> {
-    const { student, pupil } = certificate;
-
-    const template = loadTemplate("certificateTemplate", lang);
-
-    let name = student.firstname + " " + student.lastname;
-
-    if (process.env.ENV == 'dev') {
-        name = `[TEST] ${name}`;
-    }
-
-    const result = template({
-        NAMESTUDENT: name,
-        NAMESCHUELER: pupil.firstname + " " + pupil.lastname,
-        DATUMHEUTE: moment().format("D.M.YYYY"),
-        SCHUELERSTART: moment(certificate.startDate, "X").format("D.M.YYYY"),
-        SCHUELERENDE: moment(certificate.endDate, "X").format("D.M.YYYY"),
-        SCHUELERFAECHER: certificate.subjects.split(","),
-        SCHUELERFREITEXT: certificate.categories.split(/(?:\r\n|\r|\n)/g),
-        SCHUELERPROWOCHE: certificate.hoursPerWeek,
-        SCHUELERGESAMT: certificate.hoursTotal,
-        MEDIUM: certificate.medium,
-        CERTLINK: link,
-        CERTLINKTEXT: link,
-        ONGOING: certificate.ongoingLessons,
-        SIGNATURE_PARENT: certificate.signatureParent?.toString("utf-8"),
-        SIGNATURE_PUPIL: certificate.signaturePupil?.toString("utf-8"),
-        SIGNATURE_LOCATION: certificate.signatureLocation,
-        SIGNATURE_DATE: certificate.signatureDate && moment(certificate.signatureDate).format("D.M.YYYY")
-    });
-
-    const ASSETS = __dirname + "/../../../../assets";
-    return await generatePDFFromHTMLString(result, {
-        includePaths: [
-            path.resolve(ASSETS)
-        ]
-    });
-}
-
-async function viewParticipationCertificate(certificate: ParticipationCertificate, lang: Language) {
-    let verificationTemplate = loadTemplate("verifiedCertificatePage", lang);
-
-    const screeningDate = (await certificate.student?.screening)?.createdAt;
-
-    return verificationTemplate({
-        NAMESTUDENT: certificate.student?.firstname + " " + certificate.student?.lastname,
-        NAMESCHUELER: certificate.pupil?.firstname + " " + certificate.pupil?.lastname,
-        DATUMHEUTE: moment(certificate.certificateDate).format("D.M.YYYY"),
-        SCHUELERSTART: moment(certificate.startDate).format("D.M.YYYY"),
-        SCHUELERENDE: moment(certificate.endDate).format("D.M.YYYY"),
-        SCHUELERFAECHER: certificate.subjects.split(","),
-        SCHUELERFREITEXT: certificate.categories.split(/(?:\r\n|\r|\n)/g),
-        SCHUELERPROWOCHE: certificate.hoursPerWeek,
-        SCHUELERGESAMT: certificate.hoursTotal,
-        MEDIUM: certificate.medium,
-        SCREENINGDATUM: screeningDate ? moment(screeningDate).format("D.M.YYYY") : "[UNBEKANNTES DATUM]",
-        ONGOING: certificate.ongoingLessons
-    });
-}
-
-async function signCertificate(req: Request, certificate: ParticipationCertificate, signatureParent: string | undefined, signaturePupil: string | undefined, signatureLocation: string) {
-    assert(signaturePupil || signatureParent, "Parent or Pupil signs certificate");
-    assert(!signaturePupil || signaturePupil.match(VALID_BASE64), "Pupil Signature is valid Base 64");
-    assert(!signatureParent || signatureParent.match(VALID_BASE64), "Parent Signature is valid Base 64");
-    assert(certificate.state === "awaiting-approval", "Certificate awaiting signature");
-    assert(signatureLocation, "Singature location must be set");
-
-    if (signatureParent) {
-        certificate.signatureParent = Buffer.from(signatureParent, "utf-8");
-    }
-
-    if (signaturePupil) {
-        certificate.signaturePupil = Buffer.from(signaturePupil, "utf-8");
-    }
-
-    certificate.signatureDate = new Date();
-    certificate.signatureLocation = signatureLocation;
-    certificate.state = "approved";
-
-    await getManager().save(ParticipationCertificate, certificate);
-
-    const rendered = await createPDFBinary(certificate, getCertificateLink(req, certificate, "de"), "de");
-
-    const certificateLink = createAutoLoginLink(certificate.student, `/settings`);
-    const mail = mailjetTemplates.CERTIFICATESIGNED({
-        certificateLink,
-        pupilFirstname: certificate.pupil.firstname,
-        studentFirstname: certificate.student.firstname
-    }, rendered.toString("base64"));
-    await sendTemplateMail(mail, certificate.student.email);
-    await Notification.actionTaken(certificate.student, "student_certificate_sign", {
-        uniqueId: `${certificate.id}`,
-        certificateLink,
-        pupil: certificate.pupil
-    });
-
 }

--- a/web/controllers/certificateController/index.ts
+++ b/web/controllers/certificateController/index.ts
@@ -106,7 +106,7 @@ export async function createCertificateEndpoint(req: Request, res: Response) {
 
         return res.json({ uuid: certificate.uuid, automatic });
     } catch (error) {
-        if(error instanceof CertificateError) {
+        if (error instanceof CertificateError) {
             return res.status(400).send(error.message);
         }
 
@@ -167,7 +167,7 @@ export async function getCertificateEndpoint(req: Request, res: Response) {
         });
         return res.end(pdf);
     } catch (error) {
-        if(error instanceof CertificateError) {
+        if (error instanceof CertificateError) {
             return res.status(400).send(error.message);
         }
 
@@ -220,7 +220,7 @@ export async function getCertificateConfirmationEndpoint(req: Request, res: Resp
 
         return res.send(confirmation);
     } catch (error) {
-        if(error instanceof CertificateError) {
+        if (error instanceof CertificateError) {
             return res.status(400).send(error.message);
         }
 
@@ -280,7 +280,7 @@ export async function signCertificateEndpoint(req: Request, res: Response) {
         await signCertificate(certificateId, signer, signatureParent, signaturePupil, signatureLocation);
         return res.send("Certificate signed");
     } catch (error) {
-        if(error instanceof CertificateError) {
+        if (error instanceof CertificateError) {
             return res.status(400).send(error.message);
         }
 


### PR DESCRIPTION
resolves https://github.com/corona-school/project-user/issues/373

Pupils can run this query:
```gql
query { 
	me {  
  	pupil { 
    	participationCertificatesToSign { 
      	id
        uuid
        subjects
        categories
        certificateDate
        startDate
        endDate
        hoursPerWeek
        hoursTotal
        medium
        ongoingLessons
        state
        signatureLocation
      }
    }
  }
}
```

Students can get the same through:
```gql
query { me { student { participationCertificates { ... } } }
```

Also adds three mutations:

```gql
mutation { 
	participationCertificateAsPDF(language: "de" uuid: "B2FEB67654")
}
```

```gql
mutation { 
	participationCertificateCreate(pupilId: 1 certificateData: { 
             endDate: 200000 
            subjects: "Deutsch,Englisch" 
            hoursPerWeek: 5 
            hoursTotal: 10 
            medium: "PC" 
            activities: "test"  
           ongoingLessons: true 
           state: "awaiting-approval"
      }
}
```

```gql
mutation { 
	participationCertificateSign(certificateId: "3C50B96CD7" signaturePupil: "data:image/png;base64,dGVzdA==" signatureLocation: "Karlsruhe")
}
```
[Playground](https://backend-feat-graphql-ce-cwoocn.herokuapp.com/apollo)
