### PR TITLE
fix: filter appointments from published subcourses

### DIFF
--- a/common/appointment/get.ts
+++ b/common/appointment/get.ts
@@ -12,16 +12,21 @@ export const hasAppointmentsForUser = async (user: User): Promise<boolean> => {
             NOT: {
                 declinedBy: { has: user.userID },
             },
-            OR: [
+            AND: [
+                { OR: [{ subcourseId: null }, { subcourse: { published: true } }] },
                 {
-                    participantIds: {
-                        has: user.userID,
-                    },
-                },
-                {
-                    organizerIds: {
-                        has: user.userID,
-                    },
+                    OR: [
+                        {
+                            participantIds: {
+                                has: user.userID,
+                            },
+                        },
+                        {
+                            organizerIds: {
+                                has: user.userID,
+                            },
+                        },
+                    ],
                 },
             ],
         },
@@ -37,16 +42,21 @@ export const getLastAppointmentId = async (user: User): Promise<number> => {
             NOT: {
                 declinedBy: { has: user.userID },
             },
-            OR: [
+            AND: [
+                { OR: [{ subcourseId: null }, { subcourse: { published: true } }] },
                 {
-                    participantIds: {
-                        has: user.userID,
-                    },
-                },
-                {
-                    organizerIds: {
-                        has: user.userID,
-                    },
+                    OR: [
+                        {
+                            participantIds: {
+                                has: user.userID,
+                            },
+                        },
+                        {
+                            organizerIds: {
+                                has: user.userID,
+                            },
+                        },
+                    ],
                 },
             ],
         },
@@ -76,16 +86,21 @@ const getAppointmentsForUserFromCursor = async (userId: User['userID'], take: nu
             NOT: {
                 declinedBy: { has: userId },
             },
-            OR: [
+            AND: [
+                { OR: [{ subcourseId: null }, { subcourse: { published: true } }] },
                 {
-                    participantIds: {
-                        has: userId,
-                    },
-                },
-                {
-                    organizerIds: {
-                        has: userId,
-                    },
+                    OR: [
+                        {
+                            participantIds: {
+                                has: userId,
+                            },
+                        },
+                        {
+                            organizerIds: {
+                                has: userId,
+                            },
+                        },
+                    ],
                 },
             ],
         },
@@ -115,20 +130,25 @@ const getAppointmentsForUserFromNow = async (userId: User['userID'], take: numbe
             NOT: {
                 declinedBy: { has: userId },
             },
-            OR: [
+            AND: [
+                { OR: [{ subcourseId: null }, { subcourse: { published: true } }] },
                 {
-                    participantIds: {
-                        has: userId,
-                    },
-                },
-                {
-                    organizerIds: {
-                        has: userId,
-                    },
+                    OR: [
+                        {
+                            participantIds: {
+                                has: userId,
+                            },
+                        },
+                        {
+                            organizerIds: {
+                                has: userId,
+                            },
+                        },
+                    ],
                 },
             ],
         },
-        orderBy: [{ start: 'asc' }],
+        orderBy: { start: 'asc' },
         take,
         skip,
     });


### PR DESCRIPTION
### Description
We had the problem, that we only filtered for appointments for published subcourses in the frontend. So the button to load old appointments never disappear because we receive appointments from the BE from subcourses that arent published yet.

### What was done?
- [x] add filter to prisma query: `subcourse.published`