### PR TITLE
Fix CoC Deactivation inside Jobs Dyno

### DIFF
--- a/common/notification/hooks.ts
+++ b/common/notification/hooks.ts
@@ -1,0 +1,12 @@
+import { registerStudentHook } from './hook';
+
+// Hooks from the Notification System to other parts of the codebase are collected here,
+//  this ensures that the hooks are always registered when the Notification is loaded (i.e. in the jobs Deno, which only loads parts of the backend)
+import { deactivateStudent } from '../student/activation';
+registerStudentHook(
+    'deactivate-student',
+    'Account gets deactivated, matches are dissolved, courses are cancelled',
+    async (student) => {
+        await deactivateStudent(student, true, 'missing coc');
+    } // the hook does not send out a notification again, the user already knows that their account was deactivated
+);

--- a/common/notification/index.ts
+++ b/common/notification/index.ts
@@ -552,3 +552,6 @@ export async function cancelDraftedAndDelayed(notification: Notification, contex
 }
 
 export * from './hook';
+
+// Ensure hooks are always loaded
+import './hooks';

--- a/common/student/activation.ts
+++ b/common/student/activation.ts
@@ -6,14 +6,6 @@ import { getTransactionLog } from '../transactionlog';
 import DeActivateEvent from '../transactionlog/types/DeActivateEvent';
 import * as Notification from '../notification';
 
-Notification.registerStudentHook(
-    'deactivate-student',
-    'Account gets deactivated, matches are dissolved, courses are cancelled',
-    async (student) => {
-        await deactivateStudent(student, true, 'missing coc');
-    } // the hook does not send out a notification again, the user already knows that their account was deactivated
-);
-
 export async function deactivateStudent(student: Student, silent: boolean = false, reason?: string) {
     if (!student.active) {
         throw new Error('Student was already deactivated');

--- a/jobs/index.ts
+++ b/jobs/index.ts
@@ -5,6 +5,7 @@ import * as scheduler from "./scheduler";
 import { allJobs } from "./list";
 import { configureGracefulShutdown } from "./shutdown";
 import { executeJob } from "./manualExecution";
+import { createConnection } from "typeorm";
 
 //SETUP: logger
 setupLogging();
@@ -16,7 +17,6 @@ moment.locale("de"); //set global moment date format
 moment.tz.setDefault("Europe/Berlin"); //set global timezone (which is then used also for cron job scheduling and moment.format calls)
 
 //SETUP: schedule jobs
-scheduleJobs(allJobs);
 
 //SETUP: Add a graceful shutdown to the scheduler used
 configureGracefulShutdown(scheduler);
@@ -24,8 +24,12 @@ configureGracefulShutdown(scheduler);
 // Manual job execution via npm run jobs -- --execute <name>
 if (process.argv.length >= 4 && process.argv[2] === "--execute") {
     const job = process.argv[3];
-    log.info(`Manually executing ${job}`);
-    executeJob(job);
+    log.info(`Manually executing ${job}, creating DB connection`);
+    createConnection().then(() => {
+        log.info(`DB connection created, running job`);
+        executeJob(job);
+    });
 } else {
-    log.info("To directly run one of the jobs, use --execute <name>");
+    log.info("To directly run one of the jobs, use --execute <name>, we know schedule Cron Jobs to run in the future");
+    scheduleJobs(allJobs);
 }

--- a/jobs/index.ts
+++ b/jobs/index.ts
@@ -4,10 +4,12 @@ import { scheduleJobs } from "./scheduler";
 import * as scheduler from "./scheduler";
 import { allJobs } from "./list";
 import { configureGracefulShutdown } from "./shutdown";
+import { executeJob } from "./manualExecution";
 
 //SETUP: logger
 setupLogging();
-getLogger().info("Backend started");
+const log = getLogger();
+log.info("Backend started");
 
 //SETUP: moment
 moment.locale("de"); //set global moment date format
@@ -18,3 +20,12 @@ scheduleJobs(allJobs);
 
 //SETUP: Add a graceful shutdown to the scheduler used
 configureGracefulShutdown(scheduler);
+
+// Manual job execution via npm run jobs -- --execute <name>
+if (process.argv.length >= 4 && process.argv[2] === "--execute") {
+    const job = process.argv[3];
+    log.info(`Manually executing ${job}`);
+    executeJob(job);
+} else {
+    log.info("To directly run one of the jobs, use --execute <name>");
+}

--- a/jobs/index.ts
+++ b/jobs/index.ts
@@ -30,6 +30,6 @@ if (process.argv.length >= 4 && process.argv[2] === "--execute") {
         executeJob(job);
     });
 } else {
-    log.info("To directly run one of the jobs, use --execute <name>, we know schedule Cron Jobs to run in the future");
+    log.info("To directly run one of the jobs, use --execute <name>, we now schedule Cron Jobs to run in the future");
     scheduleJobs(allJobs);
 }

--- a/jobs/manualExecution.ts
+++ b/jobs/manualExecution.ts
@@ -15,6 +15,8 @@ import anonymiseAttendanceLog from './periodic/anonymise-attendance-log';
 import * as Notification from "../common/notification";
 import { runInterestConfirmations } from "../common/match/pool";
 
+// Run inside the Web Dyno via GraphQL (mutation _executeJob)
+// Run inside the Job Dyno via npm run jobs -- --execute <jobName>
 export const executeJob = async (job) => {
     switch (job) {
         case 'screeningReminderJob': {

--- a/jobs/manualExecution.ts
+++ b/jobs/manualExecution.ts
@@ -16,7 +16,7 @@ import * as Notification from "../common/notification";
 import { runInterestConfirmations } from "../common/match/pool";
 
 // Run inside the Web Dyno via GraphQL (mutation _executeJob)
-// Run inside the Job Dyno via npm run jobs -- --execute <jobName>
+// Run inside the Job Dyno via npm run jobs --execute <jobName
 export const executeJob = async (job) => {
     switch (job) {
         case 'screeningReminderJob': {


### PR DESCRIPTION
Inside the Jobs Dyno, the student-deactivate hook was not registered and could thus not be executed by the Notification System when running inside Jobs. By making hooks a direct dependency of the Notification System this should work now.

Also provide a possibility to test this, by running jobs manually. 