### PR TITLE
fix: keep query parameters during remission redirect

### DIFF
--- a/common/certificate/index.ts
+++ b/common/certificate/index.ts
@@ -18,6 +18,7 @@ import { createSecretEmailToken } from '../secret';
 import { userForPupil, userForStudent } from '../user';
 import { USER_APP_DOMAIN } from '../util/environment';
 import { generatePDFFromHTML } from '../util/pdf';
+import { Request } from 'express';
 
 // TODO: Replace TypeORM operations with Prisma
 
@@ -327,6 +328,17 @@ function exposeCertificate({ student, pupil, state, ...cert }: ParticipationCert
 
 function getCertificateLink(certificate: ParticipationCertificate, lang: Language) {
     return 'http://verify.lern-fair.de/' + certificate.uuid + '?lang=' + lang;
+}
+
+export function convertCertificateLinkToApiLink(req: Request) {
+    const url = new URL('https://api.lern-fair.de');
+
+    url.pathname = `/api/certificate/${req.params.certificateId}/confirmation`;
+    for (const [key, value] of Object.entries(req.query)) {
+        url.searchParams.append(key, value as string);
+    }
+
+    return url.toString();
 }
 
 async function createPDFBinary(certificate: ParticipationCertificate, link: string, lang: Language): Promise<Buffer> {

--- a/web/server.ts
+++ b/web/server.ts
@@ -16,6 +16,7 @@ import { WebSocketService } from '../common/websocket';
 import { fileRouter } from './controllers/fileController';
 import { attachmentRouter } from './controllers/attachmentController';
 import { certificateRouter } from './controllers/certificateController';
+import { convertCertificateLinkToApiLink } from '../common/certificate';
 
 // ------------------ Setup Logging, Common Headers, Routes ----------------
 
@@ -96,7 +97,7 @@ app.get('/:certificateId', (req, res, next) => {
         return next();
     }
 
-    res.redirect(`https://api.lern-fair.de/api/certificate/${req.params.certificateId}/confirmation`);
+    res.redirect(convertCertificateLinkToApiLink(req));
 });
 
 // ------------------------ Serve HTTP & Websocket ------------------------


### PR DESCRIPTION
Before [the refactoring](https://github.com/corona-school/backend/pull/649/files#diff-207067d922cabc071c9988d0ebf291435c4e32db3f91abf878e985aa9f40b2bdL142-L146) we've generated the confimation page directly. 
This changed to having a redirect to the API, which was not keeping the query parameters, like `ctype=remission`. This broke the endpoint, because it wasn't able to figure out which kind of certificate to check.