### PR TITLE
HOTFIX: Subcourse isCancelled predicate

### DIFF
--- a/graphql/subcourse/fields.ts
+++ b/graphql/subcourse/fields.ts
@@ -53,7 +53,7 @@ export function IS_PUBLIC_SUBCOURSE(): Prisma.subcourseWhereInput {
                 courseState: { equals: CourseState.ALLOWED },
             },
         },
-        lecture: { some: { start: { gt: new Date() }, isCanceled: false } },
+        lecture: { some: { start: { gt: new Date() }, isCanceled: { not: true } } },
     };
 }
 
@@ -84,7 +84,7 @@ export class ExtendedFieldsSubcourseResolver {
             filters.push({
                 OR: [
                     { joinAfterStart: { equals: false }, lecture: { every: { start: { gt: new Date() } } } },
-                    { joinAfterStart: { equals: true }, lecture: { some: { start: { gt: new Date() }, isCanceled: false } } },
+                    { joinAfterStart: { equals: true }, lecture: { some: { start: { gt: new Date() }, isCanceled: { not: true } } } },
                 ],
             });
             if (isSessionPupil(context)) {


### PR DESCRIPTION
isCancelled can also be null, which is equivalent to false. This removed some older courses from the public subcourse page