### PR TITLE
fix: appointment pagination and managing empty states in FE

### DIFF
--- a/common/appointment/get.ts
+++ b/common/appointment/get.ts
@@ -5,7 +5,64 @@ import { User } from '../user';
 
 type QueryDirection = 'last' | 'next';
 
-export const getAppointmentsForUser = async (user: User, take?: number, skip?: number, cursor?: number, direction?: QueryDirection): Promise<Appointment[]> => {
+export const hasAppointmentsForUser = async (user: User): Promise<boolean> => {
+    const appointmentsCount = await prisma.lecture.count({
+        where: {
+            isCanceled: false,
+            NOT: {
+                declinedBy: { has: user.userID },
+            },
+            OR: [
+                {
+                    participantIds: {
+                        has: user.userID,
+                    },
+                },
+                {
+                    organizerIds: {
+                        has: user.userID,
+                    },
+                },
+            ],
+        },
+        orderBy: [{ start: 'asc' }],
+        take: 1,
+    });
+    return appointmentsCount > 0;
+};
+export const getLastAppointmentId = async (user: User): Promise<number> => {
+    const lastAppointment = await prisma.lecture.findFirst({
+        where: {
+            isCanceled: false,
+            NOT: {
+                declinedBy: { has: user.userID },
+            },
+            OR: [
+                {
+                    participantIds: {
+                        has: user.userID,
+                    },
+                },
+                {
+                    organizerIds: {
+                        has: user.userID,
+                    },
+                },
+            ],
+        },
+        orderBy: [{ start: 'desc' }],
+        take: 1,
+    });
+    return lastAppointment?.id;
+};
+
+export const getAppointmentsForUser = async (
+    user: User,
+    take?: number,
+    skip: number = 1,
+    cursor?: number,
+    direction?: QueryDirection
+): Promise<Appointment[]> => {
     if (!direction && !cursor) {
         return getAppointmentsForUserFromNow(user.userID, take, skip);
     }
@@ -14,10 +71,10 @@ export const getAppointmentsForUser = async (user: User, take?: number, skip?: n
         throw Error('Cursor or direction not specified for cursor based pagination');
     }
 
-    return getAppointmentsForUserFromCursor(user.userID, take, cursor, direction);
+    return getAppointmentsForUserFromCursor(user.userID, take, skip, cursor, direction);
 };
 
-const getAppointmentsForUserFromCursor = async (userId: User['userID'], take: number, cursor: number, direction: QueryDirection) => {
+const getAppointmentsForUserFromCursor = async (userId: User['userID'], take: number, skip: number, cursor: number, direction: QueryDirection) => {
     const isNextQuery = direction === 'next';
     const appointments = await prisma.lecture.findMany({
         where: {
@@ -40,7 +97,7 @@ const getAppointmentsForUserFromCursor = async (userId: User['userID'], take: nu
         },
         orderBy: [isNextQuery ? { start: 'asc' } : { start: 'desc' }],
         take,
-        skip: 1, // Skipping the cursor object
+        skip: skip,
         cursor: { id: cursor },
     });
     if (!isNextQuery) {

--- a/common/appointment/get.ts
+++ b/common/appointment/get.ts
@@ -56,13 +56,7 @@ export const getLastAppointmentId = async (user: User): Promise<number> => {
     return lastAppointment?.id;
 };
 
-export const getAppointmentsForUser = async (
-    user: User,
-    take?: number,
-    skip: number = 1,
-    cursor?: number,
-    direction?: QueryDirection
-): Promise<Appointment[]> => {
+export const getAppointmentsForUser = async (user: User, take: number, skip: number, cursor?: number, direction?: QueryDirection): Promise<Appointment[]> => {
     if (!direction && !cursor) {
         return getAppointmentsForUserFromNow(user.userID, take, skip);
     }

--- a/graphql/user/fields.ts
+++ b/graphql/user/fields.ts
@@ -1,5 +1,5 @@
 import { Student, Pupil, Screener, Secret, PupilWhereInput, StudentWhereInput, Concrete_notification as ConcreteNotification, Lecture } from '../generated';
-import { Root, Authorized, FieldResolver, Query, Resolver, Arg, Ctx, ObjectType, Field } from 'type-graphql';
+import { Root, Authorized, FieldResolver, Query, Resolver, Arg, Ctx, ObjectType, Field, Int } from 'type-graphql';
 import { loginAsUser } from '../authentication';
 import { GraphQLContext } from '../context';
 import { Role } from '../authorizations';
@@ -12,7 +12,7 @@ import { ACCUMULATED_LIMIT, LimitedQuery, LimitEstimated } from '../complexity';
 import { ConcreteNotificationState } from '../../common/entity/ConcreteNotification';
 import { DEFAULT_PREFERENCES } from '../../common/notification/defaultPreferences';
 import { findUsers } from '../../common/user/search';
-import { getAppointmentsForUser } from '../../common/appointment/get';
+import { getAppointmentsForUser, getLastAppointmentId, hasAppointmentsForUser } from '../../common/appointment/get';
 import { getMyContacts } from '../../common/chat/contacts';
 import { generateMeetingSDKJWT, isZoomFeatureActive } from '../../common/zoom';
 import { getUserZAK } from '../../common/zoom/zoom-user';
@@ -167,6 +167,18 @@ export class UserFieldsResolver {
         @Arg('direction', { nullable: true }) direction?: 'next' | 'last'
     ): Promise<Lecture[]> {
         return getAppointmentsForUser(user, take, skip, cursor, direction);
+    }
+
+    @FieldResolver((returns) => Boolean)
+    @Authorized(Role.ADMIN, Role.OWNER)
+    async hasAppointments(@Root() user: User): Promise<boolean> {
+        return hasAppointmentsForUser(user);
+    }
+
+    @FieldResolver((returns) => Int, { nullable: true })
+    @Authorized(Role.ADMIN, Role.OWNER)
+    async lastAppointmentId(@Root() user: User): Promise<number> {
+        return getLastAppointmentId(user);
     }
 
     @Query((returns) => [Contact])

--- a/graphql/user/fields.ts
+++ b/graphql/user/fields.ts
@@ -161,8 +161,8 @@ export class UserFieldsResolver {
     @LimitedQuery()
     async appointments(
         @Root() user: User,
-        @Arg('take', { nullable: true }) take?: number,
-        @Arg('skip', { nullable: true }) skip?: number,
+        @Arg('take') take: number,
+        @Arg('skip') skip: number,
         @Arg('cursor', { nullable: true }) cursor?: number,
         @Arg('direction', { nullable: true }) direction?: 'next' | 'last'
     ): Promise<Lecture[]> {

--- a/integration-tests/appointments.ts
+++ b/integration-tests/appointments.ts
@@ -172,7 +172,7 @@ void test('Cancel an appointment as a organizer', async () => {
     const isAppointmentCanceled = await client.request(`query appointment {appointment(appointmentId: ${appointmentId}){isCanceled}}`);
     const {
         me: { appointments },
-    } = await client.request(`query myAppointments { me { appointments(take: 3) { id }}}`);
+    } = await client.request(`query myAppointments { me { appointments(take: 3, skip: 0) { id }}}`);
 
     assert.ok(isAppointmentCanceled);
     assert.ok(appointments.some((a) => a.id != appointmentId));

--- a/integration-tests/appointments.ts
+++ b/integration-tests/appointments.ts
@@ -130,7 +130,7 @@ const myAppointments = test('Get my appointments', async () => {
     } = await client.request(`
         query myAppointments {
             me {
-                appointments(take: 3) {
+                appointments(take: 3, skip: 0) {
                     id
                     title
                     description
@@ -203,7 +203,7 @@ void test('Update an appointment', async () => {
     } = await client.request(`
         query myAppointments {
             me {
-                appointments(take: 10) {
+                appointments(take: 10, skip: 0) {
                     id
                     title
                     description


### PR DESCRIPTION
- enhanced pagination to be able to get skip values
- added edges to get if a user has appointments and the last appointment id present