### PR TITLE
Switch from Postgres Hobby Dev to Mini for Review Apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -27,7 +27,7 @@
                 "MAILJET_LIVE": "0"
             },
             "addons": [
-                "heroku-postgresql:hobby-dev"
+                "heroku-postgresql:mini"
             ]
         }
     },


### PR DESCRIPTION
THe free Hobby Dev plan was discontinued, we now need to pay for review apps (c.f. https://help.heroku.com/RSBRUH58/removal-of-heroku-free-product-plans-faq)