### PR TITLE
Allow instructors to manage the waiting list

### DIFF
--- a/common/courses/participants.ts
+++ b/common/courses/participants.ts
@@ -115,6 +115,20 @@ export function canJoinSubcourses(pupil: Pupil): Decision<CourseDecision> {
 }
 
 export async function canJoinSubcourse(subcourse: Subcourse, pupil: Pupil): Promise<Decision<CourseDecision>> {
+    const couldJoin = await couldJoinSubcourse(subcourse, pupil);
+    if (!couldJoin.allowed) {
+        return couldJoin;
+    }
+
+    const participants = await prisma.subcourse_participants_pupil.count({ where: { subcourseId: subcourse.id } });
+    if (subcourse.maxParticipants <= participants) {
+        return { allowed: false, reason: 'subcourse-full' };
+    }
+    return { allowed: true };
+}
+
+// Whether the pupil could join the course if the course was not full (i.e. pupils can still join the waitinglist)
+export async function couldJoinSubcourse(subcourse: Subcourse, pupil: Pupil): Promise<Decision<CourseDecision>> {
     if (!canJoinSubcourses(pupil).allowed) {
         return canJoinSubcourses(pupil);
     }
@@ -139,10 +153,6 @@ export async function canJoinSubcourse(subcourse: Subcourse, pupil: Pupil): Prom
         return { allowed: false, reason: 'grade-to-high' };
     }
 
-    const participants = await prisma.subcourse_participants_pupil.count({ where: { subcourseId: subcourse.id } });
-    if (subcourse.maxParticipants <= participants) {
-        return { allowed: false, reason: 'subcourse-full' };
-    }
     return { allowed: true };
 }
 

--- a/graphql/subcourse/fields.ts
+++ b/graphql/subcourse/fields.ts
@@ -13,7 +13,7 @@ import { Bbb_meeting as BBBMeeting, Course, Lecture, Pupil, pupil_schooltype_enu
 import { Decision } from '../types/reason';
 import { Instructor } from '../types/instructor';
 import { canContactInstructors } from '../../common/courses/contact';
-import { getCourse } from '../util';
+import { Deprecated, getCourse } from '../util';
 
 @ObjectType()
 class Participant {
@@ -318,6 +318,23 @@ export class ExtendedFieldsSubcourseResolver {
         });
     }
 
+    @FieldResolver((returns) => [Participant])
+    @Authorized(Role.ADMIN, Role.OWNER)
+    @LimitEstimated(100)
+    async pupilsOnWaitinglist(@Root() subcourse: Subcourse): Promise<Participant[]> {
+        return await prisma.pupil.findMany({
+            select: { id: true, firstname: true, lastname: true, grade: true, schooltype: true, aboutMe: true },
+            where: {
+                subcourse_waiting_list_pupil: {
+                    some: {
+                        subcourseId: subcourse.id,
+                    },
+                },
+            },
+        });
+    }
+
+    @Deprecated('Use pupilsOnWaitinglist instead')
     @FieldResolver((returns) => [Pupil])
     @Authorized(Role.ADMIN)
     @LimitEstimated(100)

--- a/graphql/subcourse/fields.ts
+++ b/graphql/subcourse/fields.ts
@@ -1,7 +1,7 @@
 import { Prisma } from '@prisma/client';
 import { canPublish } from '../../common/courses/states';
 import { Arg, Authorized, Ctx, Field, FieldResolver, Int, ObjectType, Query, Resolver, Root } from 'type-graphql';
-import { canJoinSubcourse, getCourseCapacity, isParticipant } from '../../common/courses/participants';
+import { canJoinSubcourse, couldJoinSubcourse, getCourseCapacity, isParticipant } from '../../common/courses/participants';
 import { CourseState } from '../../common/entity/Course';
 import { prisma } from '../../common/prisma';
 import { getSessionPupil, getSessionStudent, isElevated, isSessionPupil, isSessionStudent } from '../authentication';
