### PR TITLE
fix: scheduled appointment meetings

### DIFF
--- a/common/appointment/create.ts
+++ b/common/appointment/create.ts
@@ -105,7 +105,7 @@ export const createGroupAppointments = async (subcourseId: number, appointmentsT
             let zoomMeetingId: string | null;
 
             if (isZoomFeatureActive()) {
-                const videoChat = await createZoomMeetingForAppointment(hosts, appointmentToBeCreated, false);
+                const videoChat = await createZoomMeetingForAppointment(hosts, appointmentToBeCreated, true);
                 logger.info(`Zoom - Created meeting ${videoChat.id} for subcourse ${subcourseId}`);
                 zoomMeetingId = videoChat.id.toString();
             }

--- a/common/appointment/create.ts
+++ b/common/appointment/create.ts
@@ -154,9 +154,6 @@ const createZoomMeetingForAppointment = async (
             })
         );
 
-        // exist meeting already?
-        // what if failed?
-
         const newVideoChat = await createZoomMeeting(studentZoomUsers, appointment.start, appointment.duration, isCourse);
         return newVideoChat;
     } catch (error) {

--- a/common/appointment/update.ts
+++ b/common/appointment/update.ts
@@ -78,7 +78,13 @@ export async function updateAppointment(
             break;
     }
 
-    await updateZoomMeeting(appointment.zoomMeetingId, newStart, newDuration, lastDate);
+    const zoomUpdate = {
+        start: newStart,
+        duration: newDuration,
+        endDate: lastDate,
+    };
+
+    await updateZoomMeeting(appointment.zoomMeetingId, zoomUpdate);
 
     logger.info(`Participants of Appointment(${id}) were notified of the appointment change`);
 }

