### PR TITLE
Adjust type of notification object in Notification.update function

### DIFF
--- a/common/notification/notification.ts
+++ b/common/notification/notification.ts
@@ -9,6 +9,7 @@ import { getLogger } from '../../common/logger/logger';
 import { hookExists } from './hook';
 import { getNotificationActions } from './actions';
 import { MessageTemplateType } from '../../graphql/types/notificationMessage';
+import { NotificationUpdateInput } from '../../graphql/generated';
 
 type MessageTranslationFromDb = {
     template: {
@@ -97,8 +98,8 @@ export async function activate(id: NotificationID, active: boolean): Promise<voi
     invalidateCache();
 }
 
-export async function update(id: NotificationID, values: Partial<Omit<Notification, 'active'>>) {
-    if (values.hookID && !hookExists(values.hookID)) {
+export async function update(id: NotificationID, values: Partial<Omit<NotificationUpdateInput, 'active'>>) {
+    if (values.hookID && !hookExists(values.hookID.set)) {
         throw new Error(`Invalid HookID`);
     }
 


### PR DESCRIPTION
I wasn't able to add a hook to a notification because the notificationUpdate endpoint [feeds an object of type `NotificationUpdateInput` into `Notification.update`](https://github.com/corona-school/backend/blob/02468d7f7159ffbabaf8fad15e6404e2db8b28c4/graphql/notification/mutations.ts#L79), but `Notification.update` expects a `Notification`.