### PR TITLE
refactor: update Expected error occoured logs

### DIFF
--- a/graphql/logging.ts
+++ b/graphql/logging.ts
@@ -30,7 +30,7 @@ export const GraphQLLogger: any = {
             didEncounterErrors(requestContext: GraphQLRequestContext) {
                 const unexpected = requestContext.errors.some(isUnexpectedError);
                 if (!unexpected) {
-                    logger.info(`Expected Errors occurred`, { errors: requestContext.errors.map((it) => `  - ${it.name} (${it.message})`) });
+                    requestContext.errors.map((it) => logger.info('Expected Errors occurred', { error: `${it.name} (${it.message})` }));
                 } else {
                     logger.addContext('uid', uid);
                     for (const err of requestContext.errors) {


### PR DESCRIPTION
Logging every error separately helps us to filter & investigate them.
Right now, it's neither possible to show them as column nor to create a filter in the [DD UI](https://app.datadoghq.eu/logs?query=env%3Aproduction%20service%3Aweb.1%20-%40categoryName%3Aaccess%20message%3A%22Expected%20Errors%20occurred%22%20&cols=%40level%2C%40categoryName%2Cmessage&event=AgAAAYh6zBcnru61IQAAAAAAAAAYAAAAAEFZaDZ6QmhkQUFDVlZlR0Fvemd5OFFBRAAAACQAAAAAMDE4ODdhZDQtOGY0Zi00YzMzLTg4OGItZDY1MmNlYWRmNGJk&index=%2A&messageDisplay=inline&saved-view-id=78591&stream_sort=desc&viz=stream&from_ts=1685687137580&to_ts=1685687515924&live=false)

AFAICS most of the logs do not have multiple errors attached, so it should not increase the log volume.