### PR TITLE
fix web logger

### DIFF
--- a/web/index.ts
+++ b/web/index.ts
@@ -1,3 +1,7 @@
+// This has to be the first line in the project, so that the logger is configured before all the imports are executed.
+// Otherwise, we might initialize new loggers within the imports, which will not be configured properly and so not working.
+import('./setupLogger');
+
 import express from 'express';
 import http from 'http';
 import bodyParser from 'body-parser';
@@ -15,7 +19,7 @@ import * as registrationController from './controllers/registrationController';
 import * as mentoringController from './controllers/mentoringController';
 import * as expertController from './controllers/expertController';
 import * as interestConfirmationController from './controllers/interestConfirmationController';
-import { configure, connectLogger, getLogger } from 'log4js';
+import { connectLogger, getLogger } from 'log4js';
 import { createConnection, getConnection } from 'typeorm';
 import { authCheckFactory, screenerAuthCheck } from './middleware/auth';
 import { setupDevDB } from './dev';
@@ -36,22 +40,6 @@ import cookieParser from 'cookie-parser';
 import { WebSocketService } from '../common/websocket';
 
 // Logger setup
-try {
-    configure({
-        appenders: {
-            stderr: { type: 'stderr' },
-        },
-        categories: {
-            default: {
-                appenders: ['stderr'],
-                level: isCommandArg('--debug') ? 'debug' : 'info',
-            }
-        },
-    });
-} catch (e) {
-    console.warn("Couldn't setup logger", e);
-}
-
 const logger = getLogger();
 const accessLogger = getLogger('access');
 logger.debug('Debug logging enabled');

--- a/web/setupLogger.ts
+++ b/web/setupLogger.ts
@@ -1,19 +1,14 @@
 import { isCommandArg } from '../common/util/basic';
 import { configure } from 'log4js';
 
-try {
-    configure({
-        appenders: {
-            out: { type: 'stdout', layout: { type: 'coloured' } },
+configure({
+    appenders: {
+        out: { type: 'stdout', layout: { type: 'coloured' } },
+    },
+    categories: {
+        default: {
+            appenders: ['out'],
+            level: isCommandArg('--debug') ? 'debug' : 'info',
         },
-        categories: {
-            default: {
-                appenders: ['out'],
-                level: isCommandArg('--debug') ? 'debug' : 'info',
-            },
-        },
-    });
-} catch (e) {
-    // TODO: should this be a breaking condition? Loosing all the logs, might be a big problem.
-    console.warn("Couldn't setup logger", e);
-}
+    },
+});

--- a/web/setupLogger.ts
+++ b/web/setupLogger.ts
@@ -1,0 +1,19 @@
+import { isCommandArg } from '../common/util/basic';
+import { configure } from 'log4js';
+
+try {
+    configure({
+        appenders: {
+            out: { type: 'stdout', layout: { type: 'coloured' } },
+        },
+        categories: {
+            default: {
+                appenders: ['out'],
+                level: isCommandArg('--debug') ? 'debug' : 'info',
+            },
+        },
+    });
+} catch (e) {
+    // TODO: should this be a breaking condition? Loosing all the logs, might be a big problem.
+    console.warn("Couldn't setup logger", e);
+}


### PR DESCRIPTION
I noticed the logger was not working during the pupil screening update mutation PR.
The problem is that log4js needs to be configured before running `getLogger`, because otherwise, a new logger with `level: 'OFF'` is created.

This PR will ensure that the first thing in the web/index is setting up the logger so we can use `getLogger` in the root of all the following imports.

We should refactor the usage in the future to have a similar setup to the job/index.