### PR TITLE
Fix: Enum handling in pupilScreenings query and distinct counting and bucket logic

### DIFF
--- a/graphql/statistics/fields.ts
+++ b/graphql/statistics/fields.ts
@@ -503,22 +503,22 @@ export class StatisticsResolver {
     @FieldResolver((returns) => [ByMonth])
     @Authorized(Role.ADMIN)
     async pupilScreenings(@Root() statistics: Statistics, @Arg('status') status: pupil_screening_status_enum) {
-        let statusInt;
+        let statusNum;
         switch (status) {
             case 'pending': {
-                statusInt = 0;
+                statusNum = '0';
                 break;
             }
             case 'success': {
-                statusInt = 1;
+                statusNum = '1';
                 break;
             }
             case 'rejection': {
-                statusInt = 2;
+                statusNum = '2';
                 break;
             }
             case 'dispute': {
-                statusInt = 3;
+                statusNum = '3';
                 break;
             }
             default: {
@@ -532,7 +532,7 @@ export class StatisticsResolver {
                                       FROM "pupil_screening"
                                       WHERE "createdAt" > ${statistics.from}::timestamp
                                         AND "createdAt" < ${statistics.to}::timestamp
-                                        AND "status" = ${statusInt}::pupil_screening_status_enum
+                                        AND "status" = ${statusNum}::pupil_screening_status_enum
                                       GROUP BY "year", "month"
                                       ORDER BY "year" ASC, "month" ASC;`;
     }

--- a/graphql/statistics/fields.ts
+++ b/graphql/statistics/fields.ts
@@ -311,10 +311,10 @@ export class StatisticsResolver {
     @FieldResolver(() => Int)
     @Authorized(Role.ADMIN)
     async numPupilsOnWaitingList(@Root() statistics: Statistics) {
-        const enrollments: { value: number } = await prisma.$queryRaw`SELECT COUNT(DISTINCT "pupilId")::int AS value
+        const enrollments: { value: number }[] = await prisma.$queryRaw`SELECT COUNT(DISTINCT "pupilId")::int AS value
             FROM "waiting_list_enrollment"
             WHERE "createdAt" >= ${statistics.from}::timestamp AND "createdAt" < ${statistics.to}::timestamp;`;
-        return enrollments.value;
+        return enrollments[0].value;
     }
 
     @FieldResolver(() => Int)
@@ -541,15 +541,15 @@ export class StatisticsResolver {
         const currentDate = new Date(); // Get the current date
         const previousDate = new Date(currentDate.getFullYear(), currentDate.getMonth() - 8, currentDate.getDate());
 
-        const successfulScreeningsCount: { value: number } = await prisma.$queryRaw`SELECT COUNT(DISTINCT "studentId")::int AS value
+        const successfulScreeningsCount: { value: number }[] = await prisma.$queryRaw`SELECT COUNT(DISTINCT "studentId")::int AS value
             FROM "screening"
             WHERE "success" = true AND "createdAt" >= ${previousDate.toISOString()}::timestamp;
         `;
-        const submittedCoCs: { value: number } = await prisma.$queryRaw`SELECT COUNT(DISTINCT "studentId")::int AS value
+        const submittedCoCs: { value: number }[] = await prisma.$queryRaw`SELECT COUNT(DISTINCT "studentId")::int AS value
             FROM "certificate_of_conduct"
             WHERE "createdAt" >= ${previousDate.toISOString()}::timestamp;
         `;
-        return submittedCoCs.value / successfulScreeningsCount.value;
+        return submittedCoCs[0].value / successfulScreeningsCount[0].value;
     }
 
     @FieldResolver((returns) => Float)
@@ -584,12 +584,12 @@ export class StatisticsResolver {
             },
         });
 
-        const successfulScreeningsCount: { value: number } = await prisma.$queryRaw`SELECT COUNT(DISTINCT "pupilId")::int AS value
+        const successfulScreeningsCount: { value: number }[] = await prisma.$queryRaw`SELECT COUNT(DISTINCT "pupilId")::int AS value
             FROM "pupil_screening"
             WHERE "status" = '1' AND "createdAt" >= ${statistics.from}::timestamp AND "createdAt" < ${statistics.to}::timestamp;
         `;
 
-        return successfulScreeningsCount.value / numPupils;
+        return successfulScreeningsCount[0].value / numPupils;
     }
 
     @FieldResolver((returns) => Int)

--- a/graphql/statistics/fields.ts
+++ b/graphql/statistics/fields.ts
@@ -503,13 +503,36 @@ export class StatisticsResolver {
     @FieldResolver((returns) => [ByMonth])
     @Authorized(Role.ADMIN)
     async pupilScreenings(@Root() statistics: Statistics, @Arg('status') status: pupil_screening_status_enum) {
+        let statusInt;
+        switch (status) {
+            case 'pending': {
+                statusInt = 0;
+                break;
+            }
+            case 'success': {
+                statusInt = 1;
+                break;
+            }
+            case 'rejection': {
+                statusInt = 2;
+                break;
+            }
+            case 'dispute': {
+                statusInt = 3;
+                break;
+            }
+            default: {
+                throw new Error('Invalid status');
+            }
+        }
+
         return await prisma.$queryRaw`SELECT COUNT(*)::INT                         AS value,
                                              date_part('year', "createdAt"::date)  AS year,
                                              date_part('month', "createdAt"::date) AS month
                                       FROM "pupil_screening"
                                       WHERE "createdAt" > ${statistics.from}::timestamp
                                         AND "createdAt" < ${statistics.to}::timestamp
-                                        AND "status" = ${status}::pupil_screening_status_enum
+                                        AND "status" = ${statusInt}::pupil_screening_status_enum
                                       GROUP BY "year", "month"
                                       ORDER BY "year" ASC, "month" ASC;`;
     }

--- a/graphql/statistics/fields.ts
+++ b/graphql/statistics/fields.ts
@@ -509,7 +509,7 @@ export class StatisticsResolver {
                                       FROM "pupil_screening"
                                       WHERE "createdAt" > ${statistics.from}::timestamp
                                         AND "createdAt" < ${statistics.to}::timestamp
-                                        AND "status" = ${status}
+                                        AND "status" = ${status}::pupil_screening_status_enum
                                       GROUP BY "year", "month"
                                       ORDER BY "year" ASC, "month" ASC;`;
     }

--- a/graphql/statistics/fields.ts
+++ b/graphql/statistics/fields.ts
@@ -509,7 +509,7 @@ export class StatisticsResolver {
                                       FROM "pupil_screening"
                                       WHERE "createdAt" > ${statistics.from}::timestamp
                                         AND "createdAt" < ${statistics.to}::timestamp
-                                        AND "status" = '${status}'
+                                        AND "status" = ${status}
                                       GROUP BY "year", "month"
                                       ORDER BY "year" ASC, "month" ASC;`;
     }

--- a/graphql/statistics/fields.ts
+++ b/graphql/statistics/fields.ts
@@ -313,7 +313,7 @@ export class StatisticsResolver {
     async numPupilsOnWaitingList(@Root() statistics: Statistics) {
         const enrollments: { value: number } = await prisma.$queryRaw`SELECT COUNT(DISTINCT "pupilId")::int AS value
             FROM "waiting_list_enrollment"
-            WHERE "createdAt" >= ${statistics.from} AND "createdAt" < ${statistics.to}`;
+            WHERE "createdAt" >= ${statistics.from}::timestamp AND "createdAt" < ${statistics.to}::timestamp;`;
         return enrollments.value;
     }
 
@@ -543,11 +543,11 @@ export class StatisticsResolver {
 
         const successfulScreeningsCount: { value: number } = await prisma.$queryRaw`SELECT COUNT(DISTINCT "studentId")::int AS value
             FROM "screening"
-            WHERE "success" = true AND "createdAt" >= ${previousDate.toISOString()}
+            WHERE "success" = true AND "createdAt" >= ${previousDate.toISOString()}::timestamp;
         `;
         const submittedCoCs: { value: number } = await prisma.$queryRaw`SELECT COUNT(DISTINCT "studentId")::int AS value
             FROM "certificate_of_conduct"
-            WHERE "createdAt" >= ${previousDate.toISOString()}
+            WHERE "createdAt" >= ${previousDate.toISOString()}::timestamp;
         `;
         return submittedCoCs.value / successfulScreeningsCount.value;
     }
@@ -586,7 +586,7 @@ export class StatisticsResolver {
 
         const successfulScreeningsCount: { value: number } = await prisma.$queryRaw`SELECT COUNT(DISTINCT "pupilId")::int AS value
             FROM "pupil_screening"
-            WHERE "status" = '1' AND "createdAt" >= ${statistics.from} AND "createdAt" < ${statistics.to}
+            WHERE "status" = '1' AND "createdAt" >= ${statistics.from}::timestamp AND "createdAt" < ${statistics.to}::timestamp;
         `;
 
         return successfulScreeningsCount.value / numPupils;

--- a/graphql/statistics/fields.ts
+++ b/graphql/statistics/fields.ts
@@ -387,7 +387,7 @@ export class StatisticsResolver {
             },
         ];
         intervals.forEach((duration, key) => {
-            buckets.find((b) => b.from >= duration && (b.to < duration || b.to === -1)).value += 1;
+            buckets.find((b) => b.from <= duration && (b.to > duration || b.to === -1)).value += 1;
         });
         return buckets;
     }
@@ -654,7 +654,7 @@ export class StatisticsResolver {
 
         matches.forEach((match) => {
             let duration = match.dissolvedAt.getTime() - match.createdAt.getTime();
-            buckets.find((b) => b.from >= duration && (b.to < duration || b.to === -1)).value += 1;
+            buckets.find((b) => b.from <= duration && (b.to > duration || b.to === -1)).value += 1;
         });
         return buckets;
     }


### PR DESCRIPTION
![Screenshot 2023-07-06 at 17 48 24](https://github.com/corona-school/backend/assets/38134006/ed7a2708-7dd1-4623-8b8b-4ca89b5982c9)
[Prisma expects template variables to appear without any quotes](https://www.prisma.io/docs/concepts/components/prisma-client/raw-database-access#considerations). Also, apparently the enum is only represented by ordinal numbers in the database, so we have to convert the TS enum values to the DB values. Also, Prisma doesn't seem to support `distinct` in queries (even though the types say so), so I had to change all queries using it to raw queries...
