### PR TITLE
Fix: Persist deactivation before sending out match dissolve mails

### DIFF
--- a/common/notification/bulk.ts
+++ b/common/notification/bulk.ts
@@ -73,6 +73,7 @@ function addBulkAction<Entity>(action: BulkAction<Entity>) {
 
 /* -------------------------------------- Actions ------------------------------------------------------------------- */
 
+/* Run on 22.01.2022
 const MATCH_SURVEYS_INTRODUCTION = new Date(1642286012775);
 
 addBulkAction<{ id: number, pupilId: number, studentId: number, createdAt: Date, uuid: string }>({
@@ -110,3 +111,4 @@ addBulkAction<{ id: number, pupilId: number, studentId: number, createdAt: Date,
         matchDate: "" + (+match.createdAt)
     })
 });
+*/

--- a/web/controllers/userController/index.ts
+++ b/web/controllers/userController/index.ts
@@ -1030,6 +1030,7 @@ async function putActive(wix_id: string, active: boolean, person: Pupil | Studen
             // Deactivate if active
             logger.info("Deactivating person " + person.firstname + " " + person.lastname);
             person.active = false;
+            await entityManager.save(type, person);
 
             // Step 1: Dissolve all matches
             let options;
@@ -1095,10 +1096,6 @@ async function putActive(wix_id: string, active: boolean, person: Pupil | Studen
                 logger.info("Courses user was removed from (as an instructor): ", debugRemovedFrom);
                 logger.info("Courses that were cancelled (user was the sole instructor): ", debugCancelledCourses);
             }
-
-
-
-            await entityManager.save(type, person);
 
             await Notification.cancelRemindersFor(person);
 


### PR DESCRIPTION
The `dissolveMatch` function reads the user record from the DB, thus the account deactivation must be persisted before dissolving all matches. 