### PR TITLE
HOTFIX: subcourse creation failed after mandatory chat fields

### DIFF
--- a/graphql/subcourse/mutations.ts
+++ b/graphql/subcourse/mutations.ts
@@ -41,12 +41,12 @@ class PublicSubcourseCreateInput {
     maxParticipants!: number;
     @TypeGraphQL.Field((_type) => Boolean)
     joinAfterStart!: boolean;
-    @TypeGraphQL.Field((_type) => Boolean)
-    allowChatContactProspects!: boolean;
-    @TypeGraphQL.Field((_type) => Boolean)
-    allowChatContactParticipants!: boolean;
-    @TypeGraphQL.Field((_type) => chat_type)
-    groupChatType!: chat_type;
+    @TypeGraphQL.Field((_type) => Boolean, { nullable: true })
+    allowChatContactProspects?: boolean;
+    @TypeGraphQL.Field((_type) => Boolean, { nullable: true })
+    allowChatContactParticipants?: boolean;
+    @TypeGraphQL.Field((_type) => chat_type, { nullable: true })
+    groupChatType?: chat_type;
     @TypeGraphQL.Field((_type) => [PublicLectureInput], { nullable: true })
     lectures?: PublicLectureInput[];
 }

--- a/graphql/subcourse/mutations.ts
+++ b/graphql/subcourse/mutations.ts
@@ -105,7 +105,7 @@ export class MutateSubcourseResolver {
                 allowChatContactParticipants,
                 allowChatContactProspects,
                 groupChatType,
-                lecture: { createMany: { data: lectures } },
+                lecture: { createMany: { data: lectures || [] } },
             },
         });
 


### PR DESCRIPTION
- made chat related fields optional
- kept defaults for db
- added type cast to empty `[]` on falsy lectures