### PR TITLE
 #LF-6 add dummy notifications resolver

### DIFF
--- a/graphql/concrete_notification/dummy_data.ts
+++ b/graphql/concrete_notification/dummy_data.ts
@@ -1,0 +1,20 @@
+import { ConcreteNotification, ConcreteNotificationState } from '../../common/entity/ConcreteNotification';
+
+const ids = Array.from({ length: 10 }, (_, i) => i + 1);
+const dummyMinutes = [0, 5, 10, 15, 20, 30, 60, 120, 150, 60 * 24, 60 * 48];
+
+// Dummy dates indexed by dummy ids
+export const getDummyCreatedAt = (id: number): Date => new Date(Date.now() - dummyMinutes[id] * 1000 * 60);
+
+export const getDummyConcreteNotifications = (userId): ConcreteNotification[] =>
+    ids.map(
+        (id): ConcreteNotification => ({
+            id,
+            attachmentGroupId: '',
+            context: {},
+            notificationID: id,
+            sentAt: new Date(),
+            userId,
+            state: ConcreteNotificationState.SENT,
+        })
+    );

--- a/graphql/concrete_notification/fields.ts
+++ b/graphql/concrete_notification/fields.ts
@@ -4,6 +4,7 @@ import { prisma } from '../../common/prisma';
 import { Role } from '../authorizations';
 import { JSONResolver } from 'graphql-scalars';
 import { ConcreteNotificationState } from '../../common/entity/ConcreteNotification';
