### PR TITLE
Turn off interest confirmations for the Lern-Fair Now Pool

### DIFF
--- a/common/match/pool.ts
+++ b/common/match/pool.ts
@@ -162,7 +162,7 @@ const balancingCoefficients = {
 const _pools = [
     {
         name: 'lern-fair-now',
-        confirmInterest: true,
+        confirmInterest: false,
         toggles: ['skip-interest-confirmation', 'confirmation-pending', 'confirmation-unknown'],
         pupilsToMatch: (toggles): Prisma.pupilWhereInput => {
             const query: Prisma.pupilWhereInput = {


### PR DESCRIPTION
I think it makes sense to already deactivate the interest confirmations now so that we have a smaller backlog of pending interest confirmations when pupil screening starts.