### PR TITLE
feature: add file storage metrics

### DIFF
--- a/common/logger/metrics.ts
+++ b/common/logger/metrics.ts
@@ -13,4 +13,6 @@ export const stats = new StatsD({
 export const metrics = {
     GRAPHQL_REQUESTS: 'graphql.requests',
     JOB_COUNT_EXECUTED: 'jobs.executed',
+    FILE_STORAGE_SIZE: 'file.storage.size',
+    FILE_STORAGE_MAX_SIZE: 'file.storage.max_size',
 };


### PR DESCRIPTION
This will help us to take informed decisions about the file storage size. It allows to monitor the usage as well as the actual size on disk.
It might help to prevent failures like [this one.](https://app.datadoghq.eu/logs?query=issue.id%3Af5cd45fe-637c-11ee-bcd4-da7ad0900005%20&cols=service%2Cmessage%2C%40context.sessionID&event=AgAAAYr_5aen5Xx6CAAAAAAAAAAYAAAAAEFZcl81YWpZQUFDaWFUUy14NGQ4YWdBQwAAACQAAAAAMDE4YjAwOGQtZmE0ZC00Yjc5LTlmYjEtMjBhMmRmYzU0NTRm&index=&messageDisplay=inline&refresh_mode=sliding&stream_sort=desc&viz=stream&from_ts=1696509657749&to_ts=1696510506303&live=false)