@@ -405,6 +405,13 @@ export class ExtendedFieldsSubcourseResolver {
     async canJoin(@Ctx() context: GraphQLContext, @Root() subcourse: Required<Subcourse>, @Arg('pupilId', { nullable: true }) pupilId: number) {
         const pupil = await getSessionPupil(context, pupilId);
         return await canJoinSubcourse(subcourse, pupil);
+    }
+
+    @FieldResolver((returns) => Decision)
+    @Authorized(Role.ADMIN, Role.PUPIL)
+    async canJoinWaitinglist(@Ctx() context: GraphQLContext, @Root() subcourse: Required<Subcourse>, @Arg('pupilId', { nullable: true }) pupilId: number) {
+        const pupil = await getSessionPupil(context, pupilId);
+        return await couldJoinSubcourse(subcourse, pupil);
     }
 
     @FieldResolver((returns) => Decision)

--- a/graphql/subcourse/mutations.ts
+++ b/graphql/subcourse/mutations.ts
@@ -10,7 +10,7 @@ import { AuthorizedDeferred, hasAccess, Role } from '../authorizations';
 import { GraphQLContext } from '../context';
 import { AuthenticationError, ForbiddenError, UserInputError } from '../error';
 import * as GraphQLModel from '../generated/models';
-import { getCourse, getLecture, getStudent, getSubcourse } from '../util';
+import { getCourse, getLecture, getPupil, getStudent, getSubcourse } from '../util';
 import { canPublish } from '../../common/courses/states';
 import { getUserTypeORM } from '../../common/user';
 import { PrerequisiteError } from '../../common/util/error';
@@ -317,6 +317,36 @@ export class MutateSubcourseResolver {
         const pupil = await getSessionPupil(context, pupilId);
         const subcourse = await getSubcourse(subcourseId);
         await joinSubcourse(subcourse, pupil, false);
+        return true;
+    }
+
+    @Mutation((returns) => Boolean)
+    @AuthorizedDeferred(Role.OWNER)
+    async subcourseJoinFromWaitinglist(
+        @Ctx() context: GraphQLContext,
+        @Arg('subcourseId') subcourseId: number,
+        @Arg('pupilId', { nullable: false }) pupilId: number
+    ) {
+        const subcourse = await getSubcourse(subcourseId);
+        await hasAccess(context, 'Subcourse', subcourse);
+        const pupil = await getPupil(pupilId);
+
+        const isOnWaitingList = (await prisma.subcourse_waiting_list_pupil.count({ where: { pupilId: pupil.id, subcourseId: subcourse.id } })) > 0;
+        if (!isOnWaitingList) {
+            throw new PrerequisiteError(
+                `Pupil(${pupil.id}) is not on the waitinglist of the Subcourse(${subcourse.id}) and can thus not be joined by the instructor`
+            );
+        }
+
+        const participantCount = await prisma.subcourse_participants_pupil.count({ where: { subcourseId: subcourse.id } });
+        if (participantCount <= subcourse.maxParticipants) {
+            // Course is full, create one single place for the pupil
+            await prisma.subcourse.update({ where: { id: subcourse.id }, data: { maxParticipants: { increment: 1 } } });
+        }
+
+        // Joining the subcourse will automatically remove the pupil from the waitinglist
+        await joinSubcourse(subcourse, pupil, true);
+
         return true;
     }
 

--- a/graphql/subcourse/mutations.ts
+++ b/graphql/subcourse/mutations.ts
@@ -339,7 +339,7 @@ export class MutateSubcourseResolver {
         }
 
         const participantCount = await prisma.subcourse_participants_pupil.count({ where: { subcourseId: subcourse.id } });
-        if (participantCount <= subcourse.maxParticipants) {
+        if (participantCount >= subcourse.maxParticipants) {
             // Course is full, create one single place for the pupil
             await prisma.subcourse.update({ where: { id: subcourse.id }, data: { maxParticipants: { increment: 1 } } });
         }


### PR DESCRIPTION
- Instructors can query the pupils on the waitinglist:
```gql
query { subcourse(...) { pupilsOnWaitinglist { id firstname lastname } } }
```

- Pupils can check whether they can join the waitinglist:
```gql
query { subcourse(...) { canJoinWaitinglist } } }
```

- Instructors can join single pupils from the waitinglist:
```gql
mutation { subcourseJoinFromWaitinglist(subcourseId: 1, pupilId: 1) }
```