### PR TITLE
Remove assertion in SUBCOURSE_PARTICIPANT check

### DIFF
--- a/graphql/authorizations.ts
+++ b/graphql/authorizations.ts
@@ -86,7 +86,7 @@ async function accessCheck(context: GraphQLContext, requiredRoles: Role[], model
     if (requiredRoles.includes(Role.SUBCOURSE_PARTICIPANT)) {
         assert(modelName === 'Subcourse', 'Type must be a Subcourse to determine access to it');
         assert(root, 'root value must be bound to determine access');
-        if(context.user.pupilId) {
+        if (context.user.pupilId) {
             const pupil = await getPupil(context.user.pupilId);
             const success = await isParticipant(root, pupil);
             if (success) {

--- a/graphql/authorizations.ts
+++ b/graphql/authorizations.ts
@@ -86,11 +86,12 @@ async function accessCheck(context: GraphQLContext, requiredRoles: Role[], model
     if (requiredRoles.includes(Role.SUBCOURSE_PARTICIPANT)) {
         assert(modelName === 'Subcourse', 'Type must be a Subcourse to determine access to it');
         assert(root, 'root value must be bound to determine access');
-        assert(context.user.pupilId, 'User must be a pupil');
-        const pupil = await getPupil(context.user.pupilId);
-        const success = await isParticipant(root, pupil);
-        if (success) {
-            return true;
+        if(context.user.pupilId) {
+            const pupil = await getPupil(context.user.pupilId);
+            const success = await isParticipant(root, pupil);
+            if (success) {
+                return true;
+            }
         }
     }
 


### PR DESCRIPTION
It can definetly happen that non pupils access the resolver guarded by the authorization, in that case we just want to continue and throw a regular authentication error instead of an INTERNAL SERVER ERROR.

(This was only hit by a user once so far, as you need to directly perform some action on the subcourse without running _any other query before_ that would trigger reauthentication). 