### PR TITLE
quickfix: get also match appointments

### DIFF
--- a/common/appointment/get.ts
+++ b/common/appointment/get.ts
@@ -9,7 +9,6 @@ export const hasAppointmentsForUser = async (user: User): Promise<boolean> => {
     const appointmentsCount = await prisma.lecture.count({
         where: {
             isCanceled: false,
-            subcourse: { published: true },
             NOT: {
                 declinedBy: { has: user.userID },
             },
@@ -35,7 +34,6 @@ export const getLastAppointmentId = async (user: User): Promise<number> => {
     const lastAppointment = await prisma.lecture.findFirst({
         where: {
             isCanceled: false,
-            subcourse: { published: true },
             NOT: {
                 declinedBy: { has: user.userID },
             },
@@ -75,7 +73,6 @@ const getAppointmentsForUserFromCursor = async (userId: User['userID'], take: nu
     const appointments = await prisma.lecture.findMany({
         where: {
             isCanceled: false,
-            subcourse: { published: true },
             NOT: {
                 declinedBy: { has: userId },
             },

--- a/common/appointment/get.ts
+++ b/common/appointment/get.ts
@@ -112,7 +112,6 @@ const getAppointmentsForUserFromNow = async (userId: User['userID'], take: numbe
     const appointmentsFromNow = await prisma.lecture.findMany({
         where: {
             isCanceled: false,
-            subcourse: { published: true },
             start: {
                 gte: moment().subtract(MAXIMUM_APPOINTMENT_DURATION, 'hours').toDate(),
             },


### PR DESCRIPTION
### Description
Currently, match appointments don't appear in the FE appointment list and also not on the dashboard.