### PR TITLE
Retool Login to Backend

### DIFF
--- a/graphql/authentication.ts
+++ b/graphql/authentication.ts
@@ -264,12 +264,22 @@ export class AuthenticationResolver {
 
     @Authorized(Role.UNAUTHENTICATED)
     @Mutation((returns) => Boolean)
-    async loginPassword(@Ctx() context: GraphQLContext, @Arg('email') email: string, @Arg('password') password: string) {
+    async loginPassword(
+        @Ctx() context: GraphQLContext,
+        @Arg('email') email: string,
+        @Arg('password') password: string,
+        @Arg('storeCookie', { nullable: true }) storeCookie: boolean = false
+    ) {
         ensureSession(context);
 
         try {
             const user = await loginPassword(email, password);
             await loginAsUser(user, context);
+
+            if (storeCookie) {
+                context.setCookie('LERNFAIR_SESSION', context.sessionToken);
+            }
+
             return true;
         } catch (error) {
             throw new AuthenticationError('Invalid E-Mail or Password');

--- a/graphql/authentication.ts
+++ b/graphql/authentication.ts
@@ -133,8 +133,10 @@ function ensureSession(context: GraphQLContext) {
     }
 }
 
-export async function loginAsUser(user: User, context: GraphQLContext) {
-    ensureSession(context);
+export async function loginAsUser(user: User, context: GraphQLContext, noSession = false) {
+    if (!noSession) {
+        ensureSession(context);
+    }
 
     context.user = { ...user, roles: [] };
 
@@ -152,8 +154,10 @@ export async function loginAsUser(user: User, context: GraphQLContext) {
         await evaluateScreenerRoles(user, context);
     }
 
-    userSessions.set(context.sessionToken, context.user);
-    logger.info(`[${context.sessionToken}] User(${user.userID}) successfully logged in`);
+    if (!noSession) {
+        userSessions.set(context.sessionToken, context.user);
+        logger.info(`[${context.sessionToken}] User(${user.userID}) successfully logged in`);
+    }
 }
 
 @Resolver((of) => UserType)

--- a/graphql/authentication.ts
+++ b/graphql/authentication.ts
@@ -264,25 +264,20 @@ export class AuthenticationResolver {
 
     @Authorized(Role.UNAUTHENTICATED)
     @Mutation((returns) => Boolean)
-    async loginPassword(
-        @Ctx() context: GraphQLContext,
-        @Arg('email') email: string,
-        @Arg('password') password: string,
-        @Arg('storeCookie', { nullable: true }) storeCookie: boolean = false
-    ) {
-        if (!storeCookie) {
-            ensureSession(context);
-        } else {
-            context.sessionToken = suggestToken();
-        }
+    createCookieSession(@Ctx() context: GraphQLContext) {
+        context.sessionToken = suggestToken();
+        context.setCookie('LERNFAIR_SESSION', context.sessionToken);
+        return true;
+    }
+
+    @Authorized(Role.UNAUTHENTICATED)
+    @Mutation((returns) => Boolean)
+    async loginPassword(@Ctx() context: GraphQLContext, @Arg('email') email: string, @Arg('password') password: string) {
+        ensureSession(context);
 
         try {
             const user = await loginPassword(email, password);
             await loginAsUser(user, context);
-
-            if (storeCookie) {
-                context.setCookie('LERNFAIR_SESSION', context.sessionToken);
-            }
 
             return true;
         } catch (error) {

--- a/graphql/authentication.ts
+++ b/graphql/authentication.ts
@@ -159,6 +159,12 @@ export async function loginAsUser(user: User, context: GraphQLContext) {
 @Resolver((of) => UserType)
 export class AuthenticationResolver {
     @Authorized(Role.UNAUTHENTICATED)
+    @Mutation((returns) => String)
+    suggestSessionToken() {
+        return suggestToken();
+    }
+
+    @Authorized(Role.UNAUTHENTICATED)
     @Mutation((returns) => Boolean)
     @Deprecated('use loginPassword or loginToken instead')
     async loginLegacy(@Ctx() context: GraphQLContext, @Arg('authToken') authToken: string) {

--- a/graphql/authentication.ts
+++ b/graphql/authentication.ts
@@ -270,7 +270,11 @@ export class AuthenticationResolver {
         @Arg('password') password: string,
         @Arg('storeCookie', { nullable: true }) storeCookie: boolean = false
     ) {
-        ensureSession(context);
+        if (!storeCookie) {
+            ensureSession(context);
+        } else {
+            context.sessionToken = suggestToken();
+        }
 
         try {
             const user = await loginPassword(email, password);

--- a/graphql/context.ts
+++ b/graphql/context.ts
@@ -89,6 +89,12 @@ export default async function injectContext({ req, res }: { req: Request; res: R
         }
 
         const sessionUser = await getUserForSession(context.sessionToken);
+
+        if (!sessionUser) {
+            authLogger.info(`Unauthenticated Session(${toPublicToken(context.sessionToken)}) started from ${ip}`);
+        } else {
+            context.user = sessionUser;
+        }
     } else {
         authLogger.info(`Unauthenticated access from ${ip}`);
     }

--- a/graphql/user/fields.ts
+++ b/graphql/user/fields.ts
@@ -68,7 +68,7 @@ export class UserFieldsResolver {
     @FieldResolver((returns) => [String])
     @Authorized(Role.ADMIN)
     async roles(@Root() user: User) {
-        const fakeContext: GraphQLContext = { ip: '?', prisma, sessionToken: 'fake' };
+        const fakeContext: GraphQLContext = { ip: '?', prisma, sessionToken: 'fake', setCookie: () => {} };
         await loginAsUser(user, fakeContext);
         return fakeContext.user.roles;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "bcrypt": "^5.0.0",
         "body-parser": "^1.19.0",
         "class-validator": "^0.13.1",
+        "cookie-parser": "^1.4.6",
         "corona-school-matching": "1.2.0",
         "cors": "^2.8.5",
         "cron": "^1.8.2",
@@ -4418,6 +4419,26 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -14021,6 +14042,22 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+    },
+    "cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "requires": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+        }
+      }
     },
     "cookie-signature": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "bcrypt": "^5.0.0",
     "body-parser": "^1.19.0",
     "class-validator": "^0.13.1",
+    "cookie-parser": "^1.4.6",
     "corona-school-matching": "1.2.0",
     "cors": "^2.8.5",
     "cron": "^1.8.2",

--- a/web/index.ts
+++ b/web/index.ts
@@ -32,6 +32,7 @@ import {getAttachmentUrlEndpoint} from "./controllers/attachmentController";
 import { isDev } from "../common/util/environment";
 import {isCommandArg} from "../common/util/basic";
 import { fileRouter } from "./controllers/fileController";
+import { cookieParser } from "cookie-parser";
 
 // Logger setup
 try {
@@ -92,6 +93,7 @@ createConnection().then(setupPDFGenerationEnvironment)
 
         // Express setup
         app.use(bodyParser.json());
+        app.use(cookieParser());
         app.use(favicon('./assets/favicon.ico'));
         app.use("/public", express.static('./assets/public'));
 

--- a/web/index.ts
+++ b/web/index.ts
@@ -32,7 +32,7 @@ import {getAttachmentUrlEndpoint} from "./controllers/attachmentController";
 import { isDev } from "../common/util/environment";
 import {isCommandArg} from "../common/util/basic";
 import { fileRouter } from "./controllers/fileController";
-import { cookieParser } from "cookie-parser";
+import cookieParser from "cookie-parser";
 
 // Logger setup
 try {


### PR DESCRIPTION
Session Token can now be placed in a cookie via `mutation { createCookieSession }` and the session token is then read from the cookie (as an alternative to the Bearer authorization header). As passing Cookies is well supported in various tools (including Retool) this simplifies porting GraphQL access to these platforms. 