### PR TITLE
Fix order in which existing CoC reminders are cancelled and remission requests are created

### DIFF
--- a/common/student/screening.ts
+++ b/common/student/screening.ts
@@ -73,8 +73,8 @@ export async function scheduleCoCReminders(student: Student, ignoreAccCreationDa
         return;
     }
 
-    await createRemissionRequest(student);
     await cancelCoCReminders(student);
+    await createRemissionRequest(student);
     await Notification.actionTaken(student, 'coc_reminder', {});
 }
 

--- a/common/student/screening.ts
+++ b/common/student/screening.ts
@@ -65,14 +65,6 @@ export async function scheduleCoCReminders(student: Student, ignoreAccCreationDa
         return;
     }
 
-    const remissionRequest = await prisma.remission_request.findUnique({
-        where: { studentId: student.id },
-    });
-
-    if (remissionRequest) {
-        return;
-    }
-
     await cancelCoCReminders(student);
     await createRemissionRequest(student);
     await Notification.actionTaken(student, 'coc_reminder', {});


### PR DESCRIPTION
As cancelling the CoC reminders invokes the cancel-remission-request hook we have to create the remission request *after* cancelling preexisting CoC reminders in `scheduleCoCReminders`