### PR TITLE
Entity roles

### DIFF
--- a/graphql/authorizations.ts
+++ b/graphql/authorizations.ts
@@ -67,7 +67,7 @@ export function AuthorizedDeferred(...requiredRoles: Role[]) {
 //  as they own the pupil entity, the user is the pupil we depart from, and thus the user is a participant of all subcourses:
 //    Pupil(1)   --[ subcoursesJoined ]  --> Subcourse(123)
 //    Role.OWNER
-// With this decorator, we can mark subcoursesJoined with @ImpliesRoleOnResult(Role.SUBCOURSE_PARTICIPANT),
+// With this decorator, we can mark subcoursesJoined with @ImpliesRoleOnResult(Role.SUBCOURSE_PARTICIPANT, Role.OWNER),
 //  and all subcourses returned by 'subcoursesJoined' will be marked with the respective role
 // Then when the 'otherParticipants' edge is evaluated on each subcourse, we already know the role and can skip the access check
 //

--- a/graphql/pupil/fields.ts
+++ b/graphql/pupil/fields.ts
@@ -34,7 +34,7 @@ export class ExtendFieldsPupilResolver {
     @FieldResolver((type) => [Subcourse])
     @Authorized(Role.ADMIN, Role.OWNER)
     @LimitEstimated(10)
-    @ImpliesRoleOnResult(Role.SUBCOURSE_PARTICIPANT)
+    @ImpliesRoleOnResult(Role.SUBCOURSE_PARTICIPANT, /* if we are */ Role.OWNER)
     async subcoursesJoined(
         @Root() pupil: Required<Pupil>,
         @Arg('excludePast', { nullable: true }) excludePast?: boolean,
@@ -119,7 +119,7 @@ export class ExtendFieldsPupilResolver {
     @FieldResolver((type) => [Match])
     @Authorized(Role.ADMIN, Role.OWNER)
     @LimitEstimated(10)
-    @ImpliesRoleOnResult(Role.OWNER)
+    @ImpliesRoleOnResult(Role.OWNER, /* if we are */ Role.OWNER)
     async matches(@Root() pupil: Required<Pupil>) {
         return await prisma.match.findMany({
             where: { pupilId: pupil.id },

--- a/graphql/pupil/fields.ts
+++ b/graphql/pupil/fields.ts
@@ -10,7 +10,7 @@ import {
 } from '../generated';
 import { Arg, Authorized, Field, FieldResolver, Int, Resolver, Root } from 'type-graphql';
 import { prisma } from '../../common/prisma';
-import { Role } from '../authorizations';
+import { ImpliesRoleOnResult, Role } from '../authorizations';
 import { getUserIdTypeORM, userForPupil } from '../../common/user';
 import { LimitEstimated } from '../complexity';
 import { Subject } from '../types/subject';
@@ -34,6 +34,7 @@ export class ExtendFieldsPupilResolver {
     @FieldResolver((type) => [Subcourse])
     @Authorized(Role.ADMIN, Role.OWNER)
     @LimitEstimated(10)
+    @ImpliesRoleOnResult(Role.SUBCOURSE_PARTICIPANT)
     async subcoursesJoined(
         @Root() pupil: Required<Pupil>,
         @Arg('excludePast', { nullable: true }) excludePast?: boolean,
@@ -118,6 +119,7 @@ export class ExtendFieldsPupilResolver {
     @FieldResolver((type) => [Match])
     @Authorized(Role.ADMIN, Role.OWNER)
     @LimitEstimated(10)
+    @ImpliesRoleOnResult(Role.OWNER)
     async matches(@Root() pupil: Required<Pupil>) {
         return await prisma.match.findMany({
             where: { pupilId: pupil.id },

--- a/graphql/student/fields.ts
+++ b/graphql/student/fields.ts
@@ -12,7 +12,7 @@ import {
 } from '../generated';
 import { Arg, Authorized, Ctx, FieldResolver, Int, ObjectType, Query, Resolver, Root } from 'type-graphql';
 import { prisma } from '../../common/prisma';
-import { Role } from '../authorizations';
+import { ImpliesRoleOnResult, Role } from '../authorizations';
 import { LimitedQuery, LimitEstimated } from '../complexity';
 import { Subject } from '../types/subject';
 import { parseSubjectString } from '../../common/util/subjectsutils';
@@ -71,6 +71,7 @@ export class ExtendFieldsStudentResolver {
     @FieldResolver((type) => [Match])
     @Authorized(Role.ADMIN, Role.OWNER)
     @LimitEstimated(10)
+    @ImpliesRoleOnResult(Role.OWNER)
     async matches(@Root() student: Required<Student>) {
         return await prisma.match.findMany({
             where: { studentId: student.id },
@@ -142,6 +143,7 @@ export class ExtendFieldsStudentResolver {
     @FieldResolver((type) => [Subcourse])
     @Authorized(Role.ADMIN, Role.OWNER)
     @LimitEstimated(10)
+    @ImpliesRoleOnResult(Role.OWNER)
     async subcoursesInstructing(@Root() student: Required<Student>, @Arg('excludePast', { nullable: true }) excludePast?: boolean) {
         const filters: Prisma.subcourseWhereInput[] = [instructedBy(student)];
 
@@ -155,6 +157,7 @@ export class ExtendFieldsStudentResolver {
     @FieldResolver((type) => [Course])
     @Authorized(Role.ADMIN, Role.OWNER)
     @LimitEstimated(10)
+    @ImpliesRoleOnResult(Role.OWNER)
     async coursesInstructing(@Root() student: Student) {
         return await prisma.course.findMany({ where: { course_instructors_student: { some: { studentId: student.id } } } });
     }

--- a/graphql/student/fields.ts
+++ b/graphql/student/fields.ts
@@ -71,7 +71,7 @@ export class ExtendFieldsStudentResolver {
     @FieldResolver((type) => [Match])
     @Authorized(Role.ADMIN, Role.OWNER)
     @LimitEstimated(10)
-    @ImpliesRoleOnResult(Role.OWNER)
+    @ImpliesRoleOnResult(Role.OWNER, /* if we are */ Role.OWNER)
     async matches(@Root() student: Required<Student>) {
         return await prisma.match.findMany({
             where: { studentId: student.id },
@@ -143,7 +143,7 @@ export class ExtendFieldsStudentResolver {
     @FieldResolver((type) => [Subcourse])
     @Authorized(Role.ADMIN, Role.OWNER)
     @LimitEstimated(10)
-    @ImpliesRoleOnResult(Role.OWNER)
+    @ImpliesRoleOnResult(Role.OWNER, /* if we are */ Role.OWNER)
     async subcoursesInstructing(@Root() student: Required<Student>, @Arg('excludePast', { nullable: true }) excludePast?: boolean) {
         const filters: Prisma.subcourseWhereInput[] = [instructedBy(student)];
 
@@ -157,7 +157,7 @@ export class ExtendFieldsStudentResolver {
     @FieldResolver((type) => [Course])
     @Authorized(Role.ADMIN, Role.OWNER)
     @LimitEstimated(10)
-    @ImpliesRoleOnResult(Role.OWNER)
+    @ImpliesRoleOnResult(Role.OWNER, /* if we are */ Role.OWNER)
     async coursesInstructing(@Root() student: Student) {
         return await prisma.course.findMany({ where: { course_instructors_student: { some: { studentId: student.id } } } });
     }


### PR DESCRIPTION
Introduce the concept of "entity roles" that are evaluated per entity, cache the role once it was evaluated (so that it can be reused when checking permissions for multiple field resolvers on the same entity). Also add the `@ImpliesRoleOnResult` decorator to skip entity role checks when the role is already clear from the context.

-----

When querying:

```gql
query { 
   me { 
      pupil { 
         subcoursesJoined { # imply role on result
            otherParticipants { firstname } # check role from cache
         } 
      } 
   }
}
```

The average response time drops from **35ms to 15ms** as a lot of entity role checks can be skipped ([details](https://github.com/corona-school/backend-loader))