--- a/common/courses/states.ts
+++ b/common/courses/states.ts
@@ -226,7 +226,7 @@ export async function addSubcourseInstructor(user: User | null, subcourse: Subco
     await prisma.subcourse_instructors_student.create({ data: { subcourseId: subcourse.id, studentId: newInstructor.id } });
 
     const newInstructorUser = userForStudent(newInstructor);
-    await addGroupAppointmentsOrganizer(subcourse.id, newInstructorUser.userID);
+    await addGroupAppointmentsOrganizer(subcourse.id, newInstructorUser.userID, newInstructorUser.email);
 
     if (subcourse.conversationId) {
         await addParticipant(newInstructorUser, subcourse.conversationId, subcourse.groupChatType as ChatType);

--- a/common/zoom/authorization.ts
+++ b/common/zoom/authorization.ts
@@ -21,11 +21,11 @@ if (isZoomFeatureActive()) {
 
 let accessTokenPerScope = new Map<string, string>();
 
-let currentFetch: Promise<void> = Promise.resolve();
+let currentFetch: Promise<any> = Promise.resolve();
 function getAccessToken(scope?: string) {
     // This synchronizes all access token fetches to be sequential,
     // so that we only fetch an access token once, and then potentially reuse it
-    return currentFetch.catch(() => {}).then(() => fetchAccessToken(scope));
+    return (currentFetch = currentFetch.catch(() => {}).then(() => fetchAccessToken(scope)));
 }
 
 const fetchAccessToken = async (scope?: string) => {

--- a/common/zoom/authorization.ts
+++ b/common/zoom/authorization.ts
@@ -21,7 +21,14 @@ if (isZoomFeatureActive()) {
 
 let accessToken: string | null = null;
 
-const getAccessToken = async (scope?: string) => {
+let currentFetch: Promise<void> = Promise.resolve();
+function getAccessToken(scope?: string) {
+    // This synchronizes all access token fetches to be sequential,
+    // so that we only fetch an access token once, and then potentially reuse it
+    return currentFetch.catch(() => {}).then(() => fetchAccessToken(scope));
+}
+
+const fetchAccessToken = async (scope?: string) => {
     assureZoomFeatureActive();
 
     if (accessToken && !scope) {

--- a/common/zoom/authorization.ts
+++ b/common/zoom/authorization.ts
@@ -19,7 +19,7 @@ if (isZoomFeatureActive()) {
     assert(accountId, 'Missing ZOOM_ACCOUNT_ID in ENV');
 }
 
-let accessToken: string | null = null;
+let accessTokenPerScope = new Map<string, string>();
 
 let currentFetch: Promise<void> = Promise.resolve();
 function getAccessToken(scope?: string) {
@@ -31,9 +31,10 @@ function getAccessToken(scope?: string) {
 const fetchAccessToken = async (scope?: string) => {
     assureZoomFeatureActive();
 
-    if (accessToken && !scope) {
-        logger.info('Using cached access token');
-        return { access_token: accessToken };
+    const cachedToken = accessTokenPerScope.get(scope ?? '');
+    if (cachedToken) {
+        logger.info(`Using cached access token for scope ${scope ?? '-'}`);
+        return { access_token: cachedToken };
     }
     try {
         const zoomOauthApiUrl = `https://api.zoom.us/oauth/token?grant_type=${grantType}&account_id=${accountId}`;
@@ -64,9 +65,9 @@ const fetchAccessToken = async (scope?: string) => {
 
         if (data.access_token && !scope) {
             logger.info('Caching access token');
-            accessToken = data.access_token;
+            accessTokenPerScope.set(scope ?? '', data.access_token);
             setTimeout(() => {
-                accessToken = null;
+                accessTokenPerScope.delete(scope ?? '');
             }, data.expires_in * 1000);
         }
 

--- a/common/zoom/scheduled-meeting.ts
+++ b/common/zoom/scheduled-meeting.ts
@@ -125,7 +125,10 @@ async function getZoomMeeting(appointment: Appointment): Promise<ZoomMeeting> {
         throw new Error(`Zoom - failed to get meeting with ${response.status} ${await response.text()}`);
     }
 
-    return (await response.json()) as ZoomMeeting;
+    const meeting = (await response.json()) as ZoomMeeting;
+    logger.debug(`Got Zoom Meeting `, meeting);
+
+    return meeting;
 }
 
 async function getUsersZoomMeetings(email: string): Promise<ZoomMeetings> {
@@ -260,7 +263,7 @@ const removeOrganizerFromZoomMeeting = async (appointment: Appointment, organize
     const zoomMeeting = await getZoomMeeting(appointment);
     const existingAltHosts = zoomMeeting.settings.alternative_hosts;
     if (!existingAltHosts.includes(organizerEmail)) {
-        logger.info(`Zoom - Organizer is no alternative host from zoom meeting ${zoomMeeting.id}`);
+        logger.info(`Zoom - Organizer ${organizerEmail} is no alternative host from zoom meeting ${zoomMeeting.id}`);
         return;
     }
 

--- a/common/zoom/util.ts
+++ b/common/zoom/util.ts
@@ -52,4 +52,24 @@ function assureZoomFeatureActive() {
     }
 }
 
-export { generateMeetingSDKJWT, isZoomFeatureActive, assureZoomFeatureActive };
+function removeHost(existingHosts: string, hostToRemove: string): string {
+    const hostsArray = existingHosts.split(';');
+    const indexToRemove = hostsArray.indexOf(hostToRemove);
+
+    if (indexToRemove !== -1) {
+        hostsArray.splice(indexToRemove, 1);
+        return hostsArray.join(';');
+    } else {
+        return existingHosts;
+    }
+}
+
+function addHost(existingHosts: string, newHost: string): string {
+    if (existingHosts === '') {
+        return newHost;
+    } else {
+        return existingHosts + (existingHosts.endsWith(';') ? '' : ';') + newHost;
+    }
+}
+
+export { generateMeetingSDKJWT, isZoomFeatureActive, assureZoomFeatureActive, addHost, removeHost };

--- a/graphql/subcourse/mutations.ts
+++ b/graphql/subcourse/mutations.ts
@@ -133,7 +133,7 @@ export class MutateSubcourseResolver {
         const instructorToBeRemoved = await getStudent(studentId);
         const instructorUser = userForStudent(instructorToBeRemoved);
         await prisma.subcourse_instructors_student.delete({ where: { subcourseId_studentId: { subcourseId, studentId } } });
-        await removeGroupAppointmentsOrganizer(subcourseId, instructorUser.userID);
+        await removeGroupAppointmentsOrganizer(subcourseId, instructorUser.userID, instructorUser.email);
         if (subcourse.conversationId) {
             await removeParticipantFromCourseChat(instructorUser, subcourse.conversationId);
         }

--- a/graphql/util.ts
+++ b/graphql/util.ts
@@ -20,6 +20,10 @@ export function Deprecated(reason: string) {
     return Directive(`@deprecated(reason: "${reason}")`);
 }
 
+export function Doc(documentation: string) {
+    return Directive(`""" ${documentation} """`);
+}
+
 /* GraphQL only has 'null values' whereas Prisma has dedicated semantics:
    - null means 'set to NULL'
    - undefined means 'do not change'

--- a/integration-tests/07_course.ts
+++ b/integration-tests/07_course.ts
@@ -287,7 +287,7 @@ void test('Add / Remove another instructor', async () => {
         "url": "https://api.zoom.us/v2/meetings/10",
         "method": "GET",
         "responseStatus": 200,
-        "response": {"agenda":"My Meeting","default_password":false,"duration":60,"start_time": new Date().toISOString(),"timezone":"Europe/Berlin","type":2,"mute_upon_entry":true,"join_before_host":true,"waiting_room":true,"breakout_room":true,"settings":{"alternative_hosts":"","alternative_hosts_email_notification":false}}
+        "response": { "agenda": "My Meeting", "default_password": false, "duration": 60, "start_time": new Date().toISOString(), "timezone": "Europe/Berlin", "type": 2, "mute_upon_entry": true, "join_before_host": true, "waiting_room": true, "breakout_room": true, "settings": { "alternative_hosts": "", "alternative_hosts_email_notification": false } }
     });
 
     expectFetch({
@@ -296,7 +296,7 @@ void test('Add / Remove another instructor', async () => {
         "body": `{"start_time":"*","timezone":"Europe/Berlin","settings":{"alternative_hosts":"${instructor2.email.toLowerCase()}"}}`,
         "responseStatus": 200,
         "response": "{}"
-    })
+    });
 
     await client.request(`mutation AddInstructorToSubcourse {
         subcourseAddInstructor(subcourseId: ${subcourseId} studentId: ${instructor2.student.id})
@@ -313,7 +313,7 @@ void test('Add / Remove another instructor', async () => {
         "url": "https://api.zoom.us/v2/meetings/10",
         "method": "GET",
         "responseStatus": 200,
-        "response": {"id": 10, "agenda":"My Meeting","default_password":false,"duration":60,"start_time": new Date().toISOString(),"timezone":"Europe/Berlin","type":2,"mute_upon_entry":true,"join_before_host":true,"waiting_room":true,"breakout_room":true,"settings":{"alternative_hosts": instructor2.email.toLowerCase(),"alternative_hosts_email_notification":false}}
+        "response": { "id": 10, "agenda": "My Meeting", "default_password": false, "duration": 60, "start_time": new Date().toISOString(), "timezone": "Europe/Berlin", "type": 2, "mute_upon_entry": true, "join_before_host": true, "waiting_room": true, "breakout_room": true, "settings": { "alternative_hosts": instructor2.email.toLowerCase(), "alternative_hosts_email_notification": false } }
     });
 
     expectFetch({
@@ -322,7 +322,7 @@ void test('Add / Remove another instructor', async () => {
         "body": '{"start_time":"*","timezone":"Europe/Berlin","settings":{"alternative_hosts":""}}',
         "responseStatus": 200,
         "response": "{}"
-    })
+    });
 
     await client.request(`mutation RemoveInstructorFromSubcourse {
         subcourseDeleteInstructor(subcourseId: ${subcourseId} studentId: ${instructor2.student.id})

--- a/integration-tests/07_course.ts
+++ b/integration-tests/07_course.ts
@@ -170,7 +170,7 @@ export const addAppointmentToSubcourse = test('Create an appointment for a subco
     return { subcourseId, client, instructor, courseId };
 });
 
-void test('Publish Subcourse', async () => {
+const publishedSubcourse = test('Publish Subcourse', async () => {
     const { client, subcourseId, instructor, courseId } = await addAppointmentToSubcourse;
 
     await client.request(`
@@ -201,8 +201,6 @@ void test('Publish Subcourse', async () => {
     assert.ok(subcourse.course.id === courseId);
     assert.ok(subcourse.published);
 
-    return { subcourseId };
-
     // Different client here as the response is cached ...
     /* const { subcoursesPublic: subcoursesPublicAfter } = await defaultClient.request(`
         query PublicSubcourses {
@@ -212,6 +210,8 @@ void test('Publish Subcourse', async () => {
 
     // Now appears in public subcourses
     assert.ok(subcoursesPublicAfter.some(it => it.id === subcourseId)); */
+
+    return { client, subcourseId, instructor, courseId };
 });
 
 void test('Search further instructors', async () => {
@@ -271,3 +271,61 @@ void test('Public Course Suggestions', async () => {
         )
     );
 });
+
+void test('Add / Remove another instructor', async () => {
+    const { instructor: instructor2 } = await screenedInstructorTwo;
+    const { subcourseId, client } = await publishedSubcourse;
+
+    expectFetch({
+        "url": "https://api.zoom.us/oauth/token?grant_type=account_credentials&account_id=ZOOM_ACCOUNT_ID",
+        "method": "POST",
+        "responseStatus": 200,
+        "response": { access_token: "ACCESS_TOKEN", expires_in: 0 }
+    });
+
+    expectFetch({
+        "url": "https://api.zoom.us/v2/meetings/10",
+        "method": "GET",
+        "responseStatus": 200,
+        "response": {"agenda":"My Meeting","default_password":false,"duration":60,"start_time": new Date().toISOString(),"timezone":"Europe/Berlin","type":2,"mute_upon_entry":true,"join_before_host":true,"waiting_room":true,"breakout_room":true,"settings":{"alternative_hosts":"","alternative_hosts_email_notification":false}}
+    });
+
+    expectFetch({
+        "url": "https://api.zoom.us/v2/meetings/10",
+        "method": "PATCH",
+        "body": `{"start_time":"*","timezone":"Europe/Berlin","settings":{"alternative_hosts":"${instructor2.email.toLowerCase()}"}}`,
+        "responseStatus": 200,
+        "response": "{}"
+    })
+
+    await client.request(`mutation AddInstructorToSubcourse {
+        subcourseAddInstructor(subcourseId: ${subcourseId} studentId: ${instructor2.student.id})
+    }`);
+
+    expectFetch({
+        "url": "https://api.zoom.us/oauth/token?grant_type=account_credentials&account_id=ZOOM_ACCOUNT_ID",
+        "method": "POST",
+        "responseStatus": 200,
+        "response": { access_token: "ACCESS_TOKEN", expires_in: 0 }
+    });
+
+    expectFetch({
+        "url": "https://api.zoom.us/v2/meetings/10",
+        "method": "GET",
+        "responseStatus": 200,
+        "response": {"id": 10, "agenda":"My Meeting","default_password":false,"duration":60,"start_time": new Date().toISOString(),"timezone":"Europe/Berlin","type":2,"mute_upon_entry":true,"join_before_host":true,"waiting_room":true,"breakout_room":true,"settings":{"alternative_hosts": instructor2.email.toLowerCase(),"alternative_hosts_email_notification":false}}
+    });
+
+    expectFetch({
+        "url": "https://api.zoom.us/v2/meetings/10",
+        "method": "PATCH",
+        "body": '{"start_time":"*","timezone":"Europe/Berlin","settings":{"alternative_hosts":""}}',
+        "responseStatus": 200,
+        "response": "{}"
+    })
+
+    await client.request(`mutation RemoveInstructorFromSubcourse {
+        subcourseDeleteInstructor(subcourseId: ${subcourseId} studentId: ${instructor2.student.id})
+    }`);
+});
+

--- a/integration-tests/08_appointments.ts
+++ b/integration-tests/08_appointments.ts
@@ -102,7 +102,7 @@ const moreAppointments = test('Create more appointments for a subcourse', async 
         "body": '{"agenda":"My Meeting","default_password":false,"duration":60,"start_time":"*","timezone":"Europe/Berlin","type":2,"mute_upon_entry":true,"join_before_host":true,"waiting_room":true,"breakout_room":true,"settings":{"alternative_hosts":"","alternative_hosts_email_notification":false}}',
         "responseStatus": 200,
         "response": { id: 12 }
-      })
+    });
 
     const res = await client.request(`
         mutation creategroupAppointments {

--- a/integration-tests/08_appointments.ts
+++ b/integration-tests/08_appointments.ts
@@ -89,7 +89,7 @@ const moreAppointments = test('Create more appointments for a subcourse', async 
     expectFetch({
         url: 'https://api.zoom.us/v2/users/123/meetings',
         method: 'POST',
-        body: '{"agenda":"My Meeting","default_password":false,"duration":*,"start_time":"*","timezone":"Europe/Berlin","type":2,"mute_upon_entry":true,"join_before_host":true,"waiting_room":true,"breakout_room":true,"recurrence":{"end_date_time":"*","type":2},"settings":{"alternative_hosts":"","alternative_hosts_email_notification":false}}',
+        body: '{"agenda":"My Meeting","default_password":false,"duration":*,"start_time":"*","timezone":"Europe/Berlin","type":2,"mute_upon_entry":true,"join_before_host":true,"waiting_room":true,"breakout_room":true,"settings":{"alternative_hosts":"","alternative_hosts_email_notification":false}}',
         responseStatus: 201,
         response: { id: 10 },
     });
@@ -199,7 +199,7 @@ void test('Update an appointment', async () => {
     expectFetch({
         url: 'https://api.zoom.us/v2/meetings/10',
         method: 'PATCH',
-        body: '{"start_time":"*","duration":120,"timezone":"Europe/Berlin","recurrence":{"end_date_time":"*","type":2}}',
+        body: '{"start_time":"*","duration":120,"timezone":"Europe/Berlin"',
         responseStatus: 200,
         response: {},
     });

--- a/integration-tests/08_appointments.ts
+++ b/integration-tests/08_appointments.ts
@@ -18,7 +18,8 @@ const firstAppointment = test('Create an appointment for a subcourse', async () 
         url: 'https://api.zoom.us/oauth/token?grant_type=account_credentials&account_id=ZOOM_ACCOUNT_ID',
         method: 'POST',
         responseStatus: 200,
-        response: { access_token: 'ZOOM_ACCESS_TOKEN' },
+        // The token expires immediately, thus the next test will fetch a new token
+        response: { access_token: 'ZOOM_ACCESS_TOKEN', expires_in: 0 },
     });
 
     expectFetch({
@@ -69,7 +70,8 @@ const moreAppointments = test('Create more appointments for a subcourse', async 
         url: 'https://api.zoom.us/oauth/token?grant_type=account_credentials&account_id=ZOOM_ACCOUNT_ID',
         method: 'POST',
         responseStatus: 200,
-        response: { access_token: 'ZOOM_ACCESS_TOKEN' },
+        // The token never expires, and will thus be reused by following tests
+        response: { access_token: 'ZOOM_ACCESS_TOKEN', expires_in: 100000 },
     });
 
     expectFetch({
@@ -89,10 +91,18 @@ const moreAppointments = test('Create more appointments for a subcourse', async 
     expectFetch({
         url: 'https://api.zoom.us/v2/users/123/meetings',
         method: 'POST',
-        body: '{"agenda":"My Meeting","default_password":false,"duration":*,"start_time":"*","timezone":"Europe/Berlin","type":2,"mute_upon_entry":true,"join_before_host":true,"waiting_room":true,"breakout_room":true,"settings":{"alternative_hosts":"","alternative_hosts_email_notification":false}}',
+        body: '{"agenda":"My Meeting","default_password":false,"duration":30,"start_time":"*","timezone":"Europe/Berlin","type":2,"mute_upon_entry":true,"join_before_host":true,"waiting_room":true,"breakout_room":true,"settings":{"alternative_hosts":"","alternative_hosts_email_notification":false}}',
         responseStatus: 201,
-        response: { id: 10 },
+        response: { id: 11 },
     });
+
+    expectFetch({
+        "url": "https://api.zoom.us/v2/users/123/meetings",
+        "method": "POST",
+        "body": '{"agenda":"My Meeting","default_password":false,"duration":60,"start_time":"*","timezone":"Europe/Berlin","type":2,"mute_upon_entry":true,"join_before_host":true,"waiting_room":true,"breakout_room":true,"settings":{"alternative_hosts":"","alternative_hosts_email_notification":false}}',
+        "responseStatus": 200,
+        "response": { id: 12 }
+      })
 
     const res = await client.request(`
         mutation creategroupAppointments {
@@ -158,30 +168,9 @@ const myAppointments = test('Get my appointments', async () => {
     return appointments;
 });
 
-// void test('Cancel an appointment as a organizer', async () => {
-//     const { client } = await screenedInstructorOne;
-//     await firstAppointment;
-//     const clientAppointments = await myAppointments;
-//     const appointmentId = clientAppointments[0].id;
 
-// expectFetch({
-//     url: 'https://api.zoom.us/oauth/token?grant_type=account_credentials&account_id=ZOOM_ACCOUNT_ID',
-//     method: 'POST',
-//     responseStatus: 200,
-//     response: { access_token: 'ZOOM_ACCESS_TOKEN' },
-// });
 
-//     await client.request(`mutation cancelAppointment {appointmentCancel(appointmentId: ${appointmentId})}`);
-//     const isAppointmentCanceled = await client.request(`query appointment {appointment(appointmentId: ${appointmentId}){isCanceled}}`);
-//     const {
-//         me: { appointments },
-//     } = await client.request(`query myAppointments { me { appointments(take: 3, skip: 0) { id }}}`);
-
-//     assert.ok(isAppointmentCanceled);
-//     assert.ok(appointments.some((a) => a.id != appointmentId));
-// });
-
-void test('Update an appointment', async () => {
+const updatedAppointments = test('Update an appointment', async () => {
     const { client, instructor } = await screenedInstructorOne;
     await firstAppointment;
     const clientAppointments = await myAppointments;
@@ -190,16 +179,9 @@ void test('Update an appointment', async () => {
     nextHour.setHours(new Date().getHours() + 1);
 
     expectFetch({
-        url: 'https://api.zoom.us/oauth/token?grant_type=account_credentials&account_id=ZOOM_ACCOUNT_ID',
-        method: 'POST',
-        responseStatus: 200,
-        response: { access_token: 'ZOOM_ACCESS_TOKEN' },
-    });
-
-    expectFetch({
         url: 'https://api.zoom.us/v2/meetings/10',
         method: 'PATCH',
-        body: '{"start_time":"*","duration":120,"timezone":"Europe/Berlin"',
+        body: '{"start_time":"*","duration":120,"timezone":"Europe/Berlin","settings":{}}',
         responseStatus: 200,
         response: {},
     });
@@ -233,4 +215,27 @@ void test('Update an appointment', async () => {
     `);
 
     assert.ok(appointments.some((a) => a.id == appointmentId && a.title == updateTitle));
+});
+
+void test('Cancel an appointment as a organizer', async () => {
+    const { client } = await screenedInstructorOne;
+    await updatedAppointments;
+    const clientAppointments = await myAppointments;
+    const appointmentId = clientAppointments[0].id;
+
+    expectFetch({
+        "url": "https://api.zoom.us/v2/meetings/10?action=delete",
+        "method": "DELETE",
+        "responseStatus": 200,
+        "response": "{}"
+    });
+
+    await client.request(`mutation cancelAppointment {appointmentCancel(appointmentId: ${appointmentId})}`);
+    const isAppointmentCanceled = await client.request(`query appointment {appointment(appointmentId: ${appointmentId}){isCanceled}}`);
+    const {
+        me: { appointments },
+    } = await client.request(`query myAppointments { me { appointments(take: 3, skip: 0) { id }}}`);
+
+    assert.ok(isAppointmentCanceled);
+    assert.ok(appointments.some((a) => a.id != appointmentId));
 });

--- a/integration-tests/base/mock.ts
+++ b/integration-tests/base/mock.ts
@@ -4,7 +4,7 @@ import wcmatch from "wildcard-match";
 
 interface MockedFetch {
     // The fetch request:
-    method: "GET" | "POST" | "PUT" | "PATCH";
+    method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
     // Use * as a wildcard (or any other 'glob' pattern)
     url: string;
     // If the body is not set, it is not tested
@@ -41,7 +41,7 @@ export function setupFetchMock() {
         const urlMatches = mock && (mock.url === url || wcmatch(mock.url)(url));
 
         if (!urlMatches) {
-            console.log(red(`Request to ${url} not mocked (net mock is for ${mock?.url ?? "-"}). The integration tests must be self containing. Mock with:\n`));
+            console.log(red(`Request to ${url} not mocked (next mock is for ${mock?.url ?? "-"}). The integration tests must be self containing. Mock with:\n`));
             console.log(blue(`expectFetch(${JSON.stringify({ url, method: options.method, body: options.body, responseStatus: 200, response: "?" }, null, 2)})`));
             process.exit(1);
         }


### PR DESCRIPTION
- Create one Zoom Meeting for each Appointment (instead of one per Course), this makes lifecycle management easier
- Changing Subcourse Instructors adapts Zoom Meeting Hosts
- Cache Zoom Access Tokens per Scope, synchronize their creation
- Add Mutation for manually creating Zoom Meetings for an Appointment