### PR TITLE
add open slots to webflow courses

### DIFF
--- a/jobs/periodic/sync-to-webflow/sync-courses.ts
+++ b/jobs/periodic/sync-to-webflow/sync-courses.ts
@@ -26,6 +26,7 @@ interface CourseDTO extends WebflowMetadata {
     link: string;
     maxparticipants: number;
     participantscount: number;
+    openslots: number;
     subject: string;
 
     mingrade: number;
@@ -127,6 +128,7 @@ function courseToDTO(logger: Logger, subcourse: WebflowSubcourse, lectureIds: DB
         link: `${appBaseUrl}/${subcourse.id}`,
         maxparticipants: subcourse.maxParticipants,
         participantscount: subcourse.subcourse_participants_pupil.length,
+        openslots: subcourse.maxParticipants - subcourse.subcourse_participants_pupil.length,
         subject: subcourse.course.subject,
 
         mingrade: subcourse.minGrade,


### PR DESCRIPTION
We want to show conditional elements based on the open slots like "ausgebucht" or "weniger als 5 Plätze verfügbar".

Unfortunately, Webflow doesn't support calculations like max-current in these cases, so we have to do it during the sync.