### PR TITLE
feature: add reminder cnt to job trace

### DIFF
--- a/common/logger/tracing.ts
+++ b/common/logger/tracing.ts
@@ -16,3 +16,10 @@ tracer.use('graphql', {});
 tracer.use('pg', { measured: true, service: 'postgres', enabled: true });
 
 export default tracer;
+
+export function addTagsToActiveSpan(tags: { [key: string]: any }): void {
+    const span = tracer.scope().active();
+    if (span) {
+        span.addTags(tags);
+    }
+}

--- a/common/notification/index.ts
+++ b/common/notification/index.ts
@@ -16,6 +16,7 @@ import { inAppChannel } from './channels/inapp';
 import { ActionID, SpecificNotificationContext } from './actions';
 import { Channels } from '../../graphql/types/preferences';
 import { ALL_PREFERENCES } from './defaultPreferences';
+import { addTagsToActiveSpan } from '../logger/tracing';
 
 const logger = getLogger('Notification');
 
@@ -580,6 +581,7 @@ export async function checkReminders() {
         }
     }
 
+    addTagsToActiveSpan({ remindersToSend: remindersToSend.length });
     logger.info(`Sent ${remindersToSend.length} reminders in ${Date.now() - start}ms`);
 }
 


### PR DESCRIPTION
This will help us to understand how many reminders have been sent within a specific trace.
The idea is to filter out the ones with a certain amount of reminders and build some distribution charts with the rest.