### PR TITLE
feat: Action for Screening dispute

### DIFF
--- a/common/notification/actions.ts
+++ b/common/notification/actions.ts
@@ -102,6 +102,10 @@ const _notificationActions = {
         description: 'Pupil / Screening was invalidated (i.e. Match Request revoked)',
         sampleContext: {},
     },
+    pupil_screening_dispute: {
+        description: 'Pupil / Screening was disputed (a Screener saved some info but did not take a decision)',
+        sampleContext: {},
+    },
     pupil_registration_finished: {
         description: 'Pupil / Registration finished',
         sampleContext: {},

--- a/common/pupil/screening.ts
+++ b/common/pupil/screening.ts
@@ -60,6 +60,9 @@ export async function updatePupilScreening(pupilScreeningId: number, screeningUp
             break;
 
         case PupilScreeningStatus.dispute:
+            await Notification.actionTaken(userForPupil(screening.pupil), 'pupil_screening_dispute', {});
+            break;
+
         case PupilScreeningStatus.pending:
             break;
     }


### PR DESCRIPTION
This allows as to cancel screening reminders once a screening happened - even if a decision is felt later by the screening team

resolves https://github.com/corona-school/project-user/issues/865