### PR TITLE
feat: Campaign Type Overrides + Documentation + Tests

### DIFF
--- a/.env.integration-tests
+++ b/.env.integration-tests
@@ -3,6 +3,9 @@ LOG_FORMAT=brief
 ADMIN_AUTH_TOKEN=admintoken
 SKIP_NOTIFICATION_IMPORT=true
 
+MAILJET_USER="test"
+MAILJET_PASSWORD="test"
+
 TALKJS_API_KEY='mocked-talkjs-apikey'
 TALKJS_APP_ID="mocked-talkjs-appid"
 CHAT_ACTIVE="true"

--- a/.env.integration-tests.debug
+++ b/.env.integration-tests.debug
@@ -3,6 +3,9 @@ LOG_FORMAT=verbose
 ADMIN_AUTH_TOKEN=admintoken
 SKIP_NOTIFICATION_IMPORT=true
 
+MAILJET_USER="test"
+MAILJET_PASSWORD="test"
+
 TALKJS_API_KEY='mocked-talkjs-apikey'
 TALKJS_APP_ID="mocked-talkjs-appid"
 CHAT_ACTIVE="true"

--- a/common/notification/index.ts
+++ b/common/notification/index.ts
@@ -64,21 +64,18 @@ async function createConcreteNotification(
 const getNotificationChannelPreferences = async (user: User, concreteNotification: ConcreteNotification): Promise<Channels> => {
     const notification = await getNotification(concreteNotification.notificationID);
 
-    let { notificationPreferences } = await queryUser(user, { notificationPreferences: true });
+    const { notificationPreferences } = await queryUser(user, { notificationPreferences: true });
 
-    // TODO: Remove after all users where migrated
-    if (notificationPreferences && typeof notificationPreferences === 'string') {
-        notificationPreferences = JSON.parse(notificationPreferences);
-    }
+    const type = (concreteNotification.context as Context)?.overrideType ?? notification.type;
 
-    const channelsBasePreference = ALL_PREFERENCES[notification.type];
+    const channelsBasePreference = ALL_PREFERENCES[type];
     assert.ok(channelsBasePreference, `No default channel preferences maintained for notification type ${notification.type}`);
 
-    const channelsUserPreference = notificationPreferences?.[notification.type] ?? {};
+    const channelsUserPreference = notificationPreferences?.[type] ?? {};
 
     const result = Object.assign({}, channelsBasePreference, channelsUserPreference);
     logger.info(`Got Notification preferences for User(${user.userID})`, {
-        type: notification.type,
+        type,
         notificationPreferences,
         channelsBasePreference,
         result,
@@ -109,6 +106,7 @@ async function deliverNotification(
     let activeChannels: Channel[] = [];
 
     try {
+        // Always trigger the hook, no matter whether we actually send something to the user
         if (notification.hookID) {
             await triggerHook(notification.hookID, user);
         }
@@ -257,8 +255,11 @@ export async function rescheduleNotification(notification: ConcreteNotification,
 
 /* --------------------------- Campaigns ---------------------------------------------------- */
 
-const allowedExtensions = ['uniqueId', 'campaign', 'overrideReceiverEmail'];
+const allowedExtensions = ['uniqueId', 'campaign', 'overrideReceiverEmail', 'overrideType'];
 
+// ATTENTION: This currently allows very powerful extensions needed for Campaign Notifications
+// This should only be used to validate contexts from trusted sources (Admins), for other users
+// prohibit the use of the "allowedExtensions"
 export function validateContext(notification: Notification, context: NotificationContext) {
     const sampleContext = getSampleContextExternal(notification);
 

--- a/common/notification/index.ts
+++ b/common/notification/index.ts
@@ -255,7 +255,9 @@ export async function rescheduleNotification(notification: ConcreteNotification,
 
 /* --------------------------- Campaigns ---------------------------------------------------- */
 
-const allowedExtensions = ['uniqueId', 'campaign', 'overrideReceiverEmail', 'overrideType'];
+// overrideType and overrideMailjetTemplateId are not listed here, they need to be specified
+// in the Notification.sample_context to be overridable
+const allowedExtensions = ['uniqueId', 'campaign', 'overrideReceiverEmail'];
 
 // ATTENTION: This currently allows very powerful extensions needed for Campaign Notifications
 // This should only be used to validate contexts from trusted sources (Admins), for other users

--- a/common/notification/messages.ts
+++ b/common/notification/messages.ts
@@ -1,5 +1,5 @@
 import { message_translation_language_enum as TranslationLanguage } from '@prisma/client';
-import { getSampleContext } from './notification';
+import { getNotification, getSampleContext } from './notification';
 import { ConcreteNotification, Notification, NotificationContext, NotificationMessage, NotificationType, TranslationTemplate } from './types';
 import { prisma } from '../prisma';
 import { compileTemplate, renderTemplate } from '../../utils/helpers';
@@ -15,10 +15,7 @@ export async function getMessageForNotification(
     notificationId: number,
     language: TranslationLanguage = TranslationLanguage.de
 ): Promise<NotificationMessage | null> {
-    const notification = await prisma.notification.findUnique({
-        where: { id: notificationId },
-        select: { type: true },
-    });
+    const notification = await getNotification(notificationId);
 
     if (!notification || !notification.type) {
         return null;
@@ -156,7 +153,7 @@ export async function getMessage(
     }
 
     return {
-        type: template.type,
+        type: context?.overrideType ?? template.type,
         headline,
         body,
         navigateTo,

--- a/common/notification/types.ts
+++ b/common/notification/types.ts
@@ -25,15 +25,27 @@ export interface NotificationContextExtensions {
     student?: Student; // set if the pupil is notified, and a certain student is relevant, this property is set
     pupil?: Pupil; // if the pupil is notified and a certain student is somehow relevant, this property is set
     replyToAddress?: Email;
-    // Sometimes it makes sense to send to some other email than the user's
-    // (i.e. when verifying an email change, or when testing mails)
-    overrideReceiverEmail?: Email;
     attachments?: Attachment[];
+
     // The notification is sent out as part of a certain campaign,
     // This will be used by Mailjet to show statistics for all notifications with the same campaign
+    // The campaign should also be set as the 'uniqueId' to properly prevent campaigns being sent to the same users multiple times
     campaign?: string;
-    // For Campaigns, support sending custom Mailjet Notifications:
+
+    // ---------------------------------------------------------------
+
+    // ATTENTION: These override attributes of the Notification in a Concrete Notification and should
+    // be used with extreme care, as they might come with unintended consequences
+
+    // For Campaigns, support sending custom Mailjet Templates / with a different Type per Campaign,
+    // without having to create a new Notification for each campaign
     overrideMailjetTemplateID?: string;
+    overrideType?: NotificationType;
+
+    // Sometimes it makes sense to send to some other email than the user's
+    // (i.e. when verifying an email change, or when testing mails)
+    // BE CAREFUL: This might otherwise send an email with an auth token to someone else!
+    overrideReceiverEmail?: Email;
 }
 
 export interface NotificationContext extends NotificationContextExtensions {

--- a/integration-tests/12_notifications.ts
+++ b/integration-tests/12_notifications.ts
@@ -1,9 +1,12 @@
 import assert from 'assert';
 import { prisma } from '../common/prisma';
-import { pupilOne } from './01_user';
+import { pupilOne, pupilTwo } from './01_user';
 import { test } from './base';
 import { adminClient } from './base/clients';
-import { createMockNotification } from './base/notifications';
+import { addMockNotification, createMockNotification } from './base/notifications';
+import { expectFetch } from './base/mock';
+
+// ------------------ Scheduling, Cancellation --------------------------------------
 
 void test('Action Notification Timing (Dry Run)', async () => {
     const { pupil } = await pupilOne;
@@ -389,4 +392,219 @@ void test('Duplicate Prevention', async () => {
     });
 
     assert.strictEqual(sentWithSameUniqueId, 3, 'Expected that no additional notification is sent out');
+});
+
+// ---------------------------- Mailjet Channel ------------------------------
+
+void test('Notification sent via Mailjet', async () => {
+    const { pupil, client: pupilClient } = await pupilOne;
+
+    const {
+        notificationCreate: { id },
+    } = await adminClient.request(`mutation CreateNotification {
+        notificationCreate(notification: {
+            description: "MOCK Campaign1"
+            active: false
+            recipient: 0
+            mailjetTemplateId: 42
+            onActions: { set: ["TEST"]}
+            cancelledOnAction: { set: []}
+            type: chat
+        }) { id }
+    }`);
+
+    await addMockNotification(id);
+
+    expectFetch({
+        url: 'https://api.mailjet.com/v3.1/send',
+        method: 'POST',
+        body: `{"SandboxMode":true,"Messages":[{"From":{"Email":"support@lern-fair.de","Name":"Lern-Fair Team"},"To":[{"Email":"${pupil.email.toLowerCase()}"}],"TemplateID":42,"TemplateLanguage":true,"Variables":{"a":"a","uniqueId":"2","user":{"userID":"${
+            pupil.userID
+        }","firstname":"${pupil.firstname}","lastname":"${pupil.lastname}","email":"${pupil.email.toLowerCase()}","active":true,"lastLogin":"*","pupilId":${
+            pupil.pupil.id
+        },"fullName":"${pupil.firstname} ${
+            pupil.lastname
+        }"},"USER_APP_DOMAIN":"*","attachmentGroup":"","authToken":"*"},"CustomID":"*","TemplateErrorReporting":{"Email":"backend@lern-fair.de"},"CustomCampaign":"Backend Notification ${id}"}]}`,
+        responseStatus: 200,
+        response: '{ "Messages": [{ "Status": "success" }]}',
+    });
+
+    await adminClient.request(`mutation TriggerAction {
+        _actionTakenAt(action: "TEST", at: "${new Date().toISOString()}" context: { a: "a", uniqueId: "2" } dryRun: false, noDuplicates: true, userID: "${
+        pupil.userID
+    }")
+    }`);
+
+    const sent = await prisma.concrete_notification.count({
+        where: {
+            notificationID: id,
+            state: 2 /* SENT */,
+        },
+    });
+
+    assert.strictEqual(sent, 1, 'Expected Notification to be sent');
+
+    await pupilClient.request(`mutation PupilDisabledNotifications {
+        meUpdate(update: { notificationPreferences: { chat: { email: false }}})
+    }`);
+
+    await adminClient.request(`mutation TriggerAction2 {
+        _actionTakenAt(action: "TEST", at: "${new Date().toISOString()}" context: { a: "a", uniqueId: "3" } dryRun: false, noDuplicates: true, userID: "${
+        pupil.userID
+    }")
+    }`);
+
+    // As the mail preference was disabled, the notification was not sent via mailjet
+
+    const sent2 = await prisma.concrete_notification.count({
+        where: {
+            notificationID: id,
+            state: 2 /* SENT */,
+        },
+    });
+
+    assert.strictEqual(sent2, 2, 'Expected Notification to be sent');
+});
+
+// ---------------------------- Campaigns ------------------------------------
+
+void test('Create Campaign', async () => {
+    const { pupil } = await pupilOne;
+
+    const {
+        notificationCreate: { id },
+    } = await adminClient.request(`mutation CreateCampaign {
+        notificationCreate(notification: {
+            description: "MOCK Campaign1"
+            active: false
+            recipient: 0
+            onActions: { set: []}
+            cancelledOnAction: { set: []}
+            sample_context: { test: "test" }
+        }) { id }
+    }`);
+
+    await addMockNotification(id);
+
+    const campaignId = `Campaign ${new Date().toISOString()}`;
+
+    await adminClient.requestShallFail(`mutation SendOutWithMissingContext {
+        concreteNotificationBulkCreate(
+        startAt: "${new Date(0).toISOString()}"
+        skipDraft: true
+        context: { }
+        userIds: ["${pupil.userID}"]
+        notificationId: ${id}
+      )
+    }`);
+
+    await adminClient.request(`mutation SendOut {
+        concreteNotificationBulkCreate(
+        startAt: "${new Date(0).toISOString()}"
+        skipDraft: false
+        context: { test: "something", uniqueId: "${campaignId}", campaign: "${campaignId}" }
+        userIds: ["${pupil.userID}"]
+        notificationId: ${id}
+      )
+    }`);
+
+    // Ensure this is not yet picked up by the worker:
+    await adminClient.request(`mutation { _executeJob(job: "Notification") }`);
+
+    const drafted = await prisma.concrete_notification.count({
+        where: {
+            notificationID: id,
+            state: 6 /* DRAFTED */,
+        },
+    });
+
+    assert.strictEqual(drafted, 1, 'Expected Campaign Notification to be drafted');
+
+    await adminClient.request(`mutation PublishCampaign {
+        concreteNotificationPublishDraft(notificationId: ${id} contextID: "${campaignId}")
+    }`);
+
+    const delayed = await prisma.concrete_notification.count({
+        where: {
+            notificationID: id,
+            state: 0 /* DELAYED */,
+        },
+    });
+
+    assert.strictEqual(delayed, 1, 'Expected Campaign Notification to be delayed');
+
+    await adminClient.request(`mutation { _executeJob(job: "Notification") }`);
+
+    const sent = await prisma.concrete_notification.count({
+        where: {
+            notificationID: id,
+            state: 2 /* SENT */,
+        },
+    });
+
+    assert.strictEqual(sent, 1, 'Expected Campaign Notification to be sent');
+});
+
+void test('Create Campaign with Overrides', async () => {
+    const { pupil } = await pupilOne;
+    const { pupil: pupil2, client: pupilTwoClient } = await pupilTwo;
+
+    const {
+        notificationCreate: { id },
+    } = await adminClient.request(`mutation CreateCampaign {
+        notificationCreate(notification: {
+            description: "MOCK Campaign1"
+            active: false
+            recipient: 0
+            onActions: { set: []}
+            cancelledOnAction: { set: []}
+            sample_context: { overrideMailjetTemplateID: "1", overrideType: "campaign" }
+        }) { id }
+    }`);
+
+    await addMockNotification(id);
+
+    const campaignId = `Campaign ${new Date().toISOString()}`;
+
+    await adminClient.request(`mutation SendOut {
+        concreteNotificationBulkCreate(
+        startAt: "${new Date(0).toISOString()}"
+        skipDraft: true
+        context: { overrideMailjetTemplateID: "42", overrideType: "suggestion", uniqueId: "${campaignId}", campaign: "${campaignId}" }
+        userIds: ["${pupil.userID}", "${pupil2.userID}"]
+        notificationId: ${id}
+      )
+    }`);
+
+    await pupilTwoClient.request(`mutation PupilDisabledNotifications {
+        meUpdate(update: { notificationPreferences: { suggestion: { email: false }}})
+    }`);
+
+    // Ensures that the notification is sent although it has no mailjetId (but it is overriden)
+    // Also ensures that the overriden mailjet template is used, and the CustomCampaignId is set
+    // Additionally pupil2 is skipped as he turned off mail notifications for the overriden type "suggestion"
+    expectFetch({
+        url: 'https://api.mailjet.com/v3.1/send',
+        method: 'POST',
+        body: `{"SandboxMode":true,"Messages":[{"From":{"Email":"support@lern-fair.de","Name":"Lern-Fair Team"},"To":[{"Email":"${pupil.email.toLowerCase()}"}],"TemplateID":42,"TemplateLanguage":true,"Variables":{"overrideMailjetTemplateID":"42","overrideType":"suggestion","uniqueId":"${campaignId}","campaign":"${campaignId}","user":{"userID":"${
+            pupil.userID
+        }","firstname":"${pupil.firstname}","lastname":"${
+            pupil.lastname
+        }","email":"${pupil.email.toLowerCase()}","active":true,"lastLogin":"*","pupilId":*,"fullName":"${pupil.firstname} ${
+            pupil.lastname
+        }"},"USER_APP_DOMAIN":"*","attachmentGroup":"","authToken":"*"},"CustomID":"*","TemplateErrorReporting":{"Email":"backend@lern-fair.de"},"CustomCampaign":"${campaignId}"}]}`,
+        responseStatus: 200,
+        response: '{ "Messages": [{ "Status": "success" }]}',
+    });
+
+    await adminClient.request(`mutation { _executeJob(job: "Notification") }`);
+
+    const sent = await prisma.concrete_notification.count({
+        where: {
+            notificationID: id,
+            state: 2 /* SENT */,
+        },
+    });
+
+    assert.strictEqual(sent, 2, 'Expected Campaign Notification to be sent');
 });

--- a/integration-tests/base/notifications.ts
+++ b/integration-tests/base/notifications.ts
@@ -34,11 +34,14 @@ export async function createMockNotification(
         }) { id }
     }`);
 
-    await adminClient.request(`mutation Activate${description} { notificationActivate(notificationId: ${id}, active: true)}`);
+    await addMockNotification(id);
+    return { id };
+}
+
+export async function addMockNotification(id: number) {
+    await adminClient.request(`mutation Activate${id} { notificationActivate(notificationId: ${id}, active: true)}`);
 
     currentMockedNotifications.push(id);
-
-    return { id };
 }
 
 export async function cleanupMockedNotifications() {


### PR DESCRIPTION
resolves https://github.com/corona-school/project-user/issues/479

- Adds overrideType to change the type for a concrete notification, to be used by campaigns
- Adds various comments and documentation
- Adds integration tests for the notification system
- Removes the workaround for notification preferences stored as strings