### PR TITLE
GraphQL: Release Student / Pupil entities via match association

### DIFF
--- a/graphql/authorizations.ts
+++ b/graphql/authorizations.ts
@@ -1,4 +1,4 @@
-import { ModelsEnhanceMap, ResolversEnhanceMap } from "./generated";
+import { ModelsEnhanceMap, Pupil, ResolversEnhanceMap, Student } from "./generated";
 import { Authorized, createMethodDecorator } from "type-graphql";
 
 import { AuthChecker } from "type-graphql";
@@ -103,6 +103,9 @@ const adminOrOwner = [Authorized(Role.ADMIN, Role.OWNER)];
 const onlyOwner = [Authorized(Role.OWNER)];
 const nobody = [Authorized(Role.NOBODY)];
 
+/* Utility to ensure that field authorizations are present except for the public fields listed */
+const withPublicFields = <Entity = "never", PublicFields extends keyof Entity = never> (otherFields: { [key in Exclude<keyof Entity, PublicFields>]: PropertyDecorator[] }) => otherFields;
+
 /* Although we do not expose all Prisma entities, we make sure authorization is present for all queries and mutations
    We use query and mutation authorizations as our main authorization strategy,
     as users usually have access to none or all fields.
@@ -156,17 +159,118 @@ export const authorizationEnhanceMap: Required<ResolversEnhanceMap> = {
    For various reasons query authorizations should be preferred, and field authorizations should only be used for
     extra sensitive data */
 export const authorizationModelEnhanceMap: ModelsEnhanceMap = {
+    // ATTENTION: Pupil entities can be seen by other users, e.g. through the Match -> pupil edge
     Pupil: {
-        fields: {
+        fields: withPublicFields<Pupil, "id" | "firstname" | "lastname" | "active" | "grade" | "isJufoParticipant" | "isParticipant" | "isProjectCoachee" | "isPupil" | "languages" | "projectFields">({
+            // authentication data shall only be accessible to the user itself
             authToken: onlyOwner,
-            email: adminOrOwner
-        }
+            authTokenSent: onlyOwner,
+            authTokenUsed: onlyOwner,
+
+            email: adminOrOwner,
+            verification: adminOrOwner,
+            verifiedAt: adminOrOwner,
+            wix_id: adminOrOwner,
+            newsletter: adminOrOwner,
+            openMatchRequestCount: adminOrOwner,
+            openProjectMatchRequestCount: adminOrOwner,
+            matchingPriority: adminOrOwner,
+            learningGermanSince: adminOrOwner,
+            createdAt: adminOrOwner,
+            registrationSource: adminOrOwner,
+            school: adminOrOwner,
+            schoolId: adminOrOwner,
+            schooltype: adminOrOwner,
+            state: adminOrOwner,
+            teacherEmailAddress: adminOrOwner,
+
+            // these should look differently in a clean data model
+            // by blacklisting them we prevent accidental usage
+            lastUpdatedSettingsViaBlocker: nobody,
+            msg: nobody,
+            projectMemberCount: nobody,
+            updatedAt: nobody,
+            wix_creation_date: nobody,
+
+            // these have cleaner variants in the data model:
+            subjects: nobody, // -> subjectsFormatted
+
+            // these are associations which are wrongly in the TypeGraphQL generation
+            // we do not have them enabled, also they are very technical and shall be replaced by semantic ones
+            participation_certificate: nobody,
+            project_match: nobody,
+            pupil_tutoring_interest_confirmation_request: nobody,
+            course_attendance_log: nobody,
+            course_participation_certificate: nobody,
+            subcourse_participants_pupil: nobody,
+            subcourse_waiting_list_pupil: nobody,
+            match: nobody
+        })
     },
+
+    // ATTENTION: Student entities can be seen by other users, e.g. through the Match -> student edge
     Student: {
-        fields: {
+        fields: withPublicFields<Student, "id" | "firstname" | "lastname" | "active" | "isStudent" | "isInstructor" | "isProjectCoach" | "isUniversityStudent" | "languages">({
+            // authentication data shall only be accessible to the user itself
             authToken: onlyOwner,
-            email: adminOrOwner
-        }
+            authTokenSent: onlyOwner,
+            authTokenUsed: onlyOwner,
+
+            email: adminOrOwner,
+            phone: adminOrOwner,
+            verification: adminOrOwner,
+            verifiedAt: adminOrOwner,
+            newsletter: adminOrOwner,
+            openMatchRequestCount: adminOrOwner,
+            state: adminOrOwner,
+            university: adminOrOwner,
+            module: adminOrOwner,
+            moduleHours: adminOrOwner,
+            createdAt: adminOrOwner,
+            openProjectMatchRequestCount: adminOrOwner,
+
+            // these have cleaner variants in the data model:
+            subjects: nobody, // -> subjectsFormatted
+
+            // these should look differently in a clean data model
+            // by blacklisting them we prevent accidental usage
+            msg: nobody,
+            feedback: nobody,
+            wasJufoParticipant: nobody,
+            hasJufoCertificate: nobody,
+            jufoPastParticipationConfirmed: nobody,
+            jufoPastParticipationInfo: nobody,
+            lastSentInstructorScreeningInvitationDate: nobody,
+            lastSentJufoAlumniScreeningInvitationDate: nobody,
+            lastSentScreeningInvitationDate: nobody,
+            lastUpdatedSettingsViaBlocker: nobody,
+            registrationSource: nobody,
+            sentInstructorScreeningReminderCount: nobody,
+            sentJufoAlumniScreeningReminderCount: nobody,
+            sentScreeningReminderCount: nobody,
+            supportsInDaZ: nobody,
+            updatedAt: nobody,
+            wix_creation_date: nobody,
+            wix_id: nobody,
+
+            // these are associations which are wrongly in the TypeGraphQL generation
+            // we do not have them enabled, also they are very technical and shall be replaced by semantic ones
+            screening: nobody,
+            lecture: nobody,
+            match: nobody,
+            participation_certificate: nobody,
+            project_coaching_screening: nobody,
+            project_field_with_grade_restriction: nobody,
+            project_match: nobody,
+            subcourse_instructors_student: nobody,
+            course: nobody,
+            course_guest: nobody,
+            course_instructors_student: nobody,
+            course_participation_certificate: nobody,
+            jufo_verification_transmission: nobody,
+            expert_data: nobody,
+            instructor_screening: nobody
+        })
 
     },
     Participation_certificate: {

--- a/graphql/match/fields.ts
+++ b/graphql/match/fields.ts
@@ -12,7 +12,7 @@ import { Subject } from "../types/subject";
 @Resolver(of => Match)
 export class ExtendedFieldsMatchResolver {
     @FieldResolver(returns => Pupil)
-    @Authorized(Role.ADMIN)
+    @Authorized(Role.ADMIN, Role.OWNER)
     @LimitEstimated(1)
     async pupil(@Root() match: Match) {
         return await prisma.pupil.findUnique({
@@ -21,7 +21,7 @@ export class ExtendedFieldsMatchResolver {
     }
 
     @FieldResolver(returns => Student)
-    @Authorized(Role.ADMIN)
+    @Authorized(Role.ADMIN, Role.OWNER)
     @LimitEstimated(1)
     async student(@Root() match: Match) {
         return await prisma.student.findUnique({
@@ -31,6 +31,7 @@ export class ExtendedFieldsMatchResolver {
 
     @FieldResolver(returns => [Subject])
     @Authorized(Role.ADMIN)
+    @LimitEstimated(1)
     async subjectsFormatted(@Root() match: Match) {
         const student = await getStudent(match.studentId);
         const pupil = await getPupil(match.pupilId);

--- a/graphql/pupil/fields.ts
+++ b/graphql/pupil/fields.ts
@@ -1,4 +1,4 @@
-import { Subcourse, Pupil, Concrete_notification, Log, Pupil_tutoring_interest_confirmation_request as TutoringInterestConfirmation, Participation_certificate as ParticipationCertificate } from "../generated";
+import { Subcourse, Pupil, Concrete_notification, Log, Pupil_tutoring_interest_confirmation_request as TutoringInterestConfirmation, Participation_certificate as ParticipationCertificate, Match } from "../generated";
 import { Authorized, Field, FieldResolver, Resolver, Root } from "type-graphql";
 import { prisma } from "../../common/prisma";
 import { Role } from "../authorizations";
@@ -57,13 +57,14 @@ export class ExtendFieldsPupilResolver {
     }
 
     @FieldResolver(type => [Subject])
-    @Authorized(Role.ADMIN)
+    @Authorized(Role.USER)
     async subjectsFormatted(@Root() pupil: Required<Pupil>) {
         return parseSubjectString(pupil.subjects);
     }
 
     @FieldResolver(type => TutoringInterestConfirmation, { nullable: true })
-    @Authorized(Role.ADMIN)
+    @Authorized(Role.ADMIN, Role.OWNER)
+    @LimitEstimated(1)
     async tutoringInterestConfirmation(@Root() pupil: Required<Pupil>) {
         return await prisma.pupil_tutoring_interest_confirmation_request.findFirst({
             where: { pupilId: pupil.id }
@@ -72,8 +73,18 @@ export class ExtendFieldsPupilResolver {
 
     @FieldResolver(type => [ParticipationCertificate])
     @Authorized(Role.ADMIN, Role.OWNER)
+    @LimitEstimated(10)
     async participationCertificatesToSign(@Root() pupil: Required<Pupil>) {
         return await prisma.participation_certificate.findMany({
+            where: { pupilId: pupil.id }
+        });
+    }
+
+    @FieldResolver(type => [Match])
+    @Authorized(Role.ADMIN, Role.OWNER)
+    @LimitEstimated(10)
+    async matches(@Root() pupil: Required<Pupil>) {
+        return await prisma.match.findMany({
             where: { pupilId: pupil.id }
         });
     }

--- a/graphql/student/fields.ts
+++ b/graphql/student/fields.ts
@@ -4,7 +4,7 @@ import { prisma } from "../../common/prisma";
 import { Role } from "../authorizations";
 import { LimitEstimated } from "../complexity";
 import { Subject } from "../types/subject";
-import { parseSubjectString } from "common/util/subjectsutils";
+import { parseSubjectString } from "../../common/util/subjectsutils";
 
 @Resolver(of => Student)
 export class ExtendFieldsStudentResolver {

--- a/graphql/student/fields.ts
+++ b/graphql/student/fields.ts
@@ -1,7 +1,10 @@
-import { Student, Participation_certificate as ParticipationCertificate } from "../generated";
+import { Student, Participation_certificate as ParticipationCertificate, Match } from "../generated";
 import { Authorized, Field, FieldResolver, Resolver, Root } from "type-graphql";
 import { prisma } from "../../common/prisma";
 import { Role } from "../authorizations";
+import { LimitEstimated } from "../complexity";
+import { Subject } from "../types/subject";
+import { parseSubjectString } from "common/util/subjectsutils";
 
 @Resolver(of => Student)
 export class ExtendFieldsStudentResolver {
@@ -12,5 +15,20 @@ export class ExtendFieldsStudentResolver {
         return await prisma.participation_certificate.findMany({
             where: { studentId: student.id }
         });
+    }
+
+    @FieldResolver(type => [Match])
+    @Authorized(Role.ADMIN, Role.OWNER)
+    @LimitEstimated(10)
+    async matches(@Root() student: Required<Student>) {
+        return await prisma.match.findMany({
+            where: { studentId: student.id }
+        });
+    }
+
+    @FieldResolver(type => [Subject])
+    @Authorized(Role.USER)
+    async subjectsFormatted(@Root() pupil: Required<Student>) {
+        return parseSubjectString(pupil.subjects);
     }
 }

--- a/graphql/types/subject.ts
+++ b/graphql/types/subject.ts
@@ -5,7 +5,7 @@ class Range { // GraphQL Type for common/entity/Student -> Subject.range
     @Field(type => Int)
     min: number;
     @Field(type => Int)
-    field: number;
+    max: number;
 }
 
 @ObjectType()


### PR DESCRIPTION
Pupils can see the public data of their matched students and vice versa. 

```gql
query { 
	me { 
  	pupil { 
    	matches { 
      	id 
        pupil { 
        	id
               authToken # as this is a self reference, the pupil can also see all their data here
        }
        student { 
               # for the student only public fields can be seen
        	id
               firstname
               lastname
               languages
               subjectsFormatted { name grade { min max }}
        }
      }
    }
  }
}
```