### PR TITLE
fix: remove cancelled lectures from webflow sync

### DIFF
--- a/jobs/periodic/sync-to-webflow/queries.ts
+++ b/jobs/periodic/sync-to-webflow/queries.ts
@@ -18,7 +18,9 @@ export const getWebflowSubcourses = async (): Promise<WebflowSubcourse[]> => {
             course: true,
             subcourse_instructors_student: { include: { student: true } },
             subcourse_participants_pupil: true,
-            lecture: true,
+            lecture: {
+                where: { isCanceled: false },
+            },
         },
     });
     return courses.filter((course) => course.lecture.length > 0);


### PR DESCRIPTION
Cancelled courses should not be synced to webflow.