### PR TITLE
Subcourse messaging, find further instructors, manage instructors

### DIFF
--- a/common/attachments/index.ts
+++ b/common/attachments/index.ts
@@ -7,6 +7,13 @@ import { getUserIdTypeORM } from '../user';
 import { friendlyFileSize } from '../util/basic';
 import { Attachment } from '../entity/Attachment';
 
+export interface File {
+    originalname: string;
+    size: number;
+    buffer: Buffer;
+    mimetype: string;
+}
+
 export interface AttachmentGroup {
     attachmentGroupId: string;
     attachmentListHTML: string;
@@ -21,7 +28,7 @@ export interface AttachmentGroup {
  * @param   attachmentGroupId  Unique per group of attachments (per message)
  * @return  attachmentId       Unique per individual attachment
  */
-export async function createAttachment(file: Express.Multer.File, uploader: Student | Pupil, attachmentGroupId: string) {
+export async function createAttachment(file: File, uploader: Student | Pupil, attachmentGroupId: string) {
     let attachmentId = uuid().toString();
     await prisma.attachment.create({
         data: {

--- a/common/courses/contact.ts
+++ b/common/courses/contact.ts
@@ -1,0 +1,122 @@
+import { course as Course, subcourse as Subcourse, pupil as Pupil, student as Student } from '@prisma/client';
+import { Decision } from '../util/decision';
+import { getManager } from 'typeorm';
+import { File } from '../attachments';
+import { Pupil as TypeORMPupil } from '../entity/Pupil';
+import { Student as TypeORMStudent } from '../entity/Student';
+import * as Notification from '../notification';
+import { prisma } from '../prisma';
+import { getLogger } from 'log4js';
+
+const logger = getLogger('CourseContact');
+
+async function courseOver(subcourse: Subcourse) {
+    const lastLecture = await prisma.lecture.findFirst({
+        where: { subcourseId: subcourse.id },
+        orderBy: { start: 'desc' },
+    });
+
+    if (!lastLecture) {
+        return false;
+    }
+
+    const twoWeeksAgo = new Date();
+    twoWeeksAgo.setDate(twoWeeksAgo.getDate() - 14);
+
+    return lastLecture.start < twoWeeksAgo;
+}
+
+export async function canContactInstructors(course: Course, subcourse: Subcourse): Promise<Decision> {
+    if (!course.allowContact) {
+        return { allowed: false, reason: 'contact-not-allowed' };
+    }
+
+    if (await courseOver(subcourse)) {
+        return { allowed: false, reason: 'course-ended' };
+    }
+
+    return { allowed: true };
+}
+
+export async function contactInstructors(course: Course, subcourse: Subcourse, pupil: Pupil, title: string, body: string, files: File[]) {
+    const decision = await canContactInstructors(course, subcourse);
+    if (!decision.allowed) {
+        throw new Error(`Not allowed to contact instructors - ${decision.reason}`);
+    }
+
+    const typeORMPupil = await getManager().findOneOrFail(TypeORMPupil, pupil.id);
+
+    const instructors = (
+        await prisma.subcourse_instructors_student.findMany({
+            where: { subcourseId: subcourse.id },
+            select: { student: true },
+        })
+    ).map((it) => it.student);
+
+    let attachmentGroup = await Notification.createAttachments(files, typeORMPupil);
+
+    await Promise.all(
+        instructors.map(async (instructor) => {
+            await Notification.actionTaken(
+                instructor,
+                'instructor_course_participant_message',
+                {
+                    instructorFirstName: instructor.firstname,
+                    participantFirstName: pupil.firstname,
+                    courseName: course.name,
+                    messageTitle: title,
+                    messageBody: body,
+                    participantMail: pupil.email,
+                },
+                attachmentGroup
+            );
+        })
+    );
+
+    logger.info(`Pupil(${pupil.id}) contacted the instructors of Subcourse(${subcourse.id}) with title '${title}' and message '${body}'`);
+}
+
+export async function contactParticipants(
+    course: Course,
+    subcourse: Subcourse,
+    instructor: Student,
+    title: string,
+    body: string,
+    files: File[],
+    participants: number[]
+) {
+    if (await courseOver(subcourse)) {
+        throw new Error(`Cannot contact participants as the course is over`);
+    }
+
+    const student = await getManager().findOneOrFail(TypeORMStudent, instructor.id);
+    let attachmentGroup = await Notification.createAttachments(files, student);
+
+    const selectedParticipants = await prisma.pupil.findMany({
+        where: {
+            active: true,
+            id: { in: participants },
+            subcourse_participants_pupil: { some: { subcourseId: subcourse.id } },
+        },
+    });
+
+    await Promise.all(
+        selectedParticipants.map(async (participant) => {
+            await Notification.actionTaken(
+                participant,
+                'participant_course_message',
+                {
+                    courseName: course.name,
+                    participantFirstName: participant.firstname,
+                    instructorFirstName: student.firstname,
+                    messageTitle: title,
+                    messageBody: body,
+                    instructorMail: student.email,
+                },
+                attachmentGroup
+            );
+        })
+    );
+
+    logger.info(`Student(${student.id}) contacted participants of the Subcourse(${subcourse.id}) with title '${title}' and message '${body}'`);
+}

--- a/common/notification/index.ts
+++ b/common/notification/index.ts
@@ -6,7 +6,7 @@ import { getUserIdTypeORM, getUserTypeORM, getFullName, getUser, getUserForTypeO
 import { getLogger } from 'log4js';
 import { Student } from '../entity/Student';
 import { v4 as uuid } from 'uuid';
-import { AttachmentGroup, createAttachment, getAttachmentGroupByAttachmentGroupId, getAttachmentListHTML } from '../attachments';
+import { AttachmentGroup, createAttachment, File, getAttachmentGroupByAttachmentGroupId, getAttachmentListHTML } from '../attachments';
 import { Pupil } from '../entity/Pupil';
 import { assert } from 'console';
 import { triggerHook } from './hook';
@@ -311,7 +311,7 @@ async function deliverNotification(
  * @param uploader  User that intends to upload the files.
  * @return          Object with attachmentListHTML, attachmentGroupId, and attachmentIds
  */
-export async function createAttachments(files: Express.Multer.File[], uploader: Student | Pupil): Promise<AttachmentGroup | null> {
+export async function createAttachments(files: File[], uploader: Student | Pupil): Promise<AttachmentGroup | null> {
     if (files.length > 0) {
         let attachmentGroupId = uuid().toString();
 

--- a/graphql/certificate/mutations.ts
+++ b/graphql/certificate/mutations.ts
@@ -79,7 +79,7 @@ export class MutateParticipationCertificateResolver {
 
         const student = await getSessionStudent(context);
         const pdf = await getCertificatePDF(uuid, student, language as Language);
-        const file = addFile({ buffer: pdf, mimetype: 'application/pdf', originalname: 'Zertifikat.pdf' });
+        const file = addFile({ buffer: pdf, mimetype: 'application/pdf', originalname: 'Zertifikat.pdf', size: pdf.length });
         return getFileURL(file);
     }
 }

--- a/graphql/course/mutations.ts
+++ b/graphql/course/mutations.ts
@@ -149,7 +149,7 @@ export class MutateCourseResolver {
 
         await getStudent(studentId);
         await prisma.course_instructors_student.create({ data: { courseId, studentId } });
-        logger.info(`Student (${studentId}) was added as an instructor to course ${courseId} by User(${context.user!.userID})`);
+        logger.info(`Student (${studentId}) was added as an instructor to Course(${courseId}) by User(${context.user!.userID})`);
         return true;
     }
 
@@ -161,7 +161,7 @@ export class MutateCourseResolver {
         await getStudent(studentId);
 
         await prisma.course_instructors_student.delete({ where: { courseId_studentId: { courseId, studentId } } });
-        logger.info(`Student (${studentId}) was deleted from course ${courseId} by User(${context.user!.userID})`);
+        logger.info(`Student (${studentId}) was deleted from Course(${courseId}) by User(${context.user!.userID})`);
         return true;
     }
 

--- a/graphql/course/mutations.ts
+++ b/graphql/course/mutations.ts
@@ -142,24 +142,29 @@ export class MutateCourseResolver {
     }
 
     @Mutation((returns) => Boolean)
-    @Authorized(Role.ADMIN)
-    async courseAddInstructor(@Arg('courseId') courseId: number, @Arg('studentId') studentId: number): Promise<boolean> {
-        await getCourse(courseId);
+    @AuthorizedDeferred(Role.ADMIN, Role.OWNER)
+    async courseAddInstructor(@Ctx() context: GraphQLContext, @Arg('courseId') courseId: number, @Arg('studentId') studentId: number): Promise<boolean> {
+        const course = await getCourse(courseId);
+        await hasAccess(context, 'Course', course);
+
         await getStudent(studentId);
         await prisma.course_instructors_student.create({ data: { courseId, studentId } });
-        logger.info(`Student (${studentId}) was added as an instructor to course ${courseId}`);
+        logger.info(`Student (${studentId}) was added as an instructor to course ${courseId} by User(${context.user!.userID})`);
         return true;
     }
 
     @Mutation((returns) => Boolean)
-    @Authorized(Role.ADMIN)
-    async courseDeleteInstructor(@Arg('courseId') courseId: number, @Arg('studentId') studentId: number): Promise<boolean> {
-        await getCourse(courseId);
+    @AuthorizedDeferred(Role.ADMIN, Role.INSTRUCTOR)
+    async courseDeleteInstructor(@Ctx() context: GraphQLContext, @Arg('courseId') courseId: number, @Arg('studentId') studentId: number): Promise<boolean> {
+        const course = await getCourse(courseId);
+        await hasAccess(context, 'Course', course);
         await getStudent(studentId);
+
         await prisma.course_instructors_student.delete({ where: { courseId_studentId: { courseId, studentId } } });
-        logger.info(`Student (${studentId}) was deleted from course ${courseId}`);
+        logger.info(`Student (${studentId}) was deleted from course ${courseId} by User(${context.user!.userID})`);
         return true;
     }
+
     @Mutation((returns) => Boolean)
     @AuthorizedDeferred(Role.ADMIN, Role.OWNER)
     async courseSubmit(@Ctx() context: GraphQLContext, @Arg('courseId') courseId: number): Promise<boolean> {

--- a/graphql/files.ts
+++ b/graphql/files.ts
@@ -30,19 +30,19 @@
   ensuring availability of the overall system while sacrificing availability of file handling.
 */
 
-
-import { v4 as uuid } from "uuid";
-import { getLogger } from "log4js";
+import { v4 as uuid } from 'uuid';
+import { getLogger } from 'log4js';
 
 const FILE_STORAGE_DURATION = 10 * 60 * 1000; // After 10 Minutes, files are removed from the store
 const FILE_STORAGE_MAX_SIZE = 20; // Prevent file storage from growing infinitely, potentially leading to OOM
 
-const log = getLogger("GraphQL Files");
+const log = getLogger('GraphQL Files');
 
 export interface File {
     originalname: string; //	Name of the file on the user's computer
     mimetype: string;
     buffer: Buffer; // of UTF-8 encoded data
+    size: number;
 }
 
 export type FileID = string;

--- a/graphql/subcourse/fields.ts
+++ b/graphql/subcourse/fields.ts
@@ -318,7 +318,7 @@ export class ExtendedFieldsSubcourseResolver {
         return await canPublish(subcourse);
     }
 
-    @FieldResolver((returns) => Boolean)
+    @FieldResolver((returns) => Decision)
     @Authorized(Role.PARTICIPANT, Role.INSTRUCTOR)
     async canContactInstructor(@Root() subcourse: Required<Subcourse>) {
         const course = await getCourse(subcourse.courseId);

--- a/graphql/subcourse/fields.ts
+++ b/graphql/subcourse/fields.ts
@@ -11,6 +11,7 @@ import { LimitedQuery, LimitEstimated } from '../complexity';
 import { GraphQLContext } from '../context';
 import { Bbb_meeting as BBBMeeting, Course, Lecture, Pupil, pupil_schooltype_enum, Subcourse } from '../generated';
 import { Decision } from '../types/reason';
+import { Instructor } from '../types/instructor';
 
 @ObjectType()
 class Participant {
@@ -36,18 +37,6 @@ class OtherParticipant {
     firstname: string;
     @Field((_type) => String)
     grade: string;
-    @Field((_type) => String)
-    aboutMe: string;
-}
-
-@ObjectType()
-class Instructor {
-    @Field((_type) => Int)
-    id: number;
-    @Field((_type) => String)
-    firstname: string;
-    @Field((_type) => String)
-    lastname: string;
     @Field((_type) => String)
     aboutMe: string;
 }

--- a/graphql/subcourse/fields.ts
+++ b/graphql/subcourse/fields.ts
@@ -12,6 +12,8 @@ import { GraphQLContext } from '../context';
 import { Bbb_meeting as BBBMeeting, Course, Lecture, Pupil, pupil_schooltype_enum, Subcourse } from '../generated';
 import { Decision } from '../types/reason';
 import { Instructor } from '../types/instructor';
+import { canContactInstructors } from '../../common/courses/contact';
+import { getCourse } from '../util';
 
 @ObjectType()
 class Participant {
@@ -314,5 +316,12 @@ export class ExtendedFieldsSubcourseResolver {
     @Authorized(Role.ADMIN, Role.OWNER)
     async canPublish(@Root() subcourse: Required<Subcourse>) {
         return await canPublish(subcourse);
+    }
+
+    @FieldResolver((returns) => Boolean)
+    @Authorized(Role.PARTICIPANT, Role.INSTRUCTOR)
+    async canContactInstructor(@Root() subcourse: Required<Subcourse>) {
+        const course = await getCourse(subcourse.courseId);
+        return await canContactInstructors(course, subcourse);
     }
 }

--- a/graphql/subcourse/mutations.ts
+++ b/graphql/subcourse/mutations.ts
@@ -428,7 +428,7 @@ export class MutateSubcourseResolver {
         @Arg('subcourseId', (type) => Int) subcourseId: number,
         @Arg('title') title: string,
         @Arg('body') body: string,
-        @Arg('files') fileIDs: string[]
+        @Arg('fileIDs', (type) => [String]) fileIDs: string[]
     ) {
         const subcourse = await prisma.subcourse.findUniqueOrThrow({
             where: { id: subcourseId },
@@ -451,7 +451,7 @@ export class MutateSubcourseResolver {
         @Arg('subcourseId', (type) => Int) subcourseId: number,
         @Arg('title') title: string,
         @Arg('body') body: string,
-        @Arg('fileIDs') fileIDs: string[],
+        @Arg('fileIDs', (type) => [String]) fileIDs: string[],
         @Arg('participantIDs', (type) => [Int]) participantIDs: number[]
     ) {
         const subcourse = await prisma.subcourse.findUniqueOrThrow({ where: { id: subcourseId } });

--- a/graphql/types/instructor.ts
+++ b/graphql/types/instructor.ts
@@ -1,0 +1,13 @@
+import { ObjectType, Field, Int } from 'type-graphql';
+
+@ObjectType()
+export class Instructor {
+    @Field((_type) => Int)
+    id: number;
+    @Field((_type) => String)
+    firstname: string;
+    @Field((_type) => String)
+    lastname: string;
+    @Field((_type) => String)
+    aboutMe: string;
+}


### PR DESCRIPTION
(1) Instructors can find other instructors:
```gql
query { 
  otherInstructors(take: 10 skip: 0 search: "") { 
    id
    firstname
    lastname
  }
}
```
(2) Instructors can add / remove other instructors:
```gql
# Course
mutation { 
  courseAddInstructor(studentId: 2 courseId: 3)
}
mutation { 
  courseDeleteInstructor(studentId: 2 courseId: 3)
}

# Subcourse
mutation { 
  subcourseAddInstructor(studentId: 2 subcourseId: 11)
}
mutation { 
  subcourseDeleteInstructor(studentId: 2 subcourseId: 11)
}
```

(3) Instructors can contact participants:
```gql
mutation { 
	subcourseNotifyParticipants(subcourseId: 11 title: "Test" body: "Test" fileIDs: [] participantIDs: [1])
}
```

(4) Participants can contact instructors, if allowed:
```gql
query { 
  me { 
    pupil { 
      subcoursesJoined { 
      	canContactInstructor { allowed reason }
      }
    }
  }
}

mutation { 
	subcourseNotifyInstructor(subcourseId: 11 title: "Test" body: "Test" fileIDs: [])
}
```