### PR TITLE
fix: last appointment date

### DIFF
--- a/common/zoom/zoom-scheduled-meeting.ts
+++ b/common/zoom/zoom-scheduled-meeting.ts
@@ -80,7 +80,7 @@ const createZoomMeeting = async (zoomUsers: ZoomUser[], startTime: Date, isCours
                     waiting_room: isCourse ? true : false,
                     breakout_room: isCourse ? true : false,
                     recurrence: endDateTime && {
-                        end_date_time: new Date(endDateTime.setHours(24, 0, 0, 0)),
+                        end_date_time: moment(endDateTime).tz(tz).format('YYYY-MM-DDTHH:mm:ss'),
                         type: RecurrenceMeetingTypes.WEEKLY,
                     },
                     settings: {


### PR DESCRIPTION
**Description**
The date of the last appointment that was created is always set to '02:00' on the next day.

**What was done?**
- [x] fixed zoom scheduled meeting end date with using moment to set end date time