### PR TITLE
Use dbid as webflow slug

### DIFF
--- a/jobs/periodic/sync-to-webflow/diff.spec.ts
+++ b/jobs/periodic/sync-to-webflow/diff.spec.ts
@@ -34,14 +34,16 @@ describe('diff', () => {
 
         expect(result.new).toStrictEqual([]);
         expect(result.outdated).toStrictEqual([]);
+        expect(result.changed).toStrictEqual([]);
     });
     it('should notice a change in data', () => {
-        const left: TestData[] = [newTestObj(1, 'foo')];
-        const right: TestData[] = [newTestObj(1, 'foobar')];
-        const result = diff(left, right);
+        const left: TestData = newTestObj(1, 'foo');
+        const right: TestData = newTestObj(1, 'foobar');
+        const result = diff([left], [right]);
 
-        expect(result.new).toStrictEqual(right);
-        expect(result.outdated).toStrictEqual(left);
+        expect(result.new).toStrictEqual([]);
+        expect(result.outdated).toStrictEqual([]);
+        expect(result.changed).toStrictEqual([{ ...right, _id: left._id }]);
     });
     it('should create new object as id was not found', () => {
         const newObj = newTestObj(2, 'foo');
@@ -51,6 +53,7 @@ describe('diff', () => {
 
         expect(result.new).toStrictEqual([newObj]);
         expect(result.outdated).toStrictEqual([]);
+        expect(result.changed).toStrictEqual([]);
     });
     it('should should remove missing object', () => {
         const oldObj = newTestObj(2, 'foo');
@@ -60,6 +63,7 @@ describe('diff', () => {
 
         expect(result.new).toStrictEqual([]);
         expect(result.outdated).toStrictEqual([oldObj]);
+        expect(result.changed).toStrictEqual([]);
     });
     it('should notice a diff in id even if the hash is the same', () => {
         const oldObj = newTestObj(1, 'foo');
@@ -73,5 +77,6 @@ describe('diff', () => {
 
         expect(result.new).toStrictEqual([newObj]);
         expect(result.outdated).toStrictEqual([oldObj]);
+        expect(result.changed).toStrictEqual([]);
     });
 });

--- a/jobs/periodic/sync-to-webflow/diff.spec.ts
+++ b/jobs/periodic/sync-to-webflow/diff.spec.ts
@@ -19,11 +19,10 @@ function newTestObj(id: number, data: string): TestData {
         _id: randomString(),
         _archived: randomBool(),
         _draft: randomBool(),
-        slug: '',
-        databaseid: `${id}`,
+        slug: `${id}`,
         data: data,
     };
-    res.slug = hash(res);
+    res.hash = hash(res);
     return res;
 }
 
@@ -65,7 +64,7 @@ describe('diff', () => {
     it('should notice a diff in id even if the hash is the same', () => {
         const oldObj = newTestObj(1, 'foo');
         const newObj = structuredClone(oldObj) as TestData;
-        newObj.databaseid = '2';
+        newObj.slug = '2';
 
         const left: TestData[] = [oldObj];
         const right: TestData[] = [newObj];

--- a/jobs/periodic/sync-to-webflow/diff.ts
+++ b/jobs/periodic/sync-to-webflow/diff.ts
@@ -9,7 +9,7 @@ export function hash<T extends WebflowMetadata>(data: T): string {
 function mapToDBId<T extends WebflowMetadata>(data: T[]): { [key: number]: T } {
     const res = {};
     for (const row of data) {
-        res[row.databaseid] = row;
+        res[row.slug] = row;
     }
     return res;
 }
@@ -26,7 +26,7 @@ export function diff<T extends WebflowMetadata>(left: T[], right: T[]): { new: T
             outdatedEntries.push(leftMap[dbId]);
             continue;
         }
-        if (leftMap[dbId].slug != rightMap[dbId].slug) {
+        if (leftMap[dbId].hash != rightMap[dbId].hash) {
             // This could also be an update operation, but at the end it's the same amount of API operations, but much more code to maintain.
             // Nevertheless, we should monitor the website and update the behavior if we see side-effects.
             outdatedEntries.push(leftMap[dbId]);
@@ -48,7 +48,7 @@ export type DBIdMap = { [key: number]: string };
 export function mapDBIdToId(items: WebflowMetadata[]): DBIdMap {
     const result: DBIdMap = {};
     for (const item of items) {
-        result[item.databaseid] = item._id;
+        result[item.slug] = item._id;
     }
     return result;
 }

--- a/jobs/periodic/sync-to-webflow/index.ts
+++ b/jobs/periodic/sync-to-webflow/index.ts
@@ -28,7 +28,7 @@ export default async function execute(): Promise<void> {
     try {
         logger.info('Run Webflow sync');
         validateEnvVars();
-        await syncLectures(logger);
+        // await syncLectures(logger);
         await syncCourses(logger);
         logger.info('Finished Webflow sync');
     } catch (e) {

--- a/jobs/periodic/sync-to-webflow/index.ts
+++ b/jobs/periodic/sync-to-webflow/index.ts
@@ -28,7 +28,7 @@ export default async function execute(): Promise<void> {
     try {
         logger.info('Run Webflow sync');
         validateEnvVars();
-        // await syncLectures(logger);
+        await syncLectures(logger);
         await syncCourses(logger);
         logger.info('Finished Webflow sync');
     } catch (e) {

--- a/jobs/periodic/sync-to-webflow/sync-courses.ts
+++ b/jobs/periodic/sync-to-webflow/sync-courses.ts
@@ -100,7 +100,7 @@ function courseToDTO(logger: Logger, subcourse: WebflowSubcourse, lectureIds: DB
         ...emptyMetadata,
 
         name: subcourse.course.name,
-        databaseid: `${subcourse.id}`, // We are using a string to be safe for any case.
+        slug: `${subcourse.id}`, // We are using a string to be safe for any case.
 
         description: subcourse.course.description,
         instructor: generateInstructor(subcourse),
@@ -129,7 +129,7 @@ function courseToDTO(logger: Logger, subcourse: WebflowSubcourse, lectureIds: DB
             alt: '',
         },
     };
-    courseDTO.slug = hash(courseDTO);
+    courseDTO.hash = hash(courseDTO);
     return courseDTO;
 }
 

--- a/jobs/periodic/sync-to-webflow/sync-courses.ts
+++ b/jobs/periodic/sync-to-webflow/sync-courses.ts
@@ -1,4 +1,4 @@
-import { createNewItem, deleteItems, emptyMetadata, getCollectionItems, publishItems, WebflowMetadata } from './webflow-adapter';
+import { createNewItem, deleteItems, emptyMetadata, getCollectionItems, patchItem, publishItems, WebflowMetadata } from './webflow-adapter';
 import { diff, hash, mapDBIdToId, DBIdMap } from './diff';
 import { Logger } from 'log4js';
 import moment, { Moment } from 'moment';
@@ -147,6 +147,10 @@ export default async function syncCourses(logger: Logger): Promise<void> {
 
     for (const row of result.new) {
         await createNewItem(collectionId, row);
+    }
+
+    for (const row of result.changed) {
+        await patchItem(collectionId, row);
     }
 
     if (result.outdated.length > 0) {

--- a/jobs/periodic/sync-to-webflow/sync-lectures.ts
+++ b/jobs/periodic/sync-to-webflow/sync-lectures.ts
@@ -22,13 +22,13 @@ function lectureToDTO(lecture: lecture): LectureDTO {
     const start = moment(lecture.start).locale('de');
     const lectureDto: LectureDTO = {
         ...emptyMetadata,
-        databaseid: `${lecture.id}`,
+        slug: `${lecture.id}`,
         start: start.toISOString(),
         duration: `${lecture.duration} min.`,
     };
-    lectureDto.slug = hash(lectureDto);
+    lectureDto.hash = hash(lectureDto);
     // Lectures don't have any names, so to prevent collisions we are just using the hash, which should be unique.
-    lectureDto.name = lectureDto.slug;
+    lectureDto.name = lectureDto.hash;
     return lectureDto;
 }
 

--- a/jobs/periodic/sync-to-webflow/webflow-adapter.ts
+++ b/jobs/periodic/sync-to-webflow/webflow-adapter.ts
@@ -58,6 +58,13 @@ export async function deleteItems(collectionId: string, itemIds: string[]) {
     await request({ path: `collections/${collectionId}/items?live=false`, method: 'DELETE', data: body });
 }
 
+export async function patchItem<T extends WebflowMetadata>(collectionId: string, item: T) {
+    const itemId = item._id;
+    const body = { fields: structuredClone(item) as WebflowMetadata };
+    delete body.fields._id;
+    await request({ path: `collections/${collectionId}/items/${itemId}`, method: 'PATCH', data: body });
+}
+
 export async function publishItems(collectionId: string) {
     const items = await getCollectionItems(collectionId, basicMetaFactory);
     const itemIds = items
@@ -80,7 +87,7 @@ export async function publishItems(collectionId: string) {
 
 interface Request {
     path: string;
-    method: 'GET' | 'POST' | 'DELETE' | 'PUT';
+    method: 'GET' | 'POST' | 'DELETE' | 'PUT' | 'PATCH';
     data?: any;
 }
 

--- a/jobs/periodic/sync-to-webflow/webflow-adapter.ts
+++ b/jobs/periodic/sync-to-webflow/webflow-adapter.ts
@@ -11,9 +11,9 @@ export interface WebflowMetadata {
     _draft?: boolean;
     name?: string;
     // The slug is a unique value that should never be changed because it cannot be reused.
-    // Said that we are using it to store the hash, which should always match the actual data stored in the item.
+    // Said that we are using it to store the database id, which should always match the actual data stored in the item.
     slug?: string;
-    databaseid?: string; // We are using a string to be safe for any case.
+    hash?: string;
     'updated-on'?: string;
     'published-on'?: string;
 }
@@ -23,6 +23,7 @@ export const emptyMetadata: WebflowMetadata = {
     _archived: false,
     _draft: false,
     slug: '',
+    hash: '',
     'updated-on': '',
     'published-on': '',
 };


### PR DESCRIPTION
The Webflow slug is used to identify a specific CMS item and is also used for the URL to show the detail page. For example:
```
https://lern-fair-new.webflow.io/single-course/<slug>
```

Currently, the slug is a hash of the data, which means that the link to the details page will change with every small adaptation of the course. To support static links, we should use the database ID instead. However, in order to do that, we also need to support patch requests because delete/create won't work if the items have the same slug.