### PR TITLE
build: Make Matching Algo & PDF Rendering optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Then run `npm run db:setup` to configure Postgres correctly, then `npm run db:re
 To run the development configuration of the web server handling the API requests run `npm run web:dev`.
 The development version of the jobs can be run using `npm run jobs:dev`.
 
+The backend has some very exotic dependencies (namely Chromium for rendering PDFs and our C++ Matching Algorithm) that require quite some effort to install on non-Linux environments. With `npm ci --omit=optional` one can skip installing these dependencies, then the Backend can be run with a limited feature set (no matching and no certificate rendering), also running the integration tests will fail. This should still be enough for the majority of development tasks though.
+
 The `/assets` folder contains development versions of various files. During Heroku builds, the folder is replaced by a secret version that is maintained in a [separate private repository](https://github.com/corona-school/coronaschool-certificate). The commit id of the version pulled is 
 stored in `.certificate-version`. 
 

--- a/common/courses/certificates.ts
+++ b/common/courses/certificates.ts
@@ -2,7 +2,7 @@ import EJS from 'ejs';
 import { readFileSync } from 'fs';
 import { resolve as resolvePath } from 'path';
 import moment from 'moment-timezone';
-import { generatePDFFromHTMLString } from 'html-pppdf';
+import { generatePDFFromHTML } from '../util/pdf';
 
 const TEMPLATE_FOLDER = './assets/courses/certificate';
 const TEMPLATE_ASSETS_FOLDER = `${TEMPLATE_FOLDER}/assets`;
@@ -45,7 +45,7 @@ export async function getCourseCertificate(
 
     const includePaths = process.env.ENV === 'dev' ? [] : [resolvePath(TEMPLATE_ASSETS_FOLDER)]; //only include assets in production
 
-    const buffer = await generatePDFFromHTMLString(htmlString, {
+    const buffer = await generatePDFFromHTML(htmlString, {
         includePaths,
     });
 

--- a/common/match/pool.ts
+++ b/common/match/pool.ts
@@ -1,5 +1,6 @@
 import { prisma } from '../prisma';
 import type { Prisma, pupil as Pupil, student as Student } from '@prisma/client';
+// @ts-ignore The matching algorithm is optional, to allow for slim local setups
 import type { Helpee, Helper, Settings, SubjectWithGradeRestriction } from 'corona-school-matching';
 import { createMatch } from './create';
 import { parseSubjectString, Subject } from '../util/subjectsutils';
@@ -360,7 +361,8 @@ export async function runMatching(poolName: string, apply: boolean, _toggles: st
 
     const startMatching = Date.now();
 
-    // To run the matching we need the C++ Part:
+    // To run the matching we need the C++ Part, if it is not installed this will fail at runtime
+    // @ts-ignore
     const { match } = await import('corona-school-matching');
 
     const result = match(helpers, helpees, pool.settings);

--- a/common/match/pool.ts
+++ b/common/match/pool.ts
@@ -1,6 +1,6 @@
 import { prisma } from '../prisma';
 import type { Prisma, pupil as Pupil, student as Student } from '@prisma/client';
-import { Helpee, Helper, match, Settings, Match as MatchResult, SubjectWithGradeRestriction } from 'corona-school-matching';
+import type { Helpee, Helper, Settings, SubjectWithGradeRestriction } from 'corona-school-matching';
 import { createMatch } from './create';
 import { parseSubjectString, Subject } from '../util/subjectsutils';
 import { gradeAsInt } from '../util/gradestrings';
@@ -359,6 +359,10 @@ export async function runMatching(poolName: string, apply: boolean, _toggles: st
     logger.info(`MatchingPool(${pool.name}) found ${pupils.length} pupils and ${students.length} students for matching in ${timing.preparation}ms`);
 
     const startMatching = Date.now();
+
+    // To run the matching we need the C++ Part:
+    const { match } = await import('corona-school-matching');
+
     const result = match(helpers, helpees, pool.settings);
 
     const matches = result.matches.map((it) => ({

--- a/common/util/pdf.ts
+++ b/common/util/pdf.ts
@@ -1,4 +1,5 @@
-import { closeBrowser, generatePDFFromHTMLString, Options, setupBrowser } from 'html-pppdf';
+// @ts-ignore Optional Dependency for slim local setups
+import type { Options } from 'html-pppdf';
 import { getLogger } from '../logger/logger';
 
 const logger = getLogger('PDF');
@@ -8,6 +9,9 @@ async function ensureBrowserSetup() {
     if (browserSetupDone) {
         return;
     }
+
+    // @ts-ignore
+    const { setupBrowser } = await import('html-pppdf');
 
     await setupBrowser({
         args: ['--no-sandbox'], //don't run in a sandbox, cause we have only trusted content and our server do not support a sandbox
@@ -20,6 +24,9 @@ async function ensureBrowserSetup() {
 
 process.on('SIGTERM', async () => {
     if (browserSetupDone) {
+        // @ts-ignore
+        const { closeBrowser } = await import('html-pppdf');
+
         await closeBrowser();
         logger.info('Shutdown PDF generation environment');
     }
@@ -27,6 +34,9 @@ process.on('SIGTERM', async () => {
 
 export async function generatePDFFromHTML(html: string, options: Options) {
     await ensureBrowserSetup();
+
+    // @ts-ignore
+    const { generatePDFFromHTMLString } = await import('html-pppdf');
 
     logger.info('Started generating PDF file');
     const result = await generatePDFFromHTMLString(html, options);

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "handlebars": "^4.7.7",
         "helmet": "^3.22.0",
         "hot-shots": "^10.0.0",
-        "html-pppdf": "^1.0.1",
         "jsonwebtoken": "^9.0.0",
         "keyv": "^4.0.3",
         "lodash": "^4.17.21",
@@ -95,7 +94,8 @@
         "node": "18.x"
       },
       "optionalDependencies": {
-        "corona-school-matching": "1.3.0"
+        "corona-school-matching": "1.3.0",
+        "html-pppdf": "^1.0.1"
       }
     },
     "linter": {
@@ -6269,6 +6269,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "optional": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -6446,6 +6447,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "devOptional": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -6456,6 +6458,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "devOptional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -6469,6 +6472,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -6488,6 +6492,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "devOptional": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -6617,6 +6622,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -6640,6 +6646,7 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "devOptional": true,
       "engines": {
         "node": "*"
       }
@@ -7800,7 +7807,8 @@
     "node_modules/devtools-protocol": {
       "version": "0.0.818844",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.818844.tgz",
-      "integrity": "sha512-AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg=="
+      "integrity": "sha512-AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg==",
+      "optional": true
     },
     "node_modules/diagnostics_channel": {
       "version": "1.1.0",
@@ -7958,6 +7966,7 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "devOptional": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -8716,6 +8725,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "optional": true,
       "dependencies": {
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
@@ -8735,6 +8745,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "optional": true,
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -8823,6 +8834,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "optional": true,
       "dependencies": {
         "pend": "~1.2.0"
       }
@@ -9025,7 +9037,8 @@
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "devOptional": true
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
@@ -9682,6 +9695,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/html-pppdf/-/html-pppdf-1.0.1.tgz",
       "integrity": "sha512-DU8CRtmi1yXmYN7Yh0LD3X6xhzz8aDSrYQATDoYefRXH3IusTkq1oEMLpo9K0LF1ptkR73wWbXmJY23ZEn9PFg==",
+      "optional": true,
       "dependencies": {
         "fs-extra": "^9.1.0",
         "puppeteer": "^5.5.0",
@@ -9692,6 +9706,7 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "optional": true,
       "dependencies": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -9706,6 +9721,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "optional": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -9717,6 +9733,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "optional": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -11638,7 +11655,8 @@
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "optional": true
     },
     "node_modules/module-details-from-path": {
       "version": "1.0.3",
@@ -12369,7 +12387,8 @@
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "optional": true
     },
     "node_modules/pg": {
       "version": "8.10.0",
@@ -12486,6 +12505,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "devOptional": true,
       "dependencies": {
         "find-up": "^4.0.0"
       },
@@ -12770,7 +12790,8 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "optional": true
     },
     "node_modules/pseudomap": {
       "version": "1.0.2",
@@ -12788,6 +12809,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "optional": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -12807,6 +12829,7 @@
       "integrity": "sha512-OM8ZvTXAhfgFA7wBIIGlPQzvyEETzDjeRa4mZRCRHxYL+GNH5WAuYUQdja3rpWZvkX/JKqmuVgbsxDNsDFjMEg==",
       "deprecated": "< 19.2.0 is no longer supported",
       "hasInstallScript": true,
+      "optional": true,
       "dependencies": {
         "debug": "^4.1.0",
         "devtools-protocol": "0.0.818844",
@@ -12829,6 +12852,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
       "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
+      "optional": true,
       "engines": {
         "node": ">= 6.0.0"
       }
@@ -12837,6 +12861,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
       "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
+      "optional": true,
       "dependencies": {
         "agent-base": "5",
         "debug": "4"
@@ -12849,6 +12874,7 @@
       "version": "7.5.9",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
       "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "optional": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -13971,6 +13997,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
       "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -13981,12 +14008,14 @@
     "node_modules/tar-fs/node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "optional": true
     },
     "node_modules/tar-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "devOptional": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -14002,6 +14031,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "devOptional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -14015,6 +14045,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -14034,6 +14065,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "devOptional": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -14203,6 +14235,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
       "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "devOptional": true,
       "dependencies": {
         "rimraf": "^3.0.0"
       },
@@ -14723,6 +14756,7 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
       "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "optional": true,
       "dependencies": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
@@ -15267,6 +15301,7 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "optional": true,
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "body-parser": "^1.19.0",
         "class-validator": "^0.14.0",
         "cookie-parser": "^1.4.6",
-        "corona-school-matching": "1.3.0",
         "cors": "^2.8.5",
         "cron": "^1.8.2",
         "date-holidays": "^1.5.3",
@@ -94,6 +93,9 @@
       },
       "engines": {
         "node": "18.x"
+      },
+      "optionalDependencies": {
+        "corona-school-matching": "1.3.0"
       }
     },
     "linter": {
@@ -6435,6 +6437,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
@@ -7316,6 +7319,7 @@
       "resolved": "https://registry.npmjs.org/corona-school-matching/-/corona-school-matching-1.3.0.tgz",
       "integrity": "sha512-lto8UhEJhVyWPQ0rcOo2IAzfR9PnmkoUtsi23nuJjEXL6Obbwb//0JBcZ3Buh8L9hmDIEf4y6e6BQ7kbGXlcYw==",
       "hasInstallScript": true,
+      "optional": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "node-addon-api": "^3.0.2",
@@ -7328,7 +7332,8 @@
     "node_modules/corona-school-matching/node_modules/node-addon-api": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
-      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+      "optional": true
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -8850,7 +8855,8 @@
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "node_modules/filelist": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "handlebars": "^4.7.7",
     "helmet": "^3.22.0",
     "hot-shots": "^10.0.0",
-    "html-pppdf": "^1.0.1",
     "jsonwebtoken": "^9.0.0",
     "keyv": "^4.0.3",
     "lodash": "^4.17.21",
@@ -122,6 +121,7 @@
     "typescript": "^4.3.5"
   },
   "optionalDependencies": {
+    "html-pppdf": "^1.0.1",
     "corona-school-matching": "1.3.0"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "body-parser": "^1.19.0",
     "class-validator": "^0.14.0",
     "cookie-parser": "^1.4.6",
-    "corona-school-matching": "1.3.0",
     "cors": "^2.8.5",
     "cron": "^1.8.2",
     "date-holidays": "^1.5.3",
@@ -121,6 +120,9 @@
     "ts-jest": "^29.0.5",
     "typegraphql-prisma": "0.26.0",
     "typescript": "^4.3.5"
+  },
+  "optionalDependencies": {
+    "corona-school-matching": "1.3.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
 Without these the dependencies the majority of the Backend still works (so good enough for most development tasks), but the installation is way easier (especially on Windows or M2 devices).

All dependencies take about 700MB of disk space, without optional dependencies it's 480MB.

There is the risk that inside of Heroku installation fails, and then we run into runtime errors when the dependency is not there. But I guess that risk is rather low, especially as the dependencies rarely change and we also test for them in the integration tests.