### PR TITLE
Increase log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,12 @@ stored in `.certificate-version`.
 
 #### Command line arguments
 
-The following command line arguments are available:
+The following command line arguments are available (i.e. run `npm run web -- --noPDF --debug`):
 
 | Argument | Description                                                                        |
 |----------|------------------------------------------------------------------------------------|
 | \--noPDF | Skips Puppeteer and PDF initialization, which is handy for speeding up development |
+| \--debug | Sets the log level to debug which prints out tons of information                   |
 
 ### Docs
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "web:keep-db": "node -r dotenv/config ./built/web/index.js --keepDB",
     "web:nopdf": "node -r dotenv/config ./built/web/index.js --noPDF",
     "web:debug": "npm run build && node --inspect=0 ./built/web/index.js",
+    "web:debug-log": "DEBUG_LOG=true node ./built/web/index.js",
     "web:docs": "apidoc -i web/controllers -i common -o web/public/docs",
     "typeorm": "npm run build:clean && npx typeorm",
     "db:migration:create": "npm run typeorm -- migration:create -n",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "web:keep-db": "node -r dotenv/config ./built/web/index.js --keepDB",
     "web:nopdf": "node -r dotenv/config ./built/web/index.js --noPDF",
     "web:debug": "npm run build && node --inspect=0 ./built/web/index.js",
-    "web:debug-log": "DEBUG_LOG=true node ./built/web/index.js",
     "web:docs": "apidoc -i web/controllers -i common -o web/public/docs",
     "typeorm": "npm run build:clean && npx typeorm",
     "db:migration:create": "npm run typeorm -- migration:create -n",

--- a/web/index.ts
+++ b/web/index.ts
@@ -44,7 +44,7 @@ try {
         categories: {
             default: {
                 appenders: ['stderr'],
-                level: process.env.DEBUG_LOG ? 'debug' : 'info',
+                level: isCommandArg('--debug') ? 'debug' : 'info',
             }
         },
     });

--- a/web/index.ts
+++ b/web/index.ts
@@ -44,7 +44,7 @@ try {
         categories: {
             default: {
                 appenders: ['stderr'],
-                level: 'info',
+                level: process.env.DEBUG_LOG ? 'debug' : 'info',
             }
         },
     });
@@ -54,6 +54,7 @@ try {
 
 const logger = getLogger();
 const accessLogger = getLogger('access');
+logger.debug('Debug logging enabled');
 
 //SETUP: moment
 moment.locale('de'); //set global moment date format

--- a/web/index.ts
+++ b/web/index.ts
@@ -39,25 +39,13 @@ import { WebSocketService } from '../common/websocket';
 try {
     configure({
         appenders: {
-            file: { type: 'dateFile', filename: 'logs/web.log', keepFileExt: true },
-            'file-filtered': { type: 'logLevelFilter', appender: 'file', level: 'info' },
-            'file-webaccess': { type: 'dateFile', filename: 'logs/access.log', keepFileExt: true },
-
-            stdout: { type: 'stdout' },
-            'stdout-filtered': { type: 'logLevelFilter', appender: 'stdout', level: isDev ? 'debug' : 'info' },
-
             stderr: { type: 'stderr' },
-            'stderr-filtered': { type: 'logLevelFilter', appender: 'stdout', level: 'all', maxLevel: 'debug' },
         },
         categories: {
             default: {
-                appenders: ['stderr-filtered', 'stdout-filtered', 'file-filtered'],
-                level: 'all',
-            },
-            access: {
-                appenders: ['file-webaccess', 'stdout-filtered'],
-                level: 'all',
-            },
+                appenders: ['stderr'],
+                level: 'info',
+            }
         },
     });
 } catch (e) {


### PR DESCRIPTION
Raises the default log level to INFO, debug logging can be enabled with the `--debug` flag.

The logging in the GraphQL stack is generally more verbose (which is a good thing in case one needs to debug something), but by default we should switch it off as we log tons of data otherwise that no one can work with anyways (and Mezmo complains about our log volumes)