### PR TITLE
fix: Subcourse cancellation

### DIFF
--- a/common/appointment/cancel.ts
+++ b/common/appointment/cancel.ts
@@ -18,12 +18,12 @@ async function isLastCourseAppointment(subcourseId: number) {
     return false;
 }
 
-export async function cancelAppointment(user: User, appointment: Appointment, silent?: boolean) {
+export async function cancelAppointment(user: User, appointment: Appointment, silent?: boolean, force?: boolean) {
     if (appointment.isCanceled) {
         throw new RedundantError(`Appointment already cancelled`);
     }
 
-    if (appointment.subcourseId) {
+    if (appointment.subcourseId && !force) {
         const isLastAppointment = await isLastCourseAppointment(appointment.subcourseId);
         if (appointment.subcourseId && isLastAppointment) {
             throw new PrerequisiteError(`Appointment is last of the course`);

--- a/common/courses/states.ts
+++ b/common/courses/states.ts
@@ -147,7 +147,7 @@ export async function cancelSubcourse(user: User, subcourse: Subcourse) {
     const course = await getCourse(subcourse.courseId);
     const courseAppointments = await prisma.lecture.findMany({ where: { subcourseId: subcourse.id } });
     for (const appointment of courseAppointments) {
-        await cancelAppointment(user, appointment, true);
+        await cancelAppointment(user, appointment, /* silent */ true, /* force */ true);
     }
     await sendSubcourseCancelNotifications(course, subcourse);
     logger.info(`Subcourse (${subcourse.id}) was cancelled`);


### PR DESCRIPTION
Every subcourse has one last appointment, thus cancelling a subcourse will always fail.