### PR TITLE
GraphQL mutation for creating pupil screenings

### DIFF
--- a/common/entity/PupilScreening.ts
+++ b/common/entity/PupilScreening.ts
@@ -29,7 +29,7 @@ export class PupilScreening {
     })
     status: PupilScreeningStatus;
 
-    @Column()
+    @Column({ default: false })
     invalidated: boolean;
 
     @Column({ nullable: true })

--- a/common/migration/1678045632307-default-pupil-screening.ts
+++ b/common/migration/1678045632307-default-pupil-screening.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class defaultPupilScreening1678045632307 implements MigrationInterface {
+    name = 'defaultPupilScreening1678045632307';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "pupil_screening" ALTER COLUMN "invalidated" SET DEFAULT false`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "pupil_screening" ALTER COLUMN "invalidated" DROP DEFAULT`);
+    }
+
+}

--- a/common/notification/actions.ts
+++ b/common/notification/actions.ts
@@ -35,6 +35,9 @@ const _notificationActions = {
     user_registration_verified_email: {
         description: 'User / E-Mail verified',
     },
+    pupil_screening_add: {
+        description: 'Pupil / Screening was added',
+    },
     pupil_registration_finished: {
         description: 'Pupil / Registration finished',
     },

--- a/common/pupil/screening.ts
+++ b/common/pupil/screening.ts
@@ -25,5 +25,5 @@ export async function addPupilScreening(pupil: Pupil, screening: PupilScreeningI
     await prisma.pupil_screening.create({ data: { ...screening, pupilId: pupil.id } });
     await Notification.actionTaken(pupil, 'pupil_screening_add', {});
 
-    logger.info(`Pupil (${pupil.id}) was screened`, screening);
+    logger.info(`Added ${screening.status || 'pending'} screening for pupil ${pupil.id}`, screening);
 }

--- a/common/pupil/screening.ts
+++ b/common/pupil/screening.ts
@@ -1,0 +1,29 @@
+import { pupil as Pupil, pupil_screening_status_enum } from '@prisma/client';
+import { prisma } from '../prisma';
+import { getLogger } from 'log4js';
+import * as Notification from '../notification';
+import { PrerequisiteError, RedundantError } from '../util/error';
+
+const logger = getLogger('Pupil Screening');
+interface PupilScreeningInput {
+    status?: pupil_screening_status_enum;
+    comment?: string;
+    invalidated?: boolean;
+}
+
+export async function addPupilScreening(pupil: Pupil, screening: PupilScreeningInput = {}) {
+    if (await prisma.pupil_screening.count({ where: { pupilId: pupil.id, invalidated: false } })) {
+        throw new RedundantError(`There already is a valid pupil screening for pupil ${pupil.id}`);
+    }
+    if (!pupil.isPupil) {
+        throw new PrerequisiteError(`Pupil ${pupil.id} has isPupil = false`);
+    }
+    if (!pupil.verifiedAt && pupil.verification) {
+        throw new PrerequisiteError(`Pupil ${pupil.id} does not have a verified email`);
+    }
+
+    await prisma.pupil_screening.create({ data: { ...screening, pupilId: pupil.id } });
+    await Notification.actionTaken(pupil, 'pupil_screening_add', {});
+
+    logger.info(`Pupil (${pupil.id}) was screened`, screening);
+}

--- a/graphql/authorizations.ts
+++ b/graphql/authorizations.ts
@@ -105,6 +105,7 @@ async function accessCheck(context: GraphQLContext, requiredRoles: Role[], model
 
 const allAdmin = { _all: [Authorized(Role.ADMIN)] };
 const adminOrOwner = [Authorized(Role.ADMIN, Role.OWNER)];
+const onlyAdmin = [Authorized(Role.ADMIN)];
 const onlyOwner = [Authorized(Role.OWNER)];
 const nobody = [Authorized(Role.NOBODY)];
 const everyone = [Authorized(Role.UNAUTHENTICATED)];
@@ -439,5 +440,10 @@ export const authorizationModelEnhanceMap: ModelsEnhanceMap = {
             // Stack traces and error messages shall not be shown to users, we do not know what secret information they might contiain
             error: nobody,
         }),
+    },
+    Pupil_screening: {
+        fields: {
+            comment: onlyAdmin,
+        },
     },
 };

--- a/graphql/pupil/fields.ts
+++ b/graphql/pupil/fields.ts
@@ -6,6 +6,7 @@ import {
     Pupil_tutoring_interest_confirmation_request as TutoringInterestConfirmation,
     Participation_certificate as ParticipationCertificate,
     Match,
+    Pupil_screening as PupilScreening,
 } from '../generated';
 import { Arg, Authorized, Field, FieldResolver, Int, Resolver, Root } from 'type-graphql';
 import { prisma } from '../../common/prisma';
@@ -139,5 +140,13 @@ export class ExtendFieldsPupilResolver {
     @Authorized(Role.ADMIN, Role.OWNER)
     async canJoinSubcourses(@Root() pupil: Required<Pupil>) {
         return canJoinSubcourses(pupil);
+    }
+
+    @FieldResolver((type) => [PupilScreening])
+    @Authorized(Role.ADMIN, Role.OWNER)
+    async screenings(@Root() pupil: Required<Pupil>) {
+        return await prisma.pupil_screening.findMany({
+            where: { pupilId: pupil.id },
+        });
     }
 }

--- a/graphql/pupil/mutations.ts
+++ b/graphql/pupil/mutations.ts
@@ -24,6 +24,7 @@ import { logInContext } from '../logging';
 import { userForPupil } from '../../common/user';
 import { MaxLength } from 'class-validator';
 import { NotificationPreferences } from '../types/preferences';
+import { addPupilScreening } from '../../common/pupil/screening';
 
 @InputType()
 export class PupilUpdateInput {
@@ -183,6 +184,15 @@ export class MutatePupilResolver {
     async pupilDeleteMatchRequest(@Ctx() context: GraphQLContext, @Arg('pupilId', { nullable: true }) pupilId?: number): Promise<boolean> {
         const pupil = await getSessionPupil(context, /* elevated override */ pupilId);
         await deletePupilMatchRequest(pupil);
+
+        return true;
+    }
+
+    @Mutation(() => Boolean)
+    @Authorized(Role.ADMIN)
+    async pupilCreateScreening(@Arg('pupilId') pupilId: number): Promise<boolean> {
+        const pupil = await getPupil(pupilId);
+        await addPupilScreening(pupil);
 
         return true;
     }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -654,7 +654,7 @@ model pupil_screening {
   createdAt   DateTime                    @default(now()) @db.Timestamp(6)
   updatedAt   DateTime                    @default(now()) @db.Timestamp(6)
   status      pupil_screening_status_enum @default(dbgenerated("0"))
-  invalidated Boolean
+  invalidated Boolean                     @default(false)
   comment     String?                     @db.VarChar
   pupilId     Int?
   pupil       pupil?                      @relation(fields: [pupilId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "FK_d53a566dbe1a58b06bea8b51c1d")


### PR DESCRIPTION
Closes https://github.com/corona-school/project-user/issues/624

> Inform stakeholders about actionId such that they can create the appropriate email template

@lsc0498 @Maascha The action ID for creating a pupil screening is `pupil_screening_add`.