### PR TITLE
fix(migration): change instructor_screening_jobstatus_enum values to match prisma

### DIFF
--- a/common/migration/1687941994171-updateInstructorScreeningEnumType.ts
+++ b/common/migration/1687941994171-updateInstructorScreeningEnumType.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class updateInstructorScreeningEnumType1687941994171 implements MigrationInterface {
+    name = 'updateInstructorScreeningEnumType1687941994171';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE "instructor_screening" ALTER COLUMN "jobStatus" TYPE "public"."screening_jobstatus_enum" USING "jobStatus"::"text"::"public"."screening_jobstatus_enum"`
+        );
+        await queryRunner.query(`DROP TYPE "public"."instructor_screening_jobstatus_enum"`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `CREATE TYPE "public"."instructor_screening_jobstatus_enum" AS ENUM('Schüler:in', 'Student:in', 'Angestellte:r', 'Rentner:in', 'Sonstige')`
+        );
+        await queryRunner.query(
+            `ALTER TABLE "instructor_screening" ALTER COLUMN "jobStatus" TYPE "public"."instructor_screening_jobstatus_enum" USING "jobStatus"::"text"::"public"."instructor_screening_jobstatus_enum"`
+        );
+    }
+}


### PR DESCRIPTION
Follow up of [this pr](https://github.com/corona-school/backend/pull/684/files#diff-3c1eda158e747f9172dc1aacd07b21a3f087105ba55efda93d86ce0787f6aadeR1-R23) to rename the instructor screening enum values as well.