### PR TITLE
Add subcourseJoinManual endpoint

### DIFF
--- a/common/courses/participants.ts
+++ b/common/courses/participants.ts
@@ -150,9 +150,10 @@ export async function canJoinSubcourse(subcourse: Subcourse, pupil: Pupil): Prom
     return { allowed: true };
 }
 
-export async function joinSubcourse(subcourse: Subcourse, pupil: Pupil): Promise<void> {
+export async function joinSubcourse(subcourse: Subcourse, pupil: Pupil, strict: boolean): Promise<void> {
     const canJoin = await canJoinSubcourse(subcourse, pupil);
-    if (!canJoin.allowed) {
+
+    if (strict && !canJoin.allowed) {
         throw new PrerequisiteError(canJoin.reason);
     }
 
@@ -271,7 +272,7 @@ export async function fillSubcourse(subcourse: Subcourse) {
 
     for (const { pupil } of toJoin) {
         try {
-            await joinSubcourse(subcourse, pupil);
+            await joinSubcourse(subcourse, pupil, true);
         } catch (error) {
             logger.warn(`Course filling - Failed to add Pupil(${pupil.id}) as:`, error);
         }

--- a/common/courses/participants.ts
+++ b/common/courses/participants.ts
@@ -179,7 +179,7 @@ export async function joinSubcourse(subcourse: Subcourse, pupil: Pupil, strict: 
         });
         logger.debug(`Found ${pupilSubCourseCount} active subcourses where the Pupil(${pupil.id}) participates`);
 
-        if (pupilSubCourseCount > PUPIL_MAX_SUBCOURSES) {
+        if (strict && pupilSubCourseCount > PUPIL_MAX_SUBCOURSES) {
             throw new CapacityReachedError(`Pupil already has joined ${pupilSubCourseCount} courses`);
         }
 

--- a/common/courses/participants.ts
+++ b/common/courses/participants.ts
@@ -161,7 +161,7 @@ export async function joinSubcourse(subcourse: Subcourse, pupil: Pupil, strict: 
         const participantCount = await prisma.subcourse_participants_pupil.count({ where: { subcourseId: subcourse.id } });
         logger.debug(`Found ${participantCount} participants for Subcourse(${subcourse.id}) with ${subcourse.maxParticipants} max participants`);
 
-        if (participantCount > subcourse.maxParticipants) {
+        if (strict && participantCount > subcourse.maxParticipants) {
             throw new CapacityReachedError(`Subcourse is full`);
         }
 

--- a/common/transactionlog/types/CreateCourseAttendanceLogEvent.ts
+++ b/common/transactionlog/types/CreateCourseAttendanceLogEvent.ts
@@ -1,10 +1,12 @@
-import LogUserEvent from "./LogUserEvent";
-import LogType from "./LogType";
-import {CourseAttendanceLog} from "../../entity/CourseAttendanceLog";
-import {Pupil} from "../../entity/Pupil";
+import LogUserEvent from './LogUserEvent';
+import LogType from './LogType';
+import { CourseAttendanceLog } from '../../entity/CourseAttendanceLog';
+import { Pupil } from '../../entity/Pupil';
 
 export default class CreateCourseAttendanceLogEvent extends LogUserEvent {
     constructor(pupil: Pupil, courseAttendanceLog: CourseAttendanceLog) {
-        super(LogType.CREATED_COURSE_ATTENDANCE_LOG, pupil, {courseAttendanceLog: courseAttendanceLog});
+        let log = Object.assign({}, courseAttendanceLog);
+        log.ip = undefined;
+        super(LogType.CREATED_COURSE_ATTENDANCE_LOG, pupil, { courseAttendanceLog: courseAttendanceLog });
     }
 }

--- a/common/transactionlog/types/CreateCourseAttendanceLogEvent.ts
+++ b/common/transactionlog/types/CreateCourseAttendanceLogEvent.ts
@@ -5,8 +5,6 @@ import { Pupil } from '../../entity/Pupil';
 
 export default class CreateCourseAttendanceLogEvent extends LogUserEvent {
     constructor(pupil: Pupil, courseAttendanceLog: CourseAttendanceLog) {
-        let log = Object.assign({}, courseAttendanceLog);
-        log.ip = undefined;
         super(LogType.CREATED_COURSE_ATTENDANCE_LOG, pupil, { courseAttendanceLog: courseAttendanceLog });
     }
 }

--- a/graphql/subcourse/mutations.ts
+++ b/graphql/subcourse/mutations.ts
@@ -305,7 +305,7 @@ export class MutateSubcourseResolver {
     async subcourseJoinManual(
         @Ctx() context: GraphQLContext,
         @Arg('subcourseId') subcourseId: number,
-        @Arg('pupilId', { nullable: false }) pupilId?: number
+        @Arg('pupilId', { nullable: false }) pupilId: number
     ): Promise<boolean> {
         const pupil = await getSessionPupil(context, pupilId);
         const subcourse = await getSubcourse(subcourseId);

--- a/graphql/subcourse/mutations.ts
+++ b/graphql/subcourse/mutations.ts
@@ -296,7 +296,20 @@ export class MutateSubcourseResolver {
     ): Promise<boolean> {
         const pupil = await getSessionPupil(context, pupilId);
         const subcourse = await getSubcourse(subcourseId);
-        await joinSubcourse(subcourse, pupil);
+        await joinSubcourse(subcourse, pupil, true);
+        return true;
+    }
+
+    @Mutation((returns) => Boolean)
+    @Authorized(Role.ADMIN)
+    async subcourseJoinManual(
+        @Ctx() context: GraphQLContext,
+        @Arg('subcourseId') subcourseId: number,
+        @Arg('pupilId', { nullable: false }) pupilId?: number
+    ): Promise<boolean> {
+        const pupil = await getSessionPupil(context, pupilId);
+        const subcourse = await getSubcourse(subcourseId);
+        await joinSubcourse(subcourse, pupil, false);
         return true;
     }
 


### PR DESCRIPTION
This is necessary for https://github.com/corona-school/project-user/issues/499. This is just the normal subcourseJoin endpoint but it bypasses the `canJoinSubcourse` function, course capacity check and `pupilSubCourseCount > PUPIL_MAX_SUBCOURSES` check