### PR TITLE
Various fixes to E-Mail Change

### DIFF
--- a/common/user/email.ts
+++ b/common/user/email.ts
@@ -4,5 +4,6 @@ export async function isEmailAvailable(email: string) {
     email = email.toLowerCase();
     const pupilHasEmail = (await prisma.pupil.count({ where: { email } })) > 0;
     const studentHasEmail = (await prisma.student.count({ where: { email } })) > 0;
-    return !pupilHasEmail && !studentHasEmail;
+    const screenerHasEmail = (await prisma.screener.count({ where: { email } })) > 0;
+    return !pupilHasEmail && !studentHasEmail && !screenerHasEmail;
 }

--- a/graphql/authentication.ts
+++ b/graphql/authentication.ts
@@ -198,6 +198,7 @@ export class AuthenticationResolver {
             await loginAsUser(user, context);
             return true;
         } catch (error) {
+            logger.info(`Failed to log in with token: `, error);
             throw new AuthenticationError('Invalid Token');
         }
     }


### PR DESCRIPTION
- Make test idempotent
- Prohibit users to change their email to the email of another user, to avoid account collision during login
- Also avoid account collision with screener accounts
