### PR TITLE
fix: heroku killing idle websocket connections

### DIFF
--- a/common/websocket/index.ts
+++ b/common/websocket/index.ts
@@ -3,8 +3,6 @@ import { getLogger } from 'log4js';
 import { WebSocketServer, WebSocket } from 'ws';
 import { v4 as createUuid } from 'uuid';
 import { getUserForSession, GraphQLUser } from '../user/session';
-import { setInterval } from 'timers';
-
 type UserId = string;
 type ConnectionId = string;
 


### PR DESCRIPTION
- implemented heartbeat by pinging all client connections
- added debug logs

```log
[2023-03-24T14:05:53.707] [DEBUG] Websockets - Pinging client with ConnectionId(37bdd08f-fbc4-4618-9b42-d6689833d7fd) of User UserId(student/1)}
[2023-03-24T14:05:53.712] [DEBUG] Websockets - Received pong from ConnectionId(37bdd08f-fbc4-4618-9b42-d6689833d7fd) of user UserId(student/1)}
[2023-03-24T14:06:23.707] [DEBUG] Websockets - Pinging client with ConnectionId(37bdd08f-fbc4-4618-9b42-d6689833d7fd) of User UserId(student/1)}
[2023-03-24T14:06:23.708] [DEBUG] Websockets - Received pong from ConnectionId(37bdd08f-fbc4-4618-9b42-d6689833d7fd) of user UserId(student/1)}
```