### PR TITLE
feat: automatic course promotion on publishing

### DIFF
--- a/graphql/subcourse/mutations.ts
+++ b/graphql/subcourse/mutations.ts
@@ -167,7 +167,8 @@ export class MutateSubcourseResolver {
         await hasAccess(context, 'Subcourse', subcourse);
 
         await publishSubcourse(subcourse);
-        await sendPupilCoursePromotion(subcourse);
+        const course = await getCourse(subcourse.courseId);
+        if (course.category !== 'focus') await sendPupilCoursePromotion(subcourse);
         return true;
     }
 

--- a/graphql/subcourse/mutations.ts
+++ b/graphql/subcourse/mutations.ts
@@ -168,7 +168,10 @@ export class MutateSubcourseResolver {
 
         await publishSubcourse(subcourse);
         const course = await getCourse(subcourse.courseId);
-        if (course.category !== 'focus') await sendPupilCoursePromotion(subcourse);
+        logger.info(`Subcourse(${subcourseId}) was published by User(${context.user!.userID})`);
+        if (course.category !== 'focus') {
+            await sendPupilCoursePromotion(subcourse);
+        }
         return true;
     }
 
@@ -179,6 +182,7 @@ export class MutateSubcourseResolver {
         await hasAccess(context, 'Subcourse', subcourse);
 
         await fillSubcourse(subcourse);
+        logger.info(`Subcourse(${subcourseId}) was filled by User(${context.user!.userID})`);
         return true;
     }
 
@@ -192,6 +196,7 @@ export class MutateSubcourseResolver {
         const subcourse = await getSubcourse(subcourseId, true);
         await hasAccess(context, 'Subcourse', subcourse);
 
+        logger.info(`Subcourse(${subcourseId}) was edited by User(${context.user!.userID})`);
         return await editSubcourse(subcourse, data);
     }
 
@@ -206,6 +211,7 @@ export class MutateSubcourseResolver {
         if (subcourse.conversationId) {
             await markConversationAsReadOnly(subcourse.conversationId);
         }
+        logger.info(`Subcourse(${subcourseId}) was canceled by User(${context.user!.userID})`);
         return true;
     }
 
@@ -224,7 +230,7 @@ export class MutateSubcourseResolver {
         if (subcourse.conversationId) {
             await addParticipant(user, subcourse.conversationId, subcourse.groupChatType as ChatType);
         }
-
+        logger.info(`Pupil(${pupilId}) joined Subcourse(${subcourseId})`);
         return true;
     }
 
@@ -241,6 +247,7 @@ export class MutateSubcourseResolver {
         await joinSubcourse(subcourse, pupil, false);
         await addGroupAppointmentsParticipant(subcourseId, user.userID);
         await addParticipant(user, subcourse.conversationId, subcourse.groupChatType as ChatType);
+        logger.info(`Pupil(${pupilId}) manually joined Subcourse(${subcourseId})`);
         return true;
     }
 
@@ -275,7 +282,7 @@ export class MutateSubcourseResolver {
         if (subcourse.conversationId) {
             await addParticipant(user, subcourse.conversationId, subcourse.groupChatType as ChatType);
         }
-
+        logger.info(`Pupil(${pupilId}) joined Subcourse(${subcourseId}) from waitinglist`);
         return true;
     }
 
@@ -297,7 +304,7 @@ export class MutateSubcourseResolver {
         if (subcourse.conversationId) {
             await removeParticipantFromCourseChat(pupilUser, subcourse.conversationId);
         }
-
+        logger.info(`Pupil(${pupilId}) left Subcourse(${subcourseId})`);
         return true;
     }
 
@@ -324,6 +331,7 @@ export class MutateSubcourseResolver {
         const pupil = await getSessionPupil(context, pupilId);
         const subcourse = await getSubcourse(subcourseId);
         await leaveSubcourseWaitinglist(subcourse, pupil, /* force */ true);
+        logger.info(`Pupil(${pupilId}) left waitinglist of Subcourse(${subcourseId})`);
         return true;
     }
 
@@ -350,6 +358,7 @@ export class MutateSubcourseResolver {
         for (const fileID in fileIDs) {
             removeFile(fileID);
         }
+        logger.info(`Pupil(${pupil.id}) sent notification to instructor of Subcourse(${subcourseId})`);
         return true;
     }
 
@@ -374,7 +383,7 @@ export class MutateSubcourseResolver {
         for (const fileID in fileIDs) {
             removeFile(fileID);
         }
-
+        logger.info(`Instructor(${instructor.id}) sent notification to participants of Subcourse(${subcourseId})`);
         return true;
     }
 
@@ -386,7 +395,7 @@ export class MutateSubcourseResolver {
         await hasAccess(context, 'Subcourse', subcourse);
         await sendPupilCoursePromotion(subcourse);
         await prisma.subcourse.update({ data: { alreadyPromoted: true }, where: { id: subcourse.id } });
-
+        logger.info(`Subcourse(${subcourseId}) was manually promoted by instructor(${context.user!.userID})`);
         return true;
     }
 }

--- a/graphql/subcourse/mutations.ts
+++ b/graphql/subcourse/mutations.ts
@@ -167,6 +167,7 @@ export class MutateSubcourseResolver {
         await hasAccess(context, 'Subcourse', subcourse);
 
         await publishSubcourse(subcourse);
+        await sendPupilCoursePromotion(subcourse);
         return true;
     }
 


### PR DESCRIPTION
Resolves https://github.com/corona-school/project-user/issues/741

**Open Questions:**
What differentiates a subcourse from a focus course technically? Because Tobias doesn't want to automatically promote focus courses so we would need to filter them out.

What do you think of this:
> The only thing you could consider for manual course promotions would be to write to people who have not yet been contacted instead of the same or random. But that's more of a nice-to-have, not a hard requirement.

This would require a separate database table keeping track of which pupils were already contacted about a newly published course, right?