### PR TITLE
Pupil registration fix (#471)

### DIFF
--- a/common/pupil/registration.ts
+++ b/common/pupil/registration.ts
@@ -95,6 +95,9 @@ export async function registerPupil(data: RegisterPupilData, noEmail: boolean = 
 
             // the authToken is used to verify the e-mail instead
             verification,
+
+            // Pupils need to specifically request a match
+            openMatchRequestCount: 0,
         },
     });
 

--- a/common/pupil/registration.ts
+++ b/common/pupil/registration.ts
@@ -90,6 +90,8 @@ export async function registerPupil(data: RegisterPupilData, noEmail: boolean = 
 
             // Every pupil can participate in courses
             isParticipant: true,
+            // Every pupil is made a Tutee by registration.
+            isPupil: true,
 
             // the authToken is used to verify the e-mail instead
             verification,
@@ -165,6 +167,21 @@ export async function becomeStatePupil(pupil: Pupil, data: BecomeStatePupilData)
         data: {
             teacherEmailAddress: data.teacherEmail,
             grade: data.gradeAsInt ? `${data.gradeAsInt}. Klasse` : undefined,
+        },
+        where: { id: pupil.id },
+    });
+
+    return updatedPupil;
+}
+
+export async function becomeParticipant(pupil: Pupil) {
+    if (pupil.isParticipant) {
+        throw new RedundantError(`Pupil is already a participant`);
+    }
+
+    const updatedPupil = await prisma.pupil.update({
+        data: {
+            isParticipant: true,
         },
         where: { id: pupil.id },
     });

--- a/graphql/me/mutation.ts
+++ b/graphql/me/mutation.ts
@@ -37,6 +37,7 @@ import {
     BecomeStatePupilData,
     becomeTutee,
     BecomeTuteeData,
+    becomeParticipant,
     registerPupil,
     RegisterPupilData,
 } from '../../common/pupil/registration';
@@ -237,7 +238,7 @@ export class MutateMeResolver {
         const byAdmin = context.user!.roles.includes(Role.ADMIN);
 
         if (data.registrationSource === RegistrationSource.plus && !byAdmin) {
-            throw new UserInputError('Lern-Fair Plus pupils may only be registered by admins');
+            throw new UserInputError('Lern-Fair Plus students may only be registered by admins');
         }
 
         const student = await registerStudent(data, noEmail);
@@ -452,6 +453,20 @@ export class MutateMeResolver {
         await evaluatePupilRoles(updatedPupil, context);
 
         log.info(`Pupil(${pupil.id}) upgraded their account to become a STATE_PUPIL`);
+
+        return true;
+    }
+
+    @Mutation((returns) => Boolean)
+    @Authorized(Role.PUPIL, Role.ADMIN)
+    async meBecomeParticipant(@Ctx() context: GraphQLContext, @Arg('pupilId', { nullable: true }) pupilId: number) {
+        const pupil = await getSessionPupil(context, pupilId);
+        const log = logInContext('Me', context);
+
+        const updatedPupil = await becomeParticipant(pupil);
+        await evaluatePupilRoles(updatedPupil, context);
+
+        log.info(`Pupil(${pupil.id}) upgraded their account to become a PARTICIPANT`);
 
         return true;
     }

--- a/integration-tests/matching.ts
+++ b/integration-tests/matching.ts
@@ -5,14 +5,37 @@ import * as assert from "assert";
 test("Pupil Request Match", async () => {
     const { client, pupil } = await pupilOne;
 
-    // Pupil is a TUTEE by registration
+    const { me: p } = await client.request(`
+    query GetOpenMatchRequestCount {
+        me {
+            pupil { 
+                openMatchRequestCount
+            }
+        }
+     }
+    `);
+
+    // Match request is 0 after registration
+    assert.strictEqual(p.pupil.openMatchRequestCount, 0);
+    
     await client.request(`
         mutation {
             pupilCreateMatchRequest
         }
     `);
 
-    // TODO assertion
+    const { me : p1 } = await client.request(`
+        query GetOpenMatchRequestCount {
+            me {
+                pupil { 
+                    openMatchRequestCount
+                }
+            }
+        }
+    `);
+
+    assert.strictEqual(p1.pupil.openMatchRequestCount, 1);
+    
 });
 
 test("Anyone Request Matching Statistics", async () => {

--- a/integration-tests/matching.ts
+++ b/integration-tests/matching.ts
@@ -1,17 +1,18 @@
 import { adminClient, defaultClient, test } from "./base";
 import { pupilOne } from "./user";
+import * as assert from "assert";
 
 test("Pupil Request Match", async () => {
     const { client, pupil } = await pupilOne;
 
-    // Pupil is not yet a TUTEE
-    await client.requestShallFail(`
+    // Pupil is a TUTEE by registration
+    await client.request(`
         mutation {
             pupilCreateMatchRequest
         }
     `);
 
-    // TODO
+    // TODO assertion
 });
 
 test("Anyone Request Matching Statistics", async () => {

--- a/integration-tests/matching.ts
+++ b/integration-tests/matching.ts
@@ -17,14 +17,14 @@ test("Pupil Request Match", async () => {
 
     // Match request is 0 after registration
     assert.strictEqual(p.pupil.openMatchRequestCount, 0);
-    
+
     await client.request(`
         mutation {
             pupilCreateMatchRequest
         }
     `);
 
-    const { me : p1 } = await client.request(`
+    const { me: p1 } = await client.request(`
         query GetOpenMatchRequestCount {
             me {
                 pupil { 
@@ -35,7 +35,7 @@ test("Pupil Request Match", async () => {
     `);
 
     assert.strictEqual(p1.pupil.openMatchRequestCount, 1);
-    
+
 });
 
 test("Anyone Request Matching Statistics", async () => {

--- a/integration-tests/user.ts
+++ b/integration-tests/user.ts
@@ -38,17 +38,6 @@ export const pupilOne = test("Register Pupil", async () => {
         }
     `);
 
-    await client.request(`
-        mutation BecomeTutee {
-            meBecomeTutee(data: {
-                subjects: [{ name: "Deutsch" }]
-                languages: [Deutsch]
-                learningGermanSince: more_than_four
-                gradeAsInt: 10
-            })
-        }
-    `);
-
     const { me: pupil } = await client.request(`
         query GetBasics {
             me {

--- a/integration-tests/user.ts
+++ b/integration-tests/user.ts
@@ -55,14 +55,20 @@ export const pupilOne = test("Register Pupil", async () => {
                 firstname
                 lastname
                 email
-                pupil { id }
+                pupil { 
+                    id 
+                    isPupil
+                    isParticipant
+                }
             }
         }
     `);
 
-    assert.equal(pupil.firstname, `firstname:${userRandom}`);
-    assert.equal(pupil.lastname, `lastname:${userRandom}`);
-    assert.equal(pupil.email, `test+${userRandom}@lern-fair.de`.toLowerCase());
+    assert.strictEqual(pupil.firstname, `firstname:${userRandom}`);
+    assert.strictEqual(pupil.lastname, `lastname:${userRandom}`);
+    assert.strictEqual(pupil.email, `test+${userRandom}@lern-fair.de`.toLowerCase());
+    assert.strictEqual(pupil.pupil.isPupil, true);
+    assert.strictEqual(pupil.pupil.isParticipant, true);
 
     // Ensure that E-Mails are consumed case-insensitive everywhere:
     pupil.email = pupil.email.toUpperCase();


### PR DESCRIPTION
1. Pupils get automatically the role `pupil` and `participant` when they register. 
2. Extend Integration tests with that.
3. Add `becomeParticipant` endpoint