### PR TITLE
HOTFIX: Fix /api/certificates endpoint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -48,6 +48,7 @@
         "max-statements-per-line": ["error", {"max": 1}],
         "newline-per-chained-call": "error",
         "lernfair-lint/graphql-authorized": "error",
-        "lernfair-lint/graphql-deferred-auth": "error"
+        "lernfair-lint/graphql-deferred-auth": "error",
+        "require-await": "warn"
     }
 }

--- a/web/controllers/certificateController/index.ts
+++ b/web/controllers/certificateController/index.ts
@@ -317,7 +317,7 @@ export async function getCertificatesEndpoint(req: Request, res: Response) {
 
 
     try {
-        const certificates = getCertificatesFor(res.locals.user);
+        const certificates = await getCertificatesFor(res.locals.user);
         return res.json({ certificates });
     } catch (error) {
         logger.error("Retrieving certificates for user failed with", error);


### PR DESCRIPTION
```
curl https://backend-hotfix-certific-sokjbo.herokuapp.com/api/certificates -H "token: authtokenP1"
```

now properly returns the certificates instead of an empty object. 

The bug has not yet arrived in PROD though but is currently only in DEV. 