### PR TITLE
feat: Custom mailjet templates for campaigns

### DIFF
--- a/common/notification/channels/mailjet.ts
+++ b/common/notification/channels/mailjet.ts
@@ -138,6 +138,6 @@ export const mailjetChannel: Channel = {
     },
 
     canSend: (notification: Notification, _user: User) => {
-        return notification.mailjetTemplateId != null;
+        return notification.mailjetTemplateId != null || (notification.sample_context && 'overrideMailjetTemplateID' in (notification.sample_context as any));
     },
 };

--- a/common/notification/index.ts
+++ b/common/notification/index.ts
@@ -264,9 +264,14 @@ export function validateContext(notification: Notification, context: Notificatio
     const expectedKeys = Object.keys(sampleContext);
     const actualKeys = Object.keys(context);
     const missing = expectedKeys.filter((it) => !actualKeys.includes(it));
+    const unexpected = actualKeys.filter((it) => expectedKeys.includes(it));
 
     if (missing.length) {
         throw new Error(`Missing the following fields in context: ${missing.join(', ')}`);
+    }
+
+    if (unexpected.length) {
+        throw new Error(`The following unexpected keys occured in the context: ${unexpected.join(', ')}`);
     }
 }
 
@@ -276,9 +281,14 @@ export function validateContextForAction(action: ActionID, context: Notification
     const expectedKeys = Object.keys(sampleContext);
     const actualKeys = Object.keys(context);
     const missing = expectedKeys.filter((it) => !actualKeys.includes(it));
+    const unexpected = actualKeys.filter((it) => expectedKeys.includes(it));
 
     if (missing.length) {
         throw new Error(`Missing the following fields in context: ${missing.join(', ')}`);
+    }
+
+    if (unexpected.length) {
+        throw new Error(`The following unexpected keys occured in the context: ${unexpected.join(', ')}`);
     }
 }
 

--- a/common/notification/index.ts
+++ b/common/notification/index.ts
@@ -264,7 +264,7 @@ export function validateContext(notification: Notification, context: Notificatio
     const expectedKeys = Object.keys(sampleContext);
     const actualKeys = Object.keys(context);
     const missing = expectedKeys.filter((it) => !actualKeys.includes(it));
-    const unexpected = actualKeys.filter((it) => expectedKeys.includes(it));
+    const unexpected = actualKeys.filter((it) => !expectedKeys.includes(it));
 
     if (missing.length) {
         throw new Error(`Missing the following fields in context: ${missing.join(', ')}`);
@@ -281,7 +281,7 @@ export function validateContextForAction(action: ActionID, context: Notification
     const expectedKeys = Object.keys(sampleContext);
     const actualKeys = Object.keys(context);
     const missing = expectedKeys.filter((it) => !actualKeys.includes(it));
-    const unexpected = actualKeys.filter((it) => expectedKeys.includes(it));
+    const unexpected = actualKeys.filter((it) => !expectedKeys.includes(it));
 
     if (missing.length) {
         throw new Error(`Missing the following fields in context: ${missing.join(', ')}`);

--- a/common/notification/index.ts
+++ b/common/notification/index.ts
@@ -258,13 +258,15 @@ export async function rescheduleNotification(notification: ConcreteNotification,
 
 /* --------------------------- Campaigns ---------------------------------------------------- */
 
+const allowedExtensions = ['uniqueId'];
+
 export function validateContext(notification: Notification, context: NotificationContext) {
     const sampleContext = getSampleContextExternal(notification);
 
     const expectedKeys = Object.keys(sampleContext);
     const actualKeys = Object.keys(context);
     const missing = expectedKeys.filter((it) => !actualKeys.includes(it));
-    const unexpected = actualKeys.filter((it) => !expectedKeys.includes(it));
+    const unexpected = actualKeys.filter((it) => !expectedKeys.includes(it) && !allowedExtensions.includes(it));
 
     if (missing.length) {
         throw new Error(`Missing the following fields in context: ${missing.join(', ')}`);
@@ -281,7 +283,7 @@ export function validateContextForAction(action: ActionID, context: Notification
     const expectedKeys = Object.keys(sampleContext);
     const actualKeys = Object.keys(context);
     const missing = expectedKeys.filter((it) => !actualKeys.includes(it));
-    const unexpected = actualKeys.filter((it) => !expectedKeys.includes(it));
+    const unexpected = actualKeys.filter((it) => !expectedKeys.includes(it) && !allowedExtensions.includes(it));
 
     if (missing.length) {
         throw new Error(`Missing the following fields in context: ${missing.join(', ')}`);

--- a/common/notification/types.ts
+++ b/common/notification/types.ts
@@ -33,6 +33,8 @@ export interface NotificationContextExtensions {
     // The notification is sent out as part of a certain campaign,
     // This will be used by Mailjet to show statistics for all notifications with the same campaign
     campaign?: string;
+    // For Campaigns, support sending custom Mailjet Notifications:
+    overrideMailjetTemplateID?: string;
 }
 
 export interface NotificationContext extends NotificationContextExtensions {

--- a/graphql/concrete_notification/fields.ts
+++ b/graphql/concrete_notification/fields.ts
@@ -72,6 +72,8 @@ export class ExtendedFieldsConcreteNotificationResolver {
         const byCampaign: { [key: string]: Campaign } = {};
 
         for (const { _count, contextID, notificationID, state } of aggregated) {
+            if (!contextID) continue;
+
             const key = notificationID + '/' + contextID;
             if (!byCampaign[key]) {
                 const context = await prisma.concrete_notification.findFirst({

--- a/graphql/concrete_notification/fields.ts
+++ b/graphql/concrete_notification/fields.ts
@@ -72,7 +72,9 @@ export class ExtendedFieldsConcreteNotificationResolver {
         const byCampaign: { [key: string]: Campaign } = {};
 
         for (const { _count, contextID, notificationID, state } of aggregated) {
-            if (!contextID) continue;
+            if (!contextID) {
+                continue;
+            }
 
             const key = notificationID + '/' + contextID;
             if (!byCampaign[key]) {


### PR DESCRIPTION
https://github.com/corona-school/project-user/issues/479

With this we can create a Notification like this:
```
{
   sample_context: {
      customMailjetTemplateID: "MUST_BE_SET",
   },
   description: "Custom Mailjet Campaign"
}
```

and then one can create a Campaign in Retool that sends out this custom template.