### PR TITLE
Adaptions to Registration E-Mail Process

### DIFF
--- a/common/pupil/registration.ts
+++ b/common/pupil/registration.ts
@@ -52,7 +52,7 @@ export interface BecomeStatePupilData {
     gradeAsInt?: number;
 }
 
-export async function registerPupil(data: RegisterPupilData) {
+export async function registerPupil(data: RegisterPupilData, noEmail: boolean = false) {
     if (!(await isEmailAvailable(data.email))) {
         throw new PrerequisiteError(`Email is already used by another account`);
     }
@@ -96,9 +96,10 @@ export async function registerPupil(data: RegisterPupilData) {
         },
     });
 
-    // TODO: Create a new E-Mail for registration
-    // TODO: Send auth token with this
-    await Notification.actionTaken(pupil, 'pupil_registration_started', { redirectTo: data.redirectTo ?? '', verification });
+    if (!noEmail) {
+        await Notification.actionTaken(pupil, 'pupil_registration_started', { redirectTo: data.redirectTo ?? '', verification });
+    }
+
     await logTransaction('verificationRequets', pupil, {});
 
     return pupil;

--- a/common/secret/token.ts
+++ b/common/secret/token.ts
@@ -56,11 +56,11 @@ export async function _createFixedToken(user: User, token: string): Promise<void
 
 // Sends the token to the user via E-Mail using one of the supported Notification actions (to distinguish the user messaging around the token login)
 // Also a redirectTo URL is provided which is passed through to the frontend
-export async function requestToken(user: User, action: 'user-register' | 'user-authenticate' | 'user-password-reset' | string, redirectTo?: string) {
+export async function requestToken(user: User, action: 'user-verify-email' | 'user-authenticate' | 'user-password-reset' | string, redirectTo?: string) {
     const token = await createSecretEmailToken(user);
     const person = await getUserTypeORM(user.userID);
 
-    if (!['user-authenticate', 'user-password-reset', 'user-register'].includes(action)) {
+    if (!['user-authenticate', 'user-password-reset', 'user-verify-email'].includes(action)) {
         throw new Error(`Unsupported Action for Token Request`);
     }
 

--- a/common/student/registration.ts
+++ b/common/student/registration.ts
@@ -63,7 +63,7 @@ export interface BecomeProjectCoachData {
     jufoPastParticipationInfo: string;
 }
 
-export async function registerStudent(data: RegisterStudentData) {
+export async function registerStudent(data: RegisterStudentData, noEmail: boolean = false) {
     if (!(await isEmailAvailable(data.email))) {
         throw new PrerequisiteError(`Email is already used by another account`);
     }
@@ -86,8 +86,10 @@ export async function registerStudent(data: RegisterStudentData) {
         },
     });
 
-    // TODO: Create a new E-Mail for registration
-    await Notification.actionTaken(student, 'student_registration_started', { redirectTo: data.redirectTo ?? '', verification: student.verification });
+    if (!noEmail) {
+        await Notification.actionTaken(student, 'student_registration_started', { redirectTo: data.redirectTo ?? '', verification: student.verification });
+    }
+
     await logTransaction('verificationRequets', student, {});
 
     return student;

--- a/graphql/me/mutation.ts
+++ b/graphql/me/mutation.ts
@@ -232,14 +232,18 @@ export class MutateMeResolver {
     @Mutation((returns) => Student)
     @Authorized(Role.UNAUTHENTICATED, Role.ADMIN)
     @RateLimit('RegisterStudent', 10 /* requests per */, 5 * 60 * 60 * 1000 /* 5 hours */)
-    async meRegisterStudent(@Ctx() context: GraphQLContext, @Arg('data') data: RegisterStudentInput) {
+    async meRegisterStudent(
+        @Ctx() context: GraphQLContext,
+        @Arg('data') data: RegisterStudentInput,
+        @Arg('noEmail', { nullable: true }) noEmail: boolean = false
+    ) {
         const byAdmin = context.user!.roles.includes(Role.ADMIN);
 
         if (data.registrationSource === RegistrationSource.plus && !byAdmin) {
             throw new UserInputError('Lern-Fair Plus pupils may only be registered by admins');
         }
 
-        const student = await registerStudent(data);
+        const student = await registerStudent(data, noEmail);
         const log = logInContext('Me', context);
         log.info(`Student(${student.id}, firstname = ${student.firstname}, lastname = ${student.lastname}) registered`);
 
@@ -258,14 +262,14 @@ export class MutateMeResolver {
     @Mutation((returns) => Pupil)
     @Authorized(Role.UNAUTHENTICATED, Role.ADMIN)
     @RateLimit('RegisterPupil', 10 /* requests per */, 5 * 60 * 60 * 1000 /* 5 hours */)
-    async meRegisterPupil(@Ctx() context: GraphQLContext, @Arg('data') data: RegisterPupilInput) {
+    async meRegisterPupil(@Ctx() context: GraphQLContext, @Arg('data') data: RegisterPupilInput, @Arg('noEmail', { nullable: true }) noEmail: boolean = false) {
         const byAdmin = context.user!.roles.includes(Role.ADMIN);
 
         if (data.registrationSource === RegistrationSource.plus && !byAdmin) {
             throw new UserInputError('Lern-Fair Plus pupils may only be registered by admins');
         }
 
-        const pupil = await registerPupil(data);
+        const pupil = await registerPupil(data, noEmail);
         const log = logInContext('Me', context);
         log.info(`Pupil(${pupil.id}, firstname = ${pupil.firstname}, lastname = ${pupil.lastname}) registered`);
 


### PR DESCRIPTION
- `noEmail: true` can be passed to `meRegisterPupil` and `meRegisterStudent`, decoupling the email verification from the registration
- Using an email token for authentication verifies the email
- New tokenRequest type user-registration used during the registration flow to verify the email