### PR TITLE
HTOFIX Ignore Message Rendering Errors

### DIFF
--- a/common/notification/messages.ts
+++ b/common/notification/messages.ts
@@ -130,7 +130,7 @@ export async function getMessage(
     let navigateTo: string | undefined;
     try {
         if (template.navigateTo) {
-            navigateTo = template.headline(context);
+            navigateTo = template.navigateTo(context);
         }
     } catch (error) {
         logger.error(

--- a/common/notification/messages.ts
+++ b/common/notification/messages.ts
@@ -101,12 +101,68 @@ export async function getMessage(
     const user = await getUser(concreteNotification.userId);
     const context = getContext(concreteNotification.context as NotificationContext, user);
 
+    let headline = '';
+    try {
+        headline = template.headline(context);
+    } catch (error) {
+        logger.error(
+            `Failed to render Headline Template of Notification(${concreteNotification.notificationID}) for ConcreteNotification(${concreteNotification.id})`,
+            {
+                context,
+                error,
+            }
+        );
+    }
+
+    let body = '';
+    try {
+        body = template.body(context);
+    } catch (error) {
+        logger.error(
+            `Failed to render Body Template of Notification(${concreteNotification.notificationID}) for ConcreteNotification(${concreteNotification.id})`,
+            {
+                context,
+                error,
+            }
+        );
+    }
+
+    let navigateTo: string | undefined;
+    try {
+        if (template.navigateTo) {
+            navigateTo = template.headline(context);
+        }
+    } catch (error) {
+        logger.error(
+            `Failed to render Headline Template of Notification(${concreteNotification.notificationID}) for ConcreteNotification(${concreteNotification.id})`,
+            {
+                context,
+                error,
+            }
+        );
+    }
+
+    let modalText: string | undefined;
+    try {
+        if (template.modalText) {
+            modalText = template.modalText(context);
+        }
+    } catch (error) {
+        logger.error(
+            `Failed to render Modal Text Template of Notification(${concreteNotification.notificationID}) for ConcreteNotification(${concreteNotification.id})`,
+            {
+                context,
+                error,
+            }
+        );
+    }
+
     return {
         type: template.type,
-        headline: template.headline(context),
-        body: template.body(context),
-        navigateTo: template.navigateTo?.(context),
-        modalText: template.modalText?.(context),
+        headline,
+        body,
+        navigateTo,
+        modalText,
     };
 }
 


### PR DESCRIPTION
When changing backend logic, sometimes the available variables change, and we only validate the current backend logic against the currently created notifications. Thus concrete notifications that were sent from the old backend logic and persisted in the database might not match the current templates. To avoid that this messes up the user-app, we silently ignore these instead (and just log backend errors for the tech-team to handle). 