### PR TITLE
HOTFIX: Fixups for previous hotfixes

### DIFF
--- a/common/notification/actions.ts
+++ b/common/notification/actions.ts
@@ -285,12 +285,20 @@ const _notificationActions = {
         description: 'Tutee / Lern-Fair Now Match success',
         sampleContext: {
             student: sampleUser,
+            matchSubjects: 'Deutsch, Englisch',
+            matchHash: '...',
+            matchDate: '...',
+            firstMatch: true,
         },
     },
     'tutee_matching_lern-fair-plus': {
         description: 'Tutee / Lern-Fair Plus Match success',
         sampleContext: {
             student: sampleUser,
+            matchSubjects: 'Deutsch, Englisch',
+            matchHash: '...',
+            matchDate: '...',
+            firstMatch: true,
         },
     },
     'tutee_matching_TEST-DO-NOT-USE': DEPRECATED,

--- a/graphql/error.ts
+++ b/graphql/error.ts
@@ -8,8 +8,9 @@ export { AuthenticationError, ForbiddenError, UserInputError, ValidationError } 
 
 export const isUnexpectedError = (error: GraphQLError) => {
     return (
-        error.extensions.code === 'INTERNAL_SERVER_ERROR' &&
-        !(error.originalError instanceof ClientError || error.originalError instanceof ArgumentValidationError)
+        !error.extensions ||
+        (error.extensions.code === 'INTERNAL_SERVER_ERROR' &&
+            !(error.originalError instanceof ClientError || error.originalError instanceof ArgumentValidationError))
     );
 };
 


### PR DESCRIPTION
Apparently non GraphQLErrors arrive in isUnexpectedError, we probably need to fix the type, but as a hotfix classify those as unexpected.

Also add missing sampleContexts that were forgotten.