### PR TITLE
refactor: open message translations

### DIFF
--- a/graphql/notification/fields.ts
+++ b/graphql/notification/fields.ts
@@ -73,7 +73,7 @@ export class NotificationExtendedFieldsResolver {
         description:
             "The message translation will be rendered in the user's language with a concrete notification context to produce the message the user sees",
     })
-    @Authorized(Role.ADMIN)
+    @Authorized(Role.UNAUTHENTICATED)
     async messageTranslations(@Root() notification: Notification) {
         return await prisma.message_translation.findMany({
             where: { notificationId: notification.id },


### PR DESCRIPTION
Changed authentication of messageTranslations to `Role.UNAUTHENTICATED` to be able to import them in dev environments