### PR TITLE
fix: Proper response in case of Syntax Errors

### DIFF
--- a/graphql/logging.ts
+++ b/graphql/logging.ts
@@ -36,7 +36,7 @@ export const GraphQLLogger: any = {
                 }
 
                 const errorCount = requestContext.response?.errors?.length || 0;
-                stats.increment(metrics.GRAPHQL_REQUESTS, { operation: requestContext.operation.operation, hasErrors: `${errorCount > 0}` });
+                stats.increment(metrics.GRAPHQL_REQUESTS, { operation: requestContext?.operation?.operation, hasErrors: `${errorCount > 0}` });
             },
         };
 


### PR DESCRIPTION
If we have syntax errors, requestContext.operation is not set, and we would fail with Internal Server Error ...