### PR TITLE
Fix Mailjet Crash - Pass matchDate as string

### DIFF
--- a/common/administration/match-making/tutoring/matches/notify/mail.ts
+++ b/common/administration/match-making/tutoring/matches/notify/mail.ts
@@ -44,7 +44,7 @@ export async function mailNotifyTuteeAboutMatch(match: Match, manager: EntityMan
         callURL,
         firstMatch,
         matchHash,
-        matchDate: +match.createdAt
+        matchDate: "" + (+match.createdAt)
     });
 }
 
@@ -71,6 +71,6 @@ export async function mailNotifyTutorAboutMatch(match: Match, manager: EntityMan
         callURL,
         firstMatch,
         matchHash,
-        matchDate: +match.createdAt
+        matchDate: "" + (+match.createdAt)
     });
 }

--- a/common/match/create.ts
+++ b/common/match/create.ts
@@ -61,7 +61,8 @@ export async function createMatch(pupil: Pupil, student: Student) {
 
 
     const matchHash = getMatchHash(match);
-    const matchDate = +match.createdAt;
+    // NOTE: JSON numbers which are larger than 32 bit integers crash mailjet internally, so strings need to be used here
+    const matchDate = "" + (+match.createdAt);
 
     await sendTemplateMail(tutorMail, student.email);
     await Notification.actionTaken(student, "tutor_matching_success", {

--- a/common/match/dissolve.ts
+++ b/common/match/dissolve.ts
@@ -33,7 +33,7 @@ export async function dissolveMatch(match: Match, dissolveReason: number, dissol
     const student = await prisma.student.findUnique({ where: { id: match.studentId }});
     const pupil = await prisma.pupil.findUnique({ where: { id: match.pupilId }});
     const matchHash = getMatchHash(match);
-    const matchDate = +match.createdAt;
+    const matchDate = "" + (+match.createdAt);
     const uniqueId = "" + match.id;
 
     await Notification.actionTaken(student, "tutor_match_dissolved", { pupil, matchHash, matchDate, uniqueId });

--- a/common/notification/ACTIONS.md
+++ b/common/notification/ACTIONS.md
@@ -488,7 +488,7 @@ Match was dissolved.
 {
     student: Student;
     matchHash: string;
-    matchDate: number;
+    matchDate: number as string;
 }
 ```
 
@@ -519,7 +519,7 @@ Match was dissolved.
 {
     pupil: Pupil;
     matchHash: string;
-    matchDate: number;
+    matchDate: number as string;
 }
 ```
 
@@ -552,7 +552,7 @@ Send mail to tutee to notify after matching
     subjects: string,
     callURL: string,
     matchHash: string,
-    matchDate: number
+    matchDate: number as string
 }
 ```
 
@@ -571,7 +571,7 @@ Send mail to tutor to notify after matching
     subjects: string,
     callURL: string,
     matchHash: string,
-    matchDate: number
+    matchDate: number as string
 }
 ```
 

--- a/web/controllers/matchController/index.ts
+++ b/web/controllers/matchController/index.ts
@@ -163,7 +163,7 @@ export async function dissolveMatch(match: Match, reason: number, dissolver: Per
         }
 
         const matchHash = getMatchHash(match);
-        const matchDate = +match.createdAt;
+        const matchDate = "" + (+match.createdAt);
         const uniqueId = "" + match.id;
 
         await Notification.actionTaken(match.pupil, "tutee_match_dissolved", {


### PR DESCRIPTION
Large numbers seem to crash Mailjet's API internally, c.f. https://twitter.com/mailjet/status/1270003900528066567 (great that this is only documented on Twitter ...)