### PR TITLE
HOTFIX: Release back edge from Appointment to Subcourse to everyone

### DIFF
--- a/graphql/appointment/fields.ts
+++ b/graphql/appointment/fields.ts
@@ -180,7 +180,7 @@ export class ExtendedFieldsLectureResolver {
     }
 
     @FieldResolver((returns) => Subcourse, { nullable: true })
-    @Authorized(Role.OWNER, Role.APPOINTMENT_PARTICIPANT, Role.ADMIN)
+    @Authorized(Role.USER, Role.ADMIN)
     async subcourse(@Root() appointment: Appointment) {
         if (!appointment.subcourseId) {
             return null;


### PR DESCRIPTION
The subcourse is public anyways, so no need to restrict access to it. This fixes the User-App for non-participants / non-instructors that visit the course detail page (as it accesses this field resolver).