### PR TITLE
fix: Move addGroupAppointmentsParticipant and addParticipant to commons

### DIFF
--- a/common/courses/participants.ts
+++ b/common/courses/participants.ts
@@ -11,6 +11,8 @@ import { gradeAsInt } from '../util/gradestrings';
 import { createSecretEmailToken } from '../secret';
 import { userForPupil } from '../user';
 import { addGroupAppointmentsParticipant, removeGroupAppointmentsParticipant } from '../appointment/participants';
+import { addParticipant } from '../chat';
+import { ChatType } from '../chat/types';
 
 const delay = (time: number) => new Promise((res) => setTimeout(res, time));
 
@@ -227,6 +229,10 @@ export async function joinSubcourse(subcourse: Subcourse, pupil: Pupil, strict: 
             orderBy: { start: 'asc' },
             take: 1,
         });
+
+        await addGroupAppointmentsParticipant(subcourse.id, userForPupil(pupil).userID);
+        await addParticipant(userForPupil(pupil), subcourse.conversationId, subcourse.groupChatType as ChatType);
+
         try {
             const course = await prisma.course.findUnique({ where: { id: subcourse.courseId } });
             const courseStart = moment(firstLecture[0].start);
@@ -250,7 +256,7 @@ export async function joinSubcourse(subcourse: Subcourse, pupil: Pupil, strict: 
                 firstLectureTime: courseStart.format('HH:mm'),
             });
         } catch (error) {
-            logger.warn(`Failed to send confirmation mail for Subcourse(${subcourse.id}) however the Pupil(${pupil.id}) still joined the course`);
+            logger.error(`Failed to send confirmation mail for Subcourse(${subcourse.id}) however the Pupil(${pupil.id}) still joined the course`, error);
         }
     });
 }

--- a/graphql/subcourse/mutations.ts
+++ b/graphql/subcourse/mutations.ts
@@ -16,8 +16,7 @@ import { getFile, removeFile } from '../files';
 import * as GraphQLModel from '../generated/models';
 import { getCourse, getPupil, getStudent, getSubcourse } from '../util';
 import { chat_type } from '../generated';
-import { addParticipant, markConversationAsReadOnly, removeParticipantFromCourseChat } from '../../common/chat/conversation';
-import { ChatType } from '../../common/chat/types';
+import { markConversationAsReadOnly, removeParticipantFromCourseChat } from '../../common/chat/conversation';
 
 const logger = getLogger('MutateCourseResolver');
 
@@ -202,10 +201,6 @@ export class MutateSubcourseResolver {
         const user = userForPupil(pupil);
         const subcourse = await getSubcourse(subcourseId);
         await joinSubcourse(subcourse, pupil, true);
-        await addGroupAppointmentsParticipant(subcourseId, user.userID);
-        if (subcourse.conversationId) {
-            await addParticipant(user, subcourse.conversationId, subcourse.groupChatType as ChatType);
-        }
         logger.info(`Pupil(${pupilId}) joined Subcourse(${subcourseId})`);
         return true;
     }
@@ -218,11 +213,8 @@ export class MutateSubcourseResolver {
         @Arg('pupilId', { nullable: false }) pupilId: number
     ): Promise<boolean> {
         const pupil = await getSessionPupil(context, pupilId);
-        const user = userForPupil(pupil);
         const subcourse = await getSubcourse(subcourseId);
         await joinSubcourse(subcourse, pupil, false);
-        await addGroupAppointmentsParticipant(subcourseId, user.userID);
-        await addParticipant(user, subcourse.conversationId, subcourse.groupChatType as ChatType);
         logger.info(`Pupil(${pupilId}) manually joined Subcourse(${subcourseId})`);
         return true;
     }
@@ -234,7 +226,6 @@ export class MutateSubcourseResolver {
         @Arg('subcourseId') subcourseId: number,
         @Arg('pupilId', { nullable: false }) pupilId: number
     ) {
-        const { user } = context;
         let subcourse = await getSubcourse(subcourseId);
         await hasAccess(context, 'Subcourse', subcourse);
         const pupil = await getPupil(pupilId);
@@ -254,10 +245,6 @@ export class MutateSubcourseResolver {
 
         // Joining the subcourse will automatically remove the pupil from the waitinglist
         await joinSubcourse(subcourse, pupil, true);
-        await addGroupAppointmentsParticipant(subcourseId, user.userID);
-        if (subcourse.conversationId) {
-            await addParticipant(user, subcourse.conversationId, subcourse.groupChatType as ChatType);
-        }
         logger.info(`Pupil(${pupilId}) joined Subcourse(${subcourseId}) from waitinglist`);
         return true;
     }


### PR DESCRIPTION
Otherwise code that doesn't go through the GraphQL layer, i.e. filling a course, does not properly add the pupils to chat & appointments.