### PR TITLE
fix(chat): prevent error in case of screener

### DIFF
--- a/common/chat/contacts.ts
+++ b/common/chat/contacts.ts
@@ -92,6 +92,9 @@ const getMatchContactsForUser = async (user: User): Promise<MatchContactStudent[
 
         return pupilWithMatchId;
     }
+
+    // This can happen if for example a screener is logged in
+    return [];
 };
 const getSubcourseInstructorsForPupil = async (pupil: User): Promise<SubcourseContactStudent[]> => {
     assert(pupil.pupilId, 'Pupil must have an pupilId');


### PR DESCRIPTION
Fixing [this error.](https://app.datadoghq.eu/logs?query=env%3Aproduction%20-%40categoryName%3Aaccess%20status%3Aerror%20service%3Abackend-api%20&cols=%40level%2C%40categoryName%2C%40context.session%2Cerror.message%2Cmessage&event=AgAAAYqEY-lmN4jl8wAAAAAAAAAYAAAAAEFZcUVZLXFVQUFCUDh0S0dyNmxpWndBSAAAACQAAAAAMDE4YTg0NjgtMWQ3MS00YzVhLWJhMTgtZmNhYzgxMGVkODRh&index=%2A&messageDisplay=inline&refresh_mode=paused&saved-view-id=78593&sort=time&stream_sort=desc&viz=stream&from_ts=1694435748089&to_ts=1694439380191&live=false)

```
TypeError: matchContacts is not iterable
```

Sometimes I don't know why typescript doesn't complain about such inconsistencies. Undefined is a pain.