+import { getDummyCreatedAt } from './dummy_data';
 
 @ObjectType()
 class Campaign {
@@ -34,6 +35,25 @@ export class ExtendedFieldsConcreteNotificationResolver {
     @Authorized(Role.UNAUTHENTICATED)
     async notification(@Root() concreteNotification: ConcreteNotification) {
         return await prisma.notification.findUnique({ where: { id: concreteNotification.notificationID } });
+    }
+
+    @FieldResolver((returns) => String)
+    @Authorized(Role.OWNER, Role.ADMIN)
+    async headline(@Root() concreteNotification: ConcreteNotification) {
+        return `Mock Headline ${concreteNotification.id}`;
+    }
+
+    @FieldResolver((returns) => String)
+    @Authorized(Role.OWNER, Role.ADMIN)
+    async body() {
+        return `Mock Body Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut`;
+    }
+
+    // @TODO: this should be a field of ConcreteNotification
+    @FieldResolver((returns) => String)
+    @Authorized(Role.OWNER, Role.ADMIN)
+    async createdAt(@Root() concreteNotification: ConcreteNotification) {
+        return getDummyCreatedAt(concreteNotification.id);
     }
 
     @Query((returns) => [Campaign])

--- a/graphql/concrete_notification/fields.ts
+++ b/graphql/concrete_notification/fields.ts
@@ -50,7 +50,7 @@ export class ExtendedFieldsConcreteNotificationResolver {
     }
 
     // @TODO: this should be a field of ConcreteNotification
-    @FieldResolver((returns) => String)
+    @FieldResolver((returns) => Date)
     @Authorized(Role.OWNER, Role.ADMIN)
     async createdAt(@Root() concreteNotification: ConcreteNotification) {
         return getDummyCreatedAt(concreteNotification.id);

--- a/graphql/index.ts
+++ b/graphql/index.ts
@@ -153,7 +153,7 @@ const schema = buildSchemaSync({
         FindManyScreenerResolver,
         MutateScreenerResolver,
 
-        AdminMutationsResolver
+        AdminMutationsResolver,
     ],
     authChecker,
 });

--- a/graphql/notification/fields.ts
+++ b/graphql/notification/fields.ts
@@ -55,7 +55,7 @@ export class NotificationExtendedFieldsResolver {
 
     // @TODO: this should be a field of Notification
     @FieldResolver((returns) => String)
-    @Authorized(Role.OWNER, Role.ADMIN)
+    @Authorized(Role.USER, Role.ADMIN)
     async messageType(@Root() notification: Notification) {
         // this is just a dummy type
         return `Type ${notification.id}`;

--- a/graphql/notification/fields.ts
+++ b/graphql/notification/fields.ts
@@ -52,4 +52,12 @@ export class NotificationExtendedFieldsResolver {
     hookDescription(@Root() notification: Notification) {
         return getHookDescription(notification.hookID);
     }
+
+    // @TODO: this should be a field of Notification
+    @FieldResolver((returns) => String)
+    @Authorized(Role.OWNER, Role.ADMIN)
+    async messageType(@Root() notification: Notification) {
+        // this is just a dummy type
+        return `Type ${notification.id}`;
+    }
 }

--- a/graphql/ownership.ts
+++ b/graphql/ownership.ts
@@ -9,10 +9,13 @@ export type ResolverModelNames = keyof typeof models;
 export type ResolverModel<Name extends ResolverModelNames> = typeof models[Name]['prototype'];
 
 /* If a user owns an entity, he has the Role.OWNER on that entity */
-export const isOwnedBy: { [Name in ResolverModelNames]?: (user: GraphQLUser, entity: ResolverModel<Name>) => boolean | Promise<boolean> } & { [name: string]: (user: GraphQLUser, entity: any) => boolean | Promise<boolean> } = {
+export const isOwnedBy: { [Name in ResolverModelNames]?: (user: GraphQLUser, entity: ResolverModel<Name>) => boolean | Promise<boolean> } & {
+    [name: string]: (user: GraphQLUser, entity: any) => boolean | Promise<boolean>;
+} = {
     Pupil: (user, pupil) => user.pupilId === pupil.id,
     Student: (user, student) => user.studentId === student.id,
-    UserType: (sessionUser, user: User) => sessionUser.studentId === user.studentId && sessionUser.pupilId === user.pupilId && sessionUser.screenerId === user.screenerId,
+    UserType: (sessionUser, user: User) =>
+        sessionUser.studentId === user.studentId && sessionUser.pupilId === user.pupilId && sessionUser.screenerId === user.screenerId,
     Course: async (user, course) => {
         if (!user.studentId) {
             return false;
@@ -28,4 +31,5 @@ export const isOwnedBy: { [Name in ResolverModelNames]?: (user: GraphQLUser, ent
         return !!instructor;
     },
     Match: (user, match) => user.pupilId === match.pupilId || user.studentId === match.studentId,
+    Concrete_notification: (user, concreteNotification) => concreteNotification.userId === user.userID,
 };

--- a/graphql/user/fields.ts
+++ b/graphql/user/fields.ts
@@ -1,6 +1,6 @@
-import { Student, Pupil, Screener, Secret, PupilWhereInput, StudentWhereInput } from '../generated';
-import { Root, Authorized, Ctx, Field, FieldResolver, ObjectType, Query, Resolver, Arg } from 'type-graphql';
-import { getSessionPupil, getSessionScreener, getSessionStudent, getSessionUser, GraphQLUser, loginAsUser } from '../authentication';
+import { Student, Pupil, Screener, Secret, PupilWhereInput, StudentWhereInput, Concrete_notification as ConcreteNotification } from '../generated';
+import { Root, Authorized, FieldResolver, Query, Resolver, Arg } from 'type-graphql';
+import { loginAsUser } from '../authentication';
 import { GraphQLContext } from '../context';
 import { Role } from '../authorizations';
 import { prisma } from '../../common/prisma';
@@ -8,6 +8,7 @@ import { getSecrets } from '../../common/secret';
 import { User, userForPupil, userForStudent } from '../../common/user';
 import { ACCUMULATED_LIMIT, LimitEstimated } from '../complexity';
 import { UserType } from '../types/user';
+import { getDummyConcreteNotifications } from '../concrete_notification/dummy_data';
 
 @Resolver((of) => UserType)
 export class UserFieldsResolver {
@@ -71,6 +72,12 @@ export class UserFieldsResolver {
         const fakeContext: GraphQLContext = { ip: '?', prisma, sessionToken: 'fake' };
         await loginAsUser(user, fakeContext);
         return fakeContext.user.roles;
+    }
+
+    @FieldResolver((returns) => [ConcreteNotification])
+    @Authorized(Role.OWNER, Role.ADMIN)
+    async concreteNotifications(@Root() user: User): Promise<ConcreteNotification[]> {
+        return getDummyConcreteNotifications(user.userID);
     }
 
     // During mail campaigns we need to retrieve a potentially large amount of users


### PR DESCRIPTION
adds a new resolver for user's (concrete) notifications
for testing locally run "npm run build" first, than you can try new query in graphql playground at http://localhost:5000/apollo
an example query would be 
```
#mutation{loginLegacy(authToken: "authtokenP1")} #uncomment and run this line first for auth
{me{concreteNotifications{id,headline,body,createdAt,notification{messageType}}}}
```