### PR TITLE
Wannabe Roles

### DIFF
--- a/common/student/registration.ts
+++ b/common/student/registration.ts
@@ -108,7 +108,7 @@ export async function becomeInstructor(student: Student, data?: BecomeInstructor
         throw new RedundantError(`Student is already instructor`);
     }
 
-    await prisma.student.update({
+    return await prisma.student.update({
         data: {
             isInstructor: true,
             msg: data ? data.message : '',

--- a/common/user/roles.ts
+++ b/common/user/roles.ts
@@ -15,10 +15,16 @@ export enum Role {
     /* No one should have access */
     NOBODY = 'NOBODY',
 
-    /* User is a student, requested to be a tutor and was successfully screened (E-Mail also verified) */
+    /* User is a student, requested to be a tutor (E-Mail also verified) and is a 'wannabe tutor' ... */
+    WANNABE_TUTOR = 'WANNABE_TUTOR',
+    // ... until they were successfully screened  */
     TUTOR = 'TUTOR',
-    /* User is a student, requested to be a course instructor and was successfully "instructor screened" (E-Mail also verified) */
+
+    /* User is a student, requested to be a course instructor (E-Mail also verified) and is a 'wannabe instructor' ... */
+    WANNABE_INSTRUCTOR = 'WANNABE_INSTRUCTOR',
+    // ... until they were successfully "instructor screened"  */
     INSTRUCTOR = 'INSTRUCTOR',
+
     /* User is a student, requested to be a project coach and was successfully screened (E-Mail also verified) */
     PROJECT_COACH = 'PROJECT_COACH',
 

--- a/graphql/me/mutation.ts
+++ b/graphql/me/mutation.ts
@@ -369,8 +369,11 @@ export class MutateMeResolver {
         const student = await getSessionStudent(context, studentId);
         const log = logInContext('Me', context);
 
-        await becomeInstructor(student, data);
+        const updatedStudent = await becomeInstructor(student, data);
         log.info(`Student(${student.id}) requested to become an instructor`);
+
+        // User gets the WANNABE_INSTRUCTOR role
+        await evaluateStudentRoles(updatedStudent, context);
 
         // After successful screening and re authentication, the user will receive the INSTRUCTOR role
 
@@ -387,9 +390,11 @@ export class MutateMeResolver {
         const student = await getSessionStudent(context, studentId);
         const log = logInContext('Me', context);
 
-        await becomeTutor(student, data);
-
+        const updatedStudent = await becomeTutor(student, data);
         log.info(`Student(${student.id}) requested to become a tutor`);
+
+        // User gets the WANNABE_TUTOR role
+        await evaluateStudentRoles(updatedStudent, context);
 
         // After successful screening and re authentication, the user will receive the TUTOR role
 

--- a/graphql/me/mutation.ts
+++ b/graphql/me/mutation.ts
@@ -1,7 +1,7 @@
 import { Role } from '../authorizations';
 import { Arg, Authorized, Ctx, Field, InputType, Int, Mutation, Resolver } from 'type-graphql';
 import { GraphQLContext } from '../context';
-import { getSessionPupil, getSessionStudent, getSessionUser, isSessionPupil, isSessionStudent, loginAsUser } from '../authentication';
+import { getSessionPupil, getSessionStudent, getSessionUser, isSessionPupil, isSessionStudent, loginAsUser, updateSessionUser } from '../authentication';
 import { prisma } from '../../common/prisma';
 import { activatePupil, deactivatePupil } from '../../common/pupil/activation';
 import { setProjectFields } from '../../common/student/update';
@@ -369,11 +369,11 @@ export class MutateMeResolver {
         const student = await getSessionStudent(context, studentId);
         const log = logInContext('Me', context);
 
-        const updatedStudent = await becomeInstructor(student, data);
+        await becomeInstructor(student, data);
         log.info(`Student(${student.id}) requested to become an instructor`);
 
         // User gets the WANNABE_INSTRUCTOR role
-        await evaluateStudentRoles(updatedStudent, context);
+        await updateSessionUser(context, userForStudent(student));
 
         // After successful screening and re authentication, the user will receive the INSTRUCTOR role
 
@@ -390,11 +390,10 @@ export class MutateMeResolver {
         const student = await getSessionStudent(context, studentId);
         const log = logInContext('Me', context);
 
-        const updatedStudent = await becomeTutor(student, data);
-        log.info(`Student(${student.id}) requested to become a tutor`);
+        await becomeTutor(student, data);
 
         // User gets the WANNABE_TUTOR role
-        await evaluateStudentRoles(updatedStudent, context);
+        await updateSessionUser(context, userForStudent(student));
 
         // After successful screening and re authentication, the user will receive the TUTOR role
 

--- a/graphql/roles.ts
+++ b/graphql/roles.ts
@@ -63,6 +63,8 @@ export async function evaluateStudentRoles(student: Student, context: GraphQLCon
     }
 
     if (student.isStudent || student.isProjectCoach) {
+        context.user.roles.push(Role.WANNABE_TUTOR);
+
         // the user wants to be a tutor or project coach, let's check if they were screened and are authorized to do so
         const wasScreened = (await prisma.screening.count({ where: { studentId: student.id, success: true } })) > 0;
         if (wasScreened) {
@@ -80,6 +82,8 @@ export async function evaluateStudentRoles(student: Student, context: GraphQLCon
     }
 
     if (student.isInstructor) {
+        context.user.roles.push(Role.WANNABE_INSTRUCTOR);
+
         // the user wants to be a course instructor, let's check if they were screened and are authorized to do so
         const wasInstructorScreened = (await prisma.instructor_screening.count({ where: { studentId: student.id, success: true } })) > 0;
         if (wasInstructorScreened) {

--- a/graphql/roles.ts
+++ b/graphql/roles.ts
@@ -63,13 +63,13 @@ export async function evaluateStudentRoles(student: Student, context: GraphQLCon
     }
 
     if (student.isStudent || student.isProjectCoach) {
-        context.user.roles.push(Role.WANNABE_TUTOR);
-
         // the user wants to be a tutor or project coach, let's check if they were screened and are authorized to do so
         const wasScreened = (await prisma.screening.count({ where: { studentId: student.id, success: true } })) > 0;
         if (wasScreened) {
             logger.info(`Student(${student.id}) was screened and has TUTOR role`);
             context.user.roles.push(Role.TUTOR);
+        } else {
+            context.user.roles.push(Role.WANNABE_TUTOR);
         }
     }
 
@@ -82,13 +82,13 @@ export async function evaluateStudentRoles(student: Student, context: GraphQLCon
     }
 
     if (student.isInstructor) {
-        context.user.roles.push(Role.WANNABE_INSTRUCTOR);
-
         // the user wants to be a course instructor, let's check if they were screened and are authorized to do so
         const wasInstructorScreened = (await prisma.instructor_screening.count({ where: { studentId: student.id, success: true } })) > 0;
         if (wasInstructorScreened) {
             logger.info(`Student(${student.id}) was instructor screened and has INSTRUCTOR role`);
             context.user.roles.push(Role.INSTRUCTOR);
+        } else {
+            context.user.roles.push(Role.WANNABE_INSTRUCTOR);
         }
     }
 }

--- a/integration-tests/screening.ts
+++ b/integration-tests/screening.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import { adminClient, test } from "./base";
-import { instructorOne } from "./user";
+import { instructorOne, studentOne } from "./user";
 
 
 export const screenedInstructorOne = test('Screen Instructor One successfully', async () => {
@@ -23,4 +23,26 @@ export const screenedInstructorOne = test('Screen Instructor One successfully', 
     // Got the INSTRUCTOR role!
 
     return { client, instructor };
+});
+
+export const screenedTutorOne = test('Screen Tutor One successfully', async () => {
+    const { client, student } = await studentOne;
+
+    await adminClient.request(`
+        mutation ScreenInstructorOne {
+            studentTutorScreeningCreate(
+                studentId: ${student.student.id}
+                screening: {success: true comment: "" knowsCoronaSchoolFrom: ""}
+            )
+        }
+    `);
+
+    // Refresh roles
+    await client.request(`mutation { loginRefresh }`);
+
+    const { myRoles } = await client.request(`query GetRoles { myRoles }`);
+    assert.deepStrictEqual(myRoles, ['UNAUTHENTICATED', 'USER', 'STUDENT', 'TUTOR']);
+    // Got the TUTOR role!
+
+    return { client, student };
 });

--- a/integration-tests/user.ts
+++ b/integration-tests/user.ts
@@ -151,7 +151,7 @@ export const studentOne = test('Register Student', async () => {
             myRoles
         }
     `);
-    assert.deepStrictEqual(rolesAfterRegistration, ['UNAUTHENTICATED', 'USER']);
+    assert.deepStrictEqual(rolesAfterRegistration, ['UNAUTHENTICATED', 'USER', 'STUDENT']);
 
     await client.request(`mutation RequestVerifyToken { tokenRequest(email: "TEST+${userRandom}@lern-fair.de", action: "user-verify-email")}`);
 

--- a/integration-tests/user.ts
+++ b/integration-tests/user.ts
@@ -138,6 +138,10 @@ export const studentOne = test('Register Student', async () => {
         }
     `);
 
+    const { myRoles: rolesBefore } = await client.request(`query GetRolesAfterBecomeTutor { myRoles }`);
+    assert(rolesBefore.includes('STUDENT'));
+    assert(!rolesBefore.includes('WANNABE_TUTOR'));
+
     await client.request(`
         mutation BecomeTutor {
             meBecomeTutor(data: {
@@ -147,6 +151,10 @@ export const studentOne = test('Register Student', async () => {
             })
         }
     `);
+
+    const { myRoles: rolesAfter } = await client.request(`query GetRolesAfterBecomeTutor { myRoles }`);
+    assert(rolesAfter.includes('WANNABE_TUTOR'));
+
 
     const { me: student } = await client.request(`
         query GetBasics {
@@ -201,6 +209,10 @@ export const instructorOne = test('Register Instructor', async () => {
         }
     `);
 
+    const { myRoles: rolesBefore } = await client.request(`query GetRolesBeforeBecomeInstructor { myRoles }`);
+    assert(rolesBefore.includes('STUDENT'));
+    assert(!rolesBefore.includes('WANNABE_INSTRUCTOR'));
+
     await client.request(`
         mutation BecomeInstructor {
             meBecomeInstructor(data: {
@@ -208,6 +220,10 @@ export const instructorOne = test('Register Instructor', async () => {
             })
         }
     `);
+
+
+    const { myRoles: rolesAfter } = await client.request(`query GetRolesAfterBecomeInstructor { myRoles }`);
+    assert(rolesAfter.includes('WANNABE_INSTRUCTOR'));
 
     const { me: instructor } = await client.request(`
         query GetBasics {
@@ -229,7 +245,7 @@ export const instructorOne = test('Register Instructor', async () => {
     await client.request(`mutation LoginForEmailVerify { loginToken(token: "${token}")}`);
 
     const { myRoles } = await client.request(`query GetRoles { myRoles }`);
-    assert.deepStrictEqual(myRoles, ['UNAUTHENTICATED', 'USER', 'STUDENT']);
+    assert.deepStrictEqual(myRoles, ['UNAUTHENTICATED', 'USER', 'STUDENT', 'WANNABE_INSTRUCTOR']);
     // Not yet INSTRUCTOR as not yet screened
 
     // Ensure that E-Mails are consumed case-insensitive everywhere:

--- a/integration-tests/user.ts
+++ b/integration-tests/user.ts
@@ -163,7 +163,7 @@ export const studentOne = test('Register Student', async () => {
     await client.request(`mutation LoginForEmailVerify { loginToken(token: "${token}")}`);
 
 
-    const { myRoles: rolesBefore } = await client.request(`query GetRolesAfterBecomeTutor { myRoles }`);
+    const { myRoles: rolesBefore } = await client.request(`query GetRolesBeforeBecomeTutor { myRoles }`);
     assert.deepStrictEqual(rolesBefore, ['UNAUTHENTICATED', 'USER', 'STUDENT']);
 
     await client.request(`
@@ -177,7 +177,7 @@ export const studentOne = test('Register Student', async () => {
     `);
 
     const { myRoles: rolesAfter } = await client.request(`query GetRolesAfterBecomeTutor { myRoles }`);
-    assert.deepStrictEqual(rolesBefore, ['UNAUTHENTICATED', 'USER', 'STUDENT', 'WANNABE_TUTOR']);
+    assert.deepStrictEqual(rolesAfter, ['UNAUTHENTICATED', 'USER', 'STUDENT', 'WANNABE_TUTOR']);
     // Not yet TUTOR as not yet screened
 
 


### PR DESCRIPTION
We recently introduced new UIs for users that "want to be tutor / instructor / ..." but were not yet screened.
I think these should be separate roles going forward (we currently use `student { canRequestMatch canCreateCourse }` to detect this). 

As a bonus we do not need another request on the Matching or Tutoring Tab in the User-App and can just take the roles from the user session. That should make loading these tabs a lot smoother. 




<sub>[Inspired by the Spice Girls](https://www.youtube.com/watch?v=gJLIiF15wjQ): _If you wanna be a tutor, you have to be screened..._</sub>