### PR TITLE
End-to-end integration tests

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -45,18 +45,11 @@ jobs:
         run: npx prisma generate
 
       - run: npm run build --if-present
-      - run: (npm run web &) | (timeout --preserve-status --foreground 10 cat; cat > /dev/null &) || exit 0
+      - run: npm test
+      - run: npm run integration tests
         env:
           DATABASE_URL: "postgres://coronaschool:coronanervt@localhost:5432/coronaschool-test"
-          ADMIN_AUTH_TOKEN: admintoken
-          ENV: dev
-          SKIP_NOTIFICATION_IMPORT: "true"
-      - run: npm run integration-tests
-        env:
-          INTEGRATION_TARGET: "http://localhost:5000/apollo"
-          INTEGRATION_SILENT: "true"
-          ADMIN_AUTH_TOKEN: admintoken
-
+        
   lint:
     runs-on: ubuntu-20.04
 
@@ -81,4 +74,3 @@ jobs:
         run: npx prisma generate
 
       - run: npm run linter
-      - run: npm test

--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ The development version of the jobs can be run using `npm run jobs:dev`.
 The `/assets` folder contains development versions of various files. During Heroku builds, the folder is replaced by a secret version that is maintained in a [separate private repository](https://github.com/corona-school/coronaschool-certificate). The commit id of the version pulled is 
 stored in `.certificate-version`. 
 
+#### Configuration
+
+The following configuration can be done via ENV variables:
+
+| Name            | Value            | Description                                                                    |
+|-----------------|------------------|--------------------------------------------------------------------------------|
+| LOG_FORMAT      | (unset)          | Every log prefixed by session and transaction id, also log HTTP requests       |
+|                 | json             | Log as JSON, used in deployed environemnts to pass rich info to Datadog        |
+|                 | brief            | Only log category and message (omitting session prefix and HTTP requests)      |
+
 
 #### Command line arguments
 

--- a/common/logger/logger.ts
+++ b/common/logger/logger.ts
@@ -21,6 +21,8 @@ addLayout('json', function () {
 let appenders = ['out'];
 if (process.env.LOG_FORMAT === 'json') {
     appenders = ['outJson'];
+} else if (process.env.LOG_FORMAT === 'brief') {
+    appenders = ['outBrief'];
 }
 
 configure({
@@ -39,6 +41,13 @@ configure({
                         return '';
                     },
                 },
+            },
+        },
+        outBrief: {
+            type: 'stdout',
+            layout: {
+                type: 'pattern',
+                pattern: '     %[[%c]%] %m{0, 1}',
             },
         },
         outJson: { type: 'stdout', layout: { type: 'json' } },

--- a/common/notification/notification.ts
+++ b/common/notification/notification.ts
@@ -367,7 +367,7 @@ export async function importMessageTranslations(messageTranslations: MessageTran
         throw new Error(log);
     }
 
-    logger.info(log);
+    logger.info('Message Translations imported', { log });
     return log;
 }
 

--- a/common/notification/notification.ts
+++ b/common/notification/notification.ts
@@ -237,7 +237,7 @@ export async function importNotifications(notifications: Notification[], dropBef
         }
     }
 
-    logger.info(log);
+    logger.info('Imported Notifications', { log });
     return log;
 }
 

--- a/common/prisma/index.ts
+++ b/common/prisma/index.ts
@@ -3,4 +3,6 @@ import { PrismaClient } from '@prisma/client';
 /* In the development environment, also log 'query'
    which is the SQL query sent to the database.
    Through that, queries can be optimized for performance */
-export const prisma = new PrismaClient(process.env.ENV !== 'dev' ? undefined : { log: ['query', 'info', `warn`, `error`] });
+export const prisma = new PrismaClient(
+    process.env.ENV !== 'dev' || process.env.LOG_FORMAT === 'brief' ? undefined : { log: ['query', 'info', `warn`, `error`] }
+);

