### PR TITLE
feature: move GraphQL error logging to formatError

### DIFF
--- a/graphql/error.ts
+++ b/graphql/error.ts
@@ -1,14 +1,31 @@
-import { ApolloError } from 'apollo-server-errors';
+import { ApolloError, UserInputError, ValidationError } from 'apollo-server-errors';
+import { GraphQLError } from 'graphql';
+import { getLogger } from 'log4js';
 import { ArgumentValidationError } from 'type-graphql';
 import { ClientError } from '../common/util/error';
 
 export { AuthenticationError, ForbiddenError, UserInputError, ValidationError } from 'apollo-server-errors';
 
-export const isUnexpectedError = (error: ApolloError) => error.name === 'INTERNAL_SERVER_ERROR' && !(error.originalError instanceof ClientError || error.originalError instanceof ArgumentValidationError);
+export const isUnexpectedError = (error: GraphQLError) => {
+    return (
+        (error.name === 'INTERNAL_SERVER_ERROR' &&
+            !(
+                error.originalError instanceof ClientError ||
+                error.originalError instanceof ArgumentValidationError ||
+                error instanceof ValidationError ||
+                error instanceof UserInputError
+            )) ||
+        error instanceof ValidationError ||
+        error instanceof UserInputError
+    );
+};
+
+const logger = getLogger('ApolloError');
 
 export function formatError(error: ApolloError) {
     /* Expected errors are intended to be shared with users */
     if (!isUnexpectedError(error)) {
+        logger.info('Expected Errors occurred', { error: `${error.name} (${error.message})` });
         // Send ClientError Type to client
         if (error.originalError instanceof ClientError) {
             return new ApolloError(error.originalError.publicMessage, error.originalError.type);
@@ -17,6 +34,7 @@ export function formatError(error: ApolloError) {
         return error;
     }
 
+    logger.error(`Unexpected Errors occurred`, error);
     /* All other kinds of errors are not expected here. Better not share them with clients, they might contain secrets! */
     return new Error(`Internal Server Error - Consult logs for details`);
 }

--- a/graphql/logging.ts
+++ b/graphql/logging.ts
@@ -1,10 +1,6 @@
 import { GraphQLRequestContext } from 'apollo-server-plugin-base';
 import { isDev } from '../common/util/environment';
 import { getLogger } from '../common/logger/logger';
-import { toPublicToken } from './authentication';
-import { Role } from './authorizations';
-import { GraphQLContext } from './context';
-import { isUnexpectedError } from './error';
 import { v4 as uuidv4 } from 'uuid';
 
 const logger = getLogger('GraphQL Query');
@@ -26,18 +22,6 @@ export const GraphQLLogger: any = {
         logger.info(`Started processing query`, { query });
 
         const handler: any = {
-            // Actually GraphQLRequestListener, but we're on v2 and not on v3
-            didEncounterErrors(requestContext: GraphQLRequestContext) {
-                const unexpected = requestContext.errors.some(isUnexpectedError);
-                if (!unexpected) {
-                    requestContext.errors.map((it) => logger.info('Expected Errors occurred', { error: `${it.name} (${it.message})` }));
-                } else {
-                    logger.addContext('uid', uid);
-                    for (const err of requestContext.errors) {
-                        logger.error(`Unexpected Errors occurred`, err);
-                    }
-                }
-            },
             willSendResponse(requestContext: GraphQLRequestContext) {
                 logger.info(
                     `Cache policy is ${JSON.stringify(requestContext.overallCachePolicy)}, cache was ${


### PR DESCRIPTION
Unfortunately, the didEncounterErrors hook doesn't have a lot of information about which kind of errors did happen. This means, that it's alsomost impossible to distinguish them and decide which to log how.

Therfore, I moved the logging to the formatError hook, because the given error is always wrapped into a class with context, like ValidationError. This helps us to devide when to log what.