### PR TITLE
write json formatted logs in non dev environments

### DIFF
--- a/web/setupLogger.ts
+++ b/web/setupLogger.ts
@@ -8,9 +8,9 @@ addLayout('json', function () {
     };
 });
 
-let appenders = ['outJson'];
-if (process.env.ENV === 'dev') {
-    appenders = ['out'];
+let appenders = ['out'];
+if (process.env.LOG_FORMAT === 'json') {
+    appenders = ['outJson'];
 }
 
 configure({

--- a/web/setupLogger.ts
+++ b/web/setupLogger.ts
@@ -3,7 +3,8 @@ import { configure, addLayout } from 'log4js';
 
 addLayout('json', function () {
     return function (logEvent) {
-        return JSON.stringify(logEvent);
+        const message = logEvent.data.shift();
+        return JSON.stringify({ ...logEvent, message });
     };
 });
 

--- a/web/setupLogger.ts
+++ b/web/setupLogger.ts
@@ -1,13 +1,25 @@
 import { isCommandArg } from '../common/util/basic';
-import { configure } from 'log4js';
+import { configure, addLayout } from 'log4js';
+
+addLayout('json', function () {
+    return function (logEvent) {
+        return JSON.stringify(logEvent);
+    };
+});
+
+let appenders = ['outJson'];
+if (process.env.ENV === 'dev') {
+    appenders = ['out'];
+}
 
 configure({
     appenders: {
         out: { type: 'stdout', layout: { type: 'coloured' } },
+        outJson: { type: 'stdout', layout: { type: 'json' } },
     },
     categories: {
         default: {
-            appenders: ['out'],
+            appenders,
             level: isCommandArg('--debug') ? 'debug' : 'info',
         },
     },


### PR DESCRIPTION
Right now, most of the logs are multi-line, which decreases the visibility in our monitoring services. Therefore, we should format them as json, so that every log will be represented in a single line.

With this PR a log line will look like that:

```
{"startTime":"2023-04-06T19:00:03.381Z","categoryName":"default","data":[],"level":{"level":20000,"levelStr":"INFO","colour":"green"},"context":{},"pid":88324,"message":"Server listening on port 4000"}
```