--- a/integration-tests/WRITING_TESTS.md
+++ b/integration-tests/WRITING_TESTS.md
@@ -4,17 +4,14 @@
 
 **Non Goals** of the tests is to cover each and every feature and ensure that nothing breaks, also we do not want to reach full coverage / test-driven development. We simply don't have capacity for that.
 
-To run integration tests locally, ensure that the environment variables `ADMIN_AUTH_TOKEN` and `INTEGRATION_TARGET` are set correctly in your `.env` (i.e. take them over from `.env.example`) and `SKIP_NOTIFICATION_IMPORT` is also set. Then start the Backend with `npm run web` and run the integration tests with `npm run integration-tests:local`, or copy and paste these into a shell:
-```
-SKIP_NOTIFICATION_IMPORT=true ADMIN_AUTH_TOKEN=admin npm run web
-INTEGRATION_TARGET=http://localhost:5000/apollo ADMIN_AUTH_TOKEN=admin npm run integration-tests
-```
+To run integration tests locally, ensure the database url is set correctly to some local database, then run the integration tests with `npm run integration-tests`.
 
 To write a new integration test, add a new Typescript file to `/integration-tests` and import it from `index.ts`.
 A test consists of the following parts:
 - the `test` function gives the test a name and handles errors
 - with the clients `defaultClient` (unauthenticated user), `adminClient` and the clients created with `createUserClient` one can send requests to GraphQL via the `.request` and `.requestShallFail` methods
 - For validation the [`assert`](https://nodejs.org/api/assert.html) module of NodeJS is used
+- calls to external systems must be mocked with `expectFetch`
 
 The result when look like this:
 

--- a/integration-tests/base.ts
+++ b/integration-tests/base.ts
@@ -1,6 +1,8 @@
 import { randomBytes } from "crypto";
 import { GraphQLClient } from "graphql-request";
 
+import "./mock";
+
 import * as WebServer from "../web";
 
 /* -------------- Configuration ------------------- */

--- a/integration-tests/base.ts
+++ b/integration-tests/base.ts
@@ -15,9 +15,9 @@ const silent = process.env.INTEGRATION_SILENT === "true";
 
 /* -------------- Utils --------------------------- */
 
-const blue = (msg: string) => '\u001b[94m' + msg + '\u001b[39m';
-const red = (msg: string) => '\u001b[31m' + msg + '\u001b[39m';
-const green = (msg: string) => '\u001b[32m' + msg + '\u001b[39m';
+export const blue = (msg: string) => '\u001b[94m' + msg + '\u001b[39m';
+export const red = (msg: string) => '\u001b[31m' + msg + '\u001b[39m';
+export const green = (msg: string) => '\u001b[32m' + msg + '\u001b[39m';
 
 console.log(
     blue(`\n\nBackend Integration Tests\n`) +

--- a/integration-tests/base.ts
+++ b/integration-tests/base.ts
@@ -1,10 +1,12 @@
 import { randomBytes } from "crypto";
 import { GraphQLClient } from "graphql-request";
 
+import * as WebServer from "../web";
+
 /* -------------- Configuration ------------------- */
 
 const APP = "lernfair-backend-dev";
-const URL = process.env.INTEGRATION_TARGET ?? `https://${APP}.herokuapp.com/apollo`;
+const URL = process.env.INTEGRATION_TARGET ?? `http://localhost:${process.env.PORT ?? 5000}/apollo`;
 const ADMIN_TOKEN = process.env.ADMIN_AUTH_TOKEN;
 
 const silent = process.env.INTEGRATION_SILENT === "true";
@@ -115,10 +117,16 @@ export function test<T>(name: string, runner: () => Promise<T>): Promise<T> {
 
 // This one actually runs all tests that were defined
 export async function finalizeTests() {
+    console.log(blue('-------------------- SETUP ------------------------'));
+
+    await WebServer.started;
+
+    console.log(blue('\n\n-------------------- TESTING ----------------------'));
+
     const startAll = Date.now();
     let failureCount = 0;
     for (const test of tests) {
-        console.log(`test ${test.name}:`);
+        console.log(blue(`\n\n------------------ TEST ${test.name} -----------`));
         try {
             const start = Date.now();
             const result = await test.runner();
@@ -133,16 +141,22 @@ export async function finalizeTests() {
         }
     }
 
-    console.log(`\n\nsummary:`);
-
     const durationAll = Date.now() - startAll;
 
     if (failureCount === 0) {
-        console.log(green(`  all tests SUCCEEDED in ${durationAll}ms`));
+        console.log(blue('\n\n-------------------- TEARDOWN ------------------------'));
+        await WebServer.shutdown();
+        console.log(green(`Regular shut down done, stop pending tasks by sending SIGINT to self`));
+        process.kill(process.pid, "SIGINT");
+
+        console.log(green(`\n\n\nAll tests SUCCEEDED in ${durationAll}ms`));
+
+
         return;
     }
 
-    console.error(red(`  ${failureCount} tests FAILED`));
+    console.error(red(`\n\n\n${failureCount} tests FAILED`));
+
 
     process.exit(1); // A non-zero return code indicates a failure to the pipeline
 }

--- a/integration-tests/mock.ts
+++ b/integration-tests/mock.ts
@@ -1,4 +1,5 @@
 import assert from "assert";
+import { red } from "./base";
 
 interface MockedFetch {
     url: string;
@@ -22,11 +23,14 @@ export function setupFetchMock() {
         if (expectedCalls.length > 0 && expectedCalls[0].url === url) {
             const expectedCall = expectedCalls.shift();
             assert.strictEqual(options.body, expectedCall.body, `Wrong Body of request to ${url}`);
+            console.log(`Request to ${url} mocked`);
             return new Response(expectedCall.response, { status: expectedCall.responseStatus });
         }
 
-        console.log(`  request to ${url} not mocked`);
-        return originalFetch(resource, options);
+        console.log(red(`Request to ${url} not mocked! The integration tests must be self containing `));
+        process.exit(1);
+
+        // return originalFetch(resource, options);
     }
 
     global.fetch = mockedFetch;

--- a/integration-tests/mock.ts
+++ b/integration-tests/mock.ts
@@ -1,0 +1,35 @@
+import assert from "assert";
+
+interface MockedFetch {
+    url: string;
+    body: string;
+    responseStatus: number;
+    response: string;
+}
+
+// A FIFO queue of mocked calls, thus expectFetch(...) must be called in order
+const expectedCalls: MockedFetch[] = [];
+
+export function expectFetch(mocked: MockedFetch) {
+    expectedCalls.push(mocked);
+}
+
+export function setupFetchMock() {
+    const originalFetch = global.fetch;
+
+    async function mockedFetch(resource: RequestInfo, options: RequestInit) {
+        const url = "" + resource;
+        if (expectedCalls.length > 0 && expectedCalls[0].url === url) {
+            const expectedCall = expectedCalls.shift();
+            assert.strictEqual(options.body, expectedCall.body, `Wrong Body of request to ${url}`);
+            return new Response(expectedCall.response, { status: expectedCall.responseStatus });
+        }
+
+        console.log(`  request to ${url} not mocked`);
+        return originalFetch(resource, options);
+    }
+
+    global.fetch = mockedFetch;
+}
+
+setupFetchMock();

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "db:migration:show": "npm run typeorm -- migration:show",
     "linter": "eslint . --ext .ts",
     "heroku:release": "if [ \"$ENV\" = 'production' ]; then npx typeorm migration:run; else echo 'Will only run migration in production...'; fi",
-    "integration-tests": "node -r source-map-support/register ./built/integration-tests/index.js",
-    "integration-tests:local": "node -r source-map-support/register -r dotenv/config ./built/integration-tests/index.js",
+    "integration-tests": "LOG_FORMAT=brief ADMIN_AUTH_TOKEN=admintoken SKIP_NOTIFICATION_IMPORT=true node -r source-map-support/register ./built/integration-tests/index.js",
     "prettier": "./prettier-commits.sh",
     "prettier-on": "prettier --write",
     "test": "jest"

--- a/web/dev.ts
+++ b/web/dev.ts
@@ -35,6 +35,9 @@ import { getNotifications, importMessageTranslations, importNotifications } from
 import { Subject } from '../common/entity/Subject';
 import { _createFixedToken, createPassword } from '../common/secret';
 import { userForStudent, userForPupil } from '../common/user';
+import { getLogger } from '../common/logger/logger';
+
+const logger = getLogger('DevSetup');
 
 export async function setupDevDB() {
     const conn = getConnection();
@@ -216,7 +219,7 @@ export async function setupDevDB() {
 
     for (let i = 0; i < pupils.length; i++) {
         await entityManager.save(Pupil, pupils[i]);
-        console.log('Inserted Dev Pupil ' + i);
+        logger.debug('Inserted Dev Pupil ' + i);
         await _createFixedToken(userForPupil(pupils[i]), `authtokenP${i + 1}`);
         if (i % 2 === 0) {
             await createPassword(userForPupil(pupils[i]), `test`);
@@ -363,7 +366,7 @@ export async function setupDevDB() {
 
     for (let i = 0; i < students.length; i++) {
         await entityManager.save(Student, students[i]);
-        console.log('Inserted Dev Student ' + i);
+        logger.debug('Inserted Dev Student ' + i);
         await _createFixedToken(userForStudent(students[i]), `authtokenS${i + 1}`);
         if (i % 2 === 0) {
             await createPassword(userForStudent(students[i]), `test`);
@@ -379,7 +382,7 @@ export async function setupDevDB() {
 
     for (let i = 0; i < matches.length; i++) {
         await entityManager.save(Match, matches[i]);
-        console.log('Inserted Dev Match ' + i);
+        logger.debug('Inserted Dev Match ' + i);
     }
 
     const projectMatches: ProjectMatch[] = [];
@@ -390,7 +393,7 @@ export async function setupDevDB() {
 
     for (let i = 0; i < projectMatches.length; i++) {
         await entityManager.save(ProjectMatch, projectMatches[i]);
-        console.log('Inserted Dev ProjectMatch ' + i);
+        logger.debug('Inserted Dev ProjectMatch ' + i);
     }
 
     const signature = Buffer.from(
@@ -542,7 +545,7 @@ export async function setupDevDB() {
 
     for (const cert of [pc1, pc2, pc3, pc4, pc5]) {
         await entityManager.save(ParticipationCertificate, cert);
-        console.log('Inserted a certificate with ID: ' + cert.uuid);
+        logger.debug('Inserted a certificate with ID: ' + cert.uuid);
     }
 
     // mentor
@@ -573,7 +576,7 @@ export async function setupDevDB() {
 
     for (let i = 0; i < mentors.length; i++) {
         await entityManager.save(Mentor, mentors[i]);
-        console.log('Inserted Dev Mentor ' + i);
+        logger.debug('Inserted Dev Mentor ' + i);
     }
 
     // course tags
@@ -700,7 +703,7 @@ export async function setupDevDB() {
 
     for (let i = 0; i < tags.length; i++) {
         await entityManager.save(CourseTag, tags[i]);
-        console.log('Inserted Course Tag ' + tags[i].identifier);
+        logger.debug('Inserted Course Tag ' + tags[i].identifier);
     }
 
     // courses
@@ -866,7 +869,7 @@ export async function setupDevDB() {
     for (const course of courses) {
         await entityManager.save(Course, course);
 
-        console.log('Inserted Course ' + course.name);
+        logger.debug('Inserted Course ' + course.name);
     }
 
     // courses
@@ -1017,7 +1020,7 @@ export async function setupDevDB() {
 
     for (const subcourse of subcourses) {
         await entityManager.save(Subcourse, subcourse);
-        console.log('Inserted SubCourse.');
+        logger.debug('Inserted SubCourse.');
     }
 
     // lectures
@@ -1126,7 +1129,7 @@ export async function setupDevDB() {
 
     for (const lecture of lectures) {
         await entityManager.save(Lecture, lecture);
-        console.log('Inserted Lecture.');
+        logger.debug('Inserted Lecture.');
     }
 
     // Screening results
@@ -1157,7 +1160,7 @@ export async function setupDevDB() {
 
     for (let i = 0; i < screeners.length; i++) {
         await entityManager.save(Screener, screeners[i]);
-        console.log('Inserted Dev Screener ' + i);
+        logger.debug('Inserted Dev Screener ' + i);
     }
 
     const screenings: Screening[] = [];
@@ -1193,7 +1196,7 @@ export async function setupDevDB() {
 
     for (let i = 0; i < screenings.length; i++) {
         await entityManager.save(Screening, screenings[i]);
-        console.log('Inserted Dev Screening ' + i);
+        logger.debug('Inserted Dev Screening ' + i);
     }
 
     // instructor screening
@@ -1228,7 +1231,7 @@ export async function setupDevDB() {
 
     for (let i = 0; i < instructorScreenings.length; i++) {
         await entityManager.save(InstructorScreening, instructorScreenings[i]);
-        console.log('Inserted Dev Instrcutor Screening ' + i);
+        logger.debug('Inserted Dev Instrcutor Screening ' + i);
     }
 
     //project coaching screenings
@@ -1245,7 +1248,7 @@ export async function setupDevDB() {
 
     for (let i = 0; i < projectCoachingScreenings.length; i++) {
         await entityManager.save(ProjectCoachingScreening, projectCoachingScreenings[i]);
-        console.log('Inserted Dev Project Screening ' + i);
+        logger.debug('Inserted Dev Project Screening ' + i);
     }
 
     // Test data for course attendance log
@@ -1258,7 +1261,7 @@ export async function setupDevDB() {
         courseAttendanceLog1.pupil = pupils[i];
         courseAttendanceLog1.lecture = lecture3;
         await entityManager.save(CourseAttendanceLog, courseAttendanceLog1);
-        console.log('Inserted Dev CourseAttendanceLog ' + i);
+        logger.debug('Inserted Dev CourseAttendanceLog ' + i);
 
         // pupil attended today's lecture, which is already over
         const courseAttendanceLog2 = new CourseAttendanceLog();
@@ -1266,7 +1269,7 @@ export async function setupDevDB() {
         courseAttendanceLog2.pupil = pupils[i];
         courseAttendanceLog2.lecture = lecture5;
         await entityManager.save(CourseAttendanceLog, courseAttendanceLog2);
-        console.log('Inserted Dev CourseAttendanceLog ' + i);
+        logger.debug('Inserted Dev CourseAttendanceLog ' + i);
     }
 
     //Insert some schools
@@ -1284,7 +1287,7 @@ export async function setupDevDB() {
 
     for (let i = 0; i < schools.length; i++) {
         await entityManager.save(schools[i]);
-        console.log('Inserted Dev School ' + i);
+        logger.debug('Inserted Dev School ' + i);
     }
 
     //Insert expert data
@@ -1302,7 +1305,7 @@ export async function setupDevDB() {
 
     for (let i = 0; i < expertiseTags.length; i++) {
         await entityManager.save(expertiseTags[i]);
-        console.log('Inserted Expertise Tag ' + i);
+        logger.debug('Inserted Expertise Tag ' + i);
     }
 
     const experts: ExpertData[] = [];
@@ -1349,7 +1352,7 @@ export async function setupDevDB() {
 
     for (let i = 0; i < experts.length; i++) {
         await entityManager.save(experts[i]);
-        console.log('Inserted Dev Expert ' + i);
+        logger.debug('Inserted Dev Expert ' + i);
     }
 
     //Insert pupil interest confirmation requests
@@ -1364,7 +1367,7 @@ export async function setupDevDB() {
 
     for (let i = 0; i < pticrs.length; i++) {
         await entityManager.save(pticrs[i]);
-        console.log('Inserted Pupil Tutoring Interest Request ' + i);
+        logger.debug('Inserted Pupil Tutoring Interest Request ' + i);
     }
 
     const certificates: CertificateOfConduct[] = [];
@@ -1379,7 +1382,7 @@ export async function setupDevDB() {
 
     for (let i = 0; i < certificates.length; i++) {
         await entityManager.save(certificates[i]);
-        console.log('Inserted COC ' + i);
+        logger.debug('Inserted COC ' + i);
     }
 
     //Insert remission request
@@ -1388,12 +1391,14 @@ export async function setupDevDB() {
     remissionRequest.uuid = randomBytes(5).toString('hex').toUpperCase();
 
     await entityManager.save(remissionRequest);
-    console.log('Inserted remission request');
+    logger.debug('Inserted remission request');
 
     if (!process.env.SKIP_NOTIFICATION_IMPORT) {
         await importNotificationsFromProd();
         await importMessagesTranslationsFromProd();
     }
+
+    logger.info(`Set up test data`);
 }
 
 function sha512(input: string): string {
@@ -1439,7 +1444,7 @@ async function importNotificationsFromProd() {
     ).json();
 
     await importNotifications(prodNotifications.data.notifications, false, true);
-    console.log(`Imported notifications from PROD`, prodNotifications.data.notifications);
+    logger.info(`Imported notifications from productive landscape`, prodNotifications.data.notifications);
 }
 
 async function importMessagesTranslationsFromProd() {

--- a/web/index.ts
+++ b/web/index.ts
@@ -1,5 +1,5 @@
 import { getLogger } from '../common/logger/logger';
-import { createConnection, getConnection } from 'typeorm';
+import { Connection, createConnection, getConnection } from 'typeorm';
 import { setupDevDB } from './dev';
 import moment from 'moment-timezone';
 import { isDev } from '../common/util/environment';
@@ -8,17 +8,19 @@ import { isCommandArg } from '../common/util/basic';
 // Ensure Notification hooks are always loaded
 import './../common/notification/hooks';
 
-const logger = getLogger();
+const logger = getLogger("WebServer");
 logger.debug('Debug logging enabled');
 
 moment.locale('de'); //set global moment date format
 moment.tz.setDefault('Europe/Berlin'); //set global timezone (which is then used also for cron job scheduling and moment.format calls)
 
-void (async function main() {
+let dbConnection: Connection | null = null;
+
+export const started = (async function main() {
     logger.info(`Starting the Webserver`);
 
     // -------- Database Connection ---------------
-    await createConnection();
+    dbConnection = await createConnection();
     logger.info(`Set up Database connection`);
 
     process.on('beforeExit', async () => {
@@ -32,5 +34,18 @@ void (async function main() {
     }
 
     // -------- Start Webserver ------------------
-    await import('./server');
+    return (await import('./server')).default;
 })();
+
+export async function shutdown() {
+    logger.info(`Shutting down manually`);
+    const server = await started;
+
+    await new Promise<void>((res, rej) => server.close(err => err ? rej(err): res()));
+    logger.info(`Webserver stopped`);
+
+    await dbConnection?.close();
+    logger.info(`DB connection closed`);
+
+    logger.info(`Server shut down manually`);
+}

--- a/web/index.ts
+++ b/web/index.ts
@@ -34,7 +34,7 @@ export const started = (async function main() {
     }
 
     // -------- Start Webserver ------------------
-    return (await import('./server')).default;
+    return (await import('./server')).server;
 })();
 
 export async function shutdown() {

--- a/web/server.ts
+++ b/web/server.ts
@@ -25,8 +25,10 @@ logger.info('Starting Webserver');
 const app = express();
 
 // Log details about every HTTP request:
-const accessLogger = getLogger('access');
-app.use(connectLogger(accessLogger.getLoggerImpl(), { level: 'auto' }));
+if (process.env.LOG_FORMAT !== 'brief') {
+    const accessLogger = getLogger('access');
+    app.use(connectLogger(accessLogger.getLoggerImpl(), { level: 'auto' }));
+}
 
 // Set common security HTTP response headers:
 app.use(helmet());
@@ -110,3 +112,5 @@ ws.configure();
 
 // Start listening
 server.listen(port, () => logger.info(`Server listening on port ${port}`));
+
+export default server;

--- a/web/server.ts
+++ b/web/server.ts
@@ -21,96 +21,97 @@ import { certificateRouter } from './controllers/certificateController';
 
 const logger = getLogger('WebServer');
 
-logger.info('Starting Webserver');
-const app = express();
+export const server = (async function setupWebserver() {
+    logger.info('Starting Webserver');
+    const app = express();
 
-// Log details about every HTTP request:
-if (process.env.LOG_FORMAT !== 'brief') {
-    const accessLogger = getLogger('access');
-    app.use(connectLogger(accessLogger.getLoggerImpl(), { level: 'auto' }));
-}
-
-// Set common security HTTP response headers:
-app.use(helmet());
-
-// Attach a transaction to each request, that is propagated across continuations:
-app.use((req, res, next) => {
-    startTransaction();
-    next();
-});
-
-// Parse Cookies and JSON Bodies:
-app.use(bodyParser.json());
-app.use(cookieParser());
-
-// Add a Favicon to the Backend (as we have some URLs that are directly opened on the backend)
-app.use(favicon('./assets/favicon.ico'));
-
-// Serve static assets:
-app.use('/public', express.static('./assets/public'));
-
-// -------------------- CORS ------------------------------
-
-let origins: (string | RegExp)[];
-
-const allowedSubdomains = [...allStateCooperationSubdomains, 'jufo', 'partnerschule', 'drehtuer', 'codu'];
-if (process.env.ENV == 'dev') {
-    origins = [
-        'http://localhost:3000',
-        ...allowedSubdomains.map((d) => `http://${d}.localhost:3000`),
-        'https://user-app-dev.herokuapp.com',
-        /^https:\/\/lernfair-user-app-[\-a-z0-9]+.herokuapp.com$/,
-        'https://lern.retool.com',
-    ];
-} else {
-    origins = [
-        'https://dashboard.corona-school.de',
-        'https://my.corona-school.de',
-        ...allowedSubdomains.map((d) => `https://${d}.corona-school.de`),
-        'https://dashboard.lern-fair.de',
-        'https://my.lern-fair.de',
-        'https://app.lern-fair.de',
-        ...allowedSubdomains.map((d) => `https://${d}.lern-fair.de`),
-        'https://lern.retool.com',
-    ];
-}
-
-const options = {
-    origin: origins,
-    methods: ['GET', 'POST', 'DELETE', 'PUT', 'HEAD', 'PATCH'],
-};
-
-app.use(cors(options));
-
-
-// ------------------------ GraphQL ---------------------------
-void (async function () {
-    await apolloServer.start();
-    apolloServer.applyMiddleware({ app, path: '/apollo' });
-})();
-
-// ------------------------ HTTP Routes -----------------------
-app.use('/api/attachments', attachmentRouter);
-app.use('/api/certificate', certificateRouter);
-app.use('/api/files', fileRouter);
-
-app.get('/:certificateId', (req, res, next) => {
-    if (!req.subdomains.includes('verify')) {
-        return next();
+    // Log details about every HTTP request:
+    if (process.env.LOG_FORMAT !== 'brief') {
+        const accessLogger = getLogger('access');
+        app.use(connectLogger(accessLogger.getLoggerImpl(), { level: 'auto' }));
     }
 
-    res.redirect(`https://api.lern-fair.de/api/certificate/${req.params.certificateId}/confirmation`);
-});
+    // Set common security HTTP response headers:
+    app.use(helmet());
 
-// ------------------------ Serve HTTP & Websocket ------------------------
-const port = process.env.PORT || 5000;
+    // Attach a transaction to each request, that is propagated across continuations:
+    app.use((req, res, next) => {
+        startTransaction();
+        next();
+    });
 
-const server = http.createServer(app);
+    // Parse Cookies and JSON Bodies:
+    app.use(bodyParser.json());
+    app.use(cookieParser());
 
-const ws = WebSocketService.getInstance(server);
-ws.configure();
+    // Add a Favicon to the Backend (as we have some URLs that are directly opened on the backend)
+    app.use(favicon('./assets/favicon.ico'));
 
-// Start listening
-server.listen(port, () => logger.info(`Server listening on port ${port}`));
+    // Serve static assets:
+    app.use('/public', express.static('./assets/public'));
 
-export default server;
+    // -------------------- CORS ------------------------------
+
+    let origins: (string | RegExp)[];
+
+    const allowedSubdomains = [...allStateCooperationSubdomains, 'jufo', 'partnerschule', 'drehtuer', 'codu'];
+    if (process.env.ENV == 'dev') {
+        origins = [
+            'http://localhost:3000',
+            ...allowedSubdomains.map((d) => `http://${d}.localhost:3000`),
+            'https://user-app-dev.herokuapp.com',
+            /^https:\/\/lernfair-user-app-[\-a-z0-9]+.herokuapp.com$/,
+            'https://lern.retool.com',
+        ];
+    } else {
+        origins = [
+            'https://dashboard.corona-school.de',
+            'https://my.corona-school.de',
+            ...allowedSubdomains.map((d) => `https://${d}.corona-school.de`),
+            'https://dashboard.lern-fair.de',
+            'https://my.lern-fair.de',
+            'https://app.lern-fair.de',
+            ...allowedSubdomains.map((d) => `https://${d}.lern-fair.de`),
+            'https://lern.retool.com',
+        ];
+    }
+
+    const options = {
+        origin: origins,
+        methods: ['GET', 'POST', 'DELETE', 'PUT', 'HEAD', 'PATCH'],
+    };
+
+    app.use(cors(options));
+
+
+    // ------------------------ GraphQL ---------------------------
+    await apolloServer.start();
+    apolloServer.applyMiddleware({ app, path: '/apollo' });
+
+    // ------------------------ HTTP Routes -----------------------
+    app.use('/api/attachments', attachmentRouter);
+    app.use('/api/certificate', certificateRouter);
+    app.use('/api/files', fileRouter);
+
+    app.get('/:certificateId', (req, res, next) => {
+        if (!req.subdomains.includes('verify')) {
+            return next();
+        }
+
+        res.redirect(`https://api.lern-fair.de/api/certificate/${req.params.certificateId}/confirmation`);
+    });
+
+    // ------------------------ Serve HTTP & Websocket ------------------------
+    const port = process.env.PORT || 5000;
+
+    const server = http.createServer(app);
+
+    const ws = WebSocketService.getInstance(server);
+    ws.configure();
+
+    // Start listening
+    await new Promise<void>((res) => server.listen(port, res));
+    logger.info(`Server listening on port ${port}`);
+
+    return server;
+})();


### PR DESCRIPTION
- Run the Webserver from within the test process itself, to be able to mock functions (among other benefits)
- Introduce a logging mode "brief" to not make logging inside tests too verbose
- Mock `fetch`, to make sure tests are always self containing and do not call external systems, allow fetch calls to be mocked with `expectFetch`
- Make `npm run integration-tests` more or less self containing (set up all relevant env variables), as it isn't that configurable now anyways