### PR TITLE
fix: execute db:reset-hard so that db:seed works on staging

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "db:setup": "psql \"$DATABASE_URL?sslmode=prefer\" -c 'CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";'",
     "db:setup:heroku": "psql \"$DATABASE_URL?sslmode=prefer\" -c 'CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\" WITH SCHEMA heroku_ext;'",
     "db:reset": "prisma db push --skip-generate",
-    "db:reset-hard": "prisma db push --force-reset",
+    "db:reset-hard": "prisma db push --skip-generate --force-reset",
     "db:seed": "node -r dotenv/config ./built/seed-db.js"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "prettier": "./prettier-commits.sh",
     "prettier-on": "prettier --write",
     "test": "jest",
-    "db:setup": "psql \"$DATABASE_URL\" -c 'CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";'",
+    "db:setup": "psql \"$DATABASE_URL?sslmode=prefer\" -c 'CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";'",
+    "db:setup:heroku": "psql \"$DATABASE_URL?sslmode=prefer\" -c 'CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\" WITH SCHEMA heroku_ext;'",
     "db:reset": "prisma db push --skip-generate",
     "db:reset-hard": "prisma db push --force-reset",
     "db:seed": "node -r dotenv/config ./built/seed-db.js"

--- a/release.sh
+++ b/release.sh
@@ -3,7 +3,7 @@ if [ "$ENV" = 'production' ]; then
     npx typeorm migration:run
 else 
     echo 'Non-Productive Deployment, setting up DB with seeded data' 
-    npm run db:setup
-    npm run db:reset
+    npm run db:setup:heroku
+    npm run db:reset-hard
     npm run db:seed 
 fi


### PR DESCRIPTION
Current logs from staging:

```
2023-08-01T05:11:00.298888+00:00 heroku[release.1601]: State changed from starting to up
2023-08-01T05:11:03.178166+00:00 app[release.1601]:
2023-08-01T05:11:03.178190+00:00 app[release.1601]: > corona-school-backend@0.3.0 heroku:release
2023-08-01T05:11:03.178190+00:00 app[release.1601]: > ./release.sh
2023-08-01T05:11:03.178190+00:00 app[release.1601]:
2023-08-01T05:11:03.188549+00:00 app[release.1601]: Non-Productive Deployment, setting up DB with seeded data
2023-08-01T05:11:03.498861+00:00 app[release.1601]:
2023-08-01T05:11:03.498881+00:00 app[release.1601]: > corona-school-backend@0.3.0 db:setup
2023-08-01T05:11:03.498882+00:00 app[release.1601]: > psql "$DATABASE_URL" -c 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp";'
2023-08-01T05:11:03.498882+00:00 app[release.1601]:
2023-08-01T05:11:03.554614+00:00 app[release.1601]: psql: error: invalid sslmode value: "no-verify"
2023-08-01T05:11:03.861535+00:00 app[release.1601]:
2023-08-01T05:11:03.861557+00:00 app[release.1601]: > corona-school-backend@0.3.0 db:reset
2023-08-01T05:11:03.861557+00:00 app[release.1601]: > prisma db push --skip-generate
2023-08-01T05:11:03.861557+00:00 app[release.1601]:
2023-08-01T05:11:04.643333+00:00 app[release.1601]: Prisma schema loaded from prisma/schema.prisma
2023-08-01T05:11:04.654583+00:00 app[release.1601]: Datasource "db": PostgreSQL database "dcg7dm2ho6vl3k", schema "public" at "ec2-34-254-138-204.eu-west-1.compute.amazonaws.com:5432"
2023-08-01T05:11:04.903857+00:00 app[release.1601]:
2023-08-01T05:11:04.903875+00:00 app[release.1601]: The database is already in sync with the Prisma schema.
2023-08-01T05:11:04.903918+00:00 app[release.1601]:
2023-08-01T05:11:05.278942+00:00 app[release.1601]:
2023-08-01T05:11:05.278980+00:00 app[release.1601]: > corona-school-backend@0.3.0 db:seed
2023-08-01T05:11:05.278981+00:00 app[release.1601]: > node -r dotenv/config ./built/seed-db.js
2023-08-01T05:11:05.278981+00:00 app[release.1601]:
2023-08-01T05:11:06.500718+00:00 app[release.1601]: imports from "@prisma/client/runtime" are deprecated.
2023-08-01T05:11:06.500734+00:00 app[release.1601]: Use "@prisma/client/runtime/library",  "@prisma/client/runtime/data-proxy" or  "@prisma/client/runtime/binary"
2023-08-01T05:11:06.584768+00:00 app[release.1601]: prisma:info Starting a postgresql pool with 9 connections.
2023-08-01T05:11:06.845847+00:00 app[release.1601]: prisma:query SELECT COUNT(*) FROM (SELECT "public"."pupil"."id" FROM "public"."pupil" WHERE 1=1 OFFSET $1) AS "sub"
2023-08-01T05:11:06.847982+00:00 app[release.1601]: /app/built/seed-db.js:32
2023-08-01T05:11:06.847984+00:00 app[release.1601]: throw new Error(`Cannot seed a non empty database. Use npm run db:reset-hard to drop it`);
2023-08-01T05:11:06.847985+00:00 app[release.1601]: ^
2023-08-01T05:11:06.847986+00:00 app[release.1601]:
2023-08-01T05:11:06.847986+00:00 app[release.1601]: Error: Cannot seed a non empty database. Use npm run db:reset-hard to drop it
2023-08-01T05:11:06.847987+00:00 app[release.1601]: at setupDevDB (/app/built/seed-db.js:32:15)
2023-08-01T05:11:06.847987+00:00 app[release.1601]:
2023-08-01T05:11:06.847987+00:00 app[release.1601]: Node.js v18.17.0
```