### PR TITLE
Fix CORS for review apps

### DIFF
--- a/web/server.ts
+++ b/web/server.ts
@@ -61,7 +61,7 @@ export const server = (async function setupWebserver() {
             'http://localhost:3000',
             ...allowedSubdomains.map((d) => `http://${d}.localhost:3000`),
             'https://user-app-dev.herokuapp.com',
-            /^https:\/\/lernfair-user-app-[\-a-z0-9]+.herokuapp.com$/,
+            /^https:\/\/user-app-[\-a-z0-9]+.herokuapp.com$/,
             'https://lern.retool.com',
         ];
     } else {

--- a/web/server.ts
+++ b/web/server.ts
@@ -60,7 +60,7 @@ export const server = (async function setupWebserver() {
         origins = [
             'http://localhost:3000',
             ...allowedSubdomains.map((d) => `http://${d}.localhost:3000`),
-            'https://user-app-dev.herokuapp.com',
+            'https://lernfair-user-app-dev.herokuapp.com',
             /^https:\/\/user-app-[\-a-z0-9]+.herokuapp.com$/,
             'https://lern.retool.com',
         ];


### PR DESCRIPTION
resolves https://github.com/corona-school/project-user/issues/759

The app names schema is lernfair-user-app-(...) however the pipeline is still named user-app, and review apps are prefixed by the pipeline name. 