### PR TITLE
Added participationCertificateUpdate endpoint, Extracted issueCertifi…

### DIFF
--- a/graphql/certificate/fields.ts
+++ b/graphql/certificate/fields.ts
@@ -1,7 +1,10 @@
 import * as GraphQLModel from '../generated/models';
+import { Pupil, Student } from '../generated/models';
 import { Role } from '../authorizations';
 import { Authorized, FieldResolver, Resolver, Root } from 'type-graphql';
 import { participation_certificate as ParticipationCertificate } from '@prisma/client';
+import { getPupil, getStudent } from '../util';
+import { LimitEstimated } from '../complexity';
 
 @Resolver((of) => GraphQLModel.Participation_certificate)
 export class ExtendedFieldsParticipationCertificateResolver {
@@ -9,5 +12,19 @@ export class ExtendedFieldsParticipationCertificateResolver {
     @Authorized(Role.ADMIN, Role.STUDENT)
     subjectsFormatted(@Root() certificate: ParticipationCertificate) {
         return certificate.subjects.split(',');
+    }
+
+    @FieldResolver((returns) => Pupil)
+    @Authorized(Role.ADMIN, Role.OWNER)
+    @LimitEstimated(1)
+    pupil(@Root() certificate: ParticipationCertificate) {
+        return getPupil(certificate.pupilId);
+    }
+
+    @FieldResolver((returns) => Student)
+    @Authorized(Role.ADMIN, Role.OWNER)
+    @LimitEstimated(1)
+    student(@Root() certificate: ParticipationCertificate) {
+        return getStudent(certificate.pupilId);
     }
 }

--- a/graphql/certificate/mutations.ts
+++ b/graphql/certificate/mutations.ts
@@ -98,6 +98,14 @@ export class MutateParticipationCertificateResolver {
         @Arg('certificateId') certificateId: string,
         @Arg('data') data: CertificateUpdateInput
     ): Promise<boolean> {
+        const cert = await prisma.participation_certificate.findUnique({ where: { uuid: certificateId } });
+        if (!cert) {
+            throw new Error("Couldn't find certificate.");
+        }
+        if (cert.state !== 'awaiting-approval') {
+            throw new Error('This participation certificate is already finalized and cannot be changed anymore.');
+        }
+
         await prisma.participation_certificate.update({
             where: {
                 uuid: certificateId,


### PR DESCRIPTION
- Added participationCertificateUpdate endpoint
- Extracted issueCertificateRequest to its own endpoint
- Fieldresolvers for Students and Pupils

Open questions:
1. Are the mutable fields sufficient/are there fields that shouldn't be mutable (other than state)?
2. I assumed that updating the certificate is only possible as a student and only when the state is `awaiting-approval`. Is this correct?