### PR TITLE
Allow overriding the startDate of certificates, fix time handling

### DIFF
--- a/common/certificate/index.ts
+++ b/common/certificate/index.ts
@@ -111,7 +111,8 @@ export async function getCertificatePDF(certificateId: string, _requestor: Stude
 }
 
 export interface ICertificateCreationParams {
-    endDate: number;
+    startDate?: Date;
+    endDate: Date;
     subjects: string;
     hoursPerWeek: number;
     hoursTotal: number;
@@ -138,6 +139,13 @@ export async function issueCertificateRequest(
     });
 }
 
+export async function createCertificateLEGACY(
+    _requestor: Student | PrismaStudent,
+    matchId: string,
+    params: Omit<ICertificateCreationParams, 'endDate'> & { endDate: number /* UNIX timestamp in seconds */ }
+) {
+    return await createCertificate(_requestor, matchId, { ...params, endDate: params.endDate && moment(params.endDate, 'X').toDate() });
+}
 /* Students can create certificates, which pupils can then sign */
 export async function createCertificate(
     _requestor: Student | PrismaStudent,
@@ -162,8 +170,8 @@ export async function createCertificate(
     pc.hoursPerWeek = params.hoursPerWeek;
     pc.hoursTotal = params.hoursTotal;
     pc.medium = params.medium;
-    pc.startDate = match.createdAt;
-    pc.endDate = moment(params.endDate, 'X').toDate();
+    pc.startDate = params.startDate ?? match.createdAt;
+    pc.endDate = params.endDate;
     pc.ongoingLessons = params.ongoingLessons;
     pc.state = params.state;
 

--- a/graphql/certificate/mutations.ts
+++ b/graphql/certificate/mutations.ts
@@ -17,12 +17,13 @@ import { IsIn } from 'class-validator';
 import { ValidationError } from '../error';
 import { addFile, getFileURL } from '../files';
 import { prisma } from '../../common/prisma';
-import moment from 'moment/moment';
 
 @InputType()
 class CertificateCreationInput implements ICertificateCreationParams {
+    @Field({ nullable: true })
+    startDate?: Date;
     @Field()
-    endDate: number;
+    endDate: Date;
     @Field()
     subjects: string;
     @Field()
@@ -43,7 +44,9 @@ class CertificateCreationInput implements ICertificateCreationParams {
 @InputType()
 class CertificateUpdateInput {
     @Field({ nullable: true })
-    endDate?: number;
+    startDate?: Date;
+    @Field({ nullable: true })
+    endDate?: Date;
     @Field({ nullable: true })
     subjects?: string;
     @Field({ nullable: true })
@@ -111,7 +114,8 @@ export class MutateParticipationCertificateResolver {
                 uuid: certificateId,
             },
             data: {
-                endDate: moment(data.endDate, 'X').toDate(),
+                startDate: data.startDate,
+                endDate: data.endDate,
                 subjects: data.subjects,
                 hoursPerWeek: data.hoursPerWeek,
                 hoursTotal: data.hoursTotal,

--- a/web/controllers/certificateController/index.ts
+++ b/web/controllers/certificateController/index.ts
@@ -4,7 +4,7 @@ import { Pupil } from '../../../common/entity/Pupil';
 import { Student } from '../../../common/entity/Student';
 import { assert } from 'console';
 import { createRemissionRequestPDF, createRemissionRequestVerificationPage } from "../../../common/remission-request";
-import { CERTIFICATE_MEDIUMS, CertificateState, ICertificateCreationParams, createCertificate, DefaultLanguage, LANGUAGES, Language, signCertificate, VALID_BASE64, getCertificatePDF, getConfirmationPage, getCertificatesFor, CertificateError } from '../../../common/certificate';
+import { CERTIFICATE_MEDIUMS, CertificateState, ICertificateCreationParams, createCertificate, DefaultLanguage, LANGUAGES, Language, signCertificate, VALID_BASE64, getCertificatePDF, getConfirmationPage, getCertificatesFor, CertificateError, createCertificateLEGACY } from '../../../common/certificate';
 
 const logger = getLogger();
 
@@ -94,7 +94,7 @@ export async function createCertificateEndpoint(req: Request, res: Response) {
 
         let state = automatic ? CertificateState.awaitingApproval : CertificateState.manual;
 
-        let params: ICertificateCreationParams = {
+        let params = {
             endDate,
             subjects: subjects.join(","),
             hoursPerWeek,
@@ -107,7 +107,7 @@ export async function createCertificateEndpoint(req: Request, res: Response) {
 
         // Students may only request for their matches
 
-        const certificate = await createCertificate(requestor, pupil, params);
+        const certificate = await createCertificateLEGACY(requestor, pupil, params);
 
         return res.json({ uuid: certificate.uuid, automatic });
     } catch (error) {


### PR DESCRIPTION
The old API uses UNIX timestamps in seconds, and improperly validates it. Let's just use GraphQL's Date Type instead for the GraphQL based API