### PR TITLE
Send out reminders hourly

### DIFF
--- a/jobs/list.ts
+++ b/jobs/list.ts
@@ -33,5 +33,6 @@ export const allJobs: CSCronJob[] = [
     // every day at midnight/beginning
     { cronTime: "00 00 00 * * *", jobFunction: jufoVerificationInfo},
     { cronTime: "00 30 00 * * 0", jobFunction: deactivateMissingCoc},
-    { cronTime: "00 00 09 * * *", jobFunction: Notification.checkReminders }
+    // every hour during day
+    { cronTime: "00 00 09-17 * * *", jobFunction: Notification.checkReminders }
 ];


### PR DESCRIPTION
That way reminders are easier to test, hourly reminders actually work as scheduled and the workload is distributed over the day (though that shouldn't matter anyways).