### PR TITLE
Fix cancel coc hook delete -> deleteMany

### DIFF
--- a/common/remission-request/index.ts
+++ b/common/remission-request/index.ts
@@ -109,5 +109,5 @@ export async function createRemissionRequestVerificationPage(remissionRequestUUI
 
 export async function cancelRemissionRequest(student: student) {
     logger.info(`Cancelled remission request for Student(${student.id})`);
-    await prisma.remission_request.delete({ where: { studentId: student.id } });
+    await prisma.remission_request.deleteMany({ where: { studentId: student.id } });
 }

--- a/common/student/screening.ts
+++ b/common/student/screening.ts
@@ -73,8 +73,8 @@ export async function scheduleCoCReminders(student: Student, ignoreAccCreationDa
         return;
     }
 
-    await createRemissionRequest(student);
     await cancelCoCReminders(student);
+    await createRemissionRequest(student);
     await Notification.actionTaken(student, 'coc_reminder', {});
 }
 

--- a/common/student/screening.ts
+++ b/common/student/screening.ts
@@ -65,14 +65,6 @@ export async function scheduleCoCReminders(student: Student, ignoreAccCreationDa
         return;
     }
 
-    const remissionRequest = await prisma.remission_request.findUnique({
-        where: { studentId: student.id },
-    });
-
-    if (remissionRequest) {
-        return;
-    }
-
     await cancelCoCReminders(student);
     await createRemissionRequest(student);
     await Notification.actionTaken(student, 'coc_reminder', {});


### PR DESCRIPTION
Prisma throws in the cancel-remission-request hook if no remission request exists, thus failing the entire cocCancel notification. Thus, deleteMany should be used as it deletes an arbitrary amount of remission requests.