### PR TITLE
feat: evaluation of tiered achievements

### DIFF
--- a/common/achievement/bucket.ts
+++ b/common/achievement/bucket.ts
@@ -1,63 +1,97 @@
 import moment from 'moment';
-import { Bucket, BucketFormula } from './types';
-import { getRelationContext } from './util';
+import { Bucket, BucketConfig, BucketFormula, DefaultBucket, FilterBucket, GenericBucketConfig, TimeBucket } from './types';
+import { getActionsContext, getRelationContext } from './util';
 
 type BucketCreatorDefs = Record<string, BucketFormula>;
 
 // Buckets are needed to pre-sort and aggregate certain events by types / a certain time window (e.g. weekly) etc.
 export const bucketCreatorDefs: BucketCreatorDefs = {
     default: {
-        function: async (): Promise<Bucket[]> => {
-            return await [];
+        function: async (): Promise<GenericBucketConfig<DefaultBucket>> => {
+            return await {
+                bucketKind: 'default',
+                buckets: [],
+            };
         },
     },
     by_lecture_start: {
-        function: async (relation): Promise<Bucket[]> => {
+        function: async (relation): Promise<GenericBucketConfig<TimeBucket>> => {
             if (!relation) {
-                return [];
+                return {
+                    bucketKind: 'time',
+                    buckets: [],
+                };
             }
             const context = await getRelationContext(relation);
-            return context.lecture.map((lecture) => ({
-                startTime: moment(lecture.start).subtract(10, 'minutes').toDate(),
-                endTime: moment(lecture.start).add(lecture.duration, 'minutes').add(10, 'minutes').toDate(),
-            }));
+            return {
+                bucketKind: 'time',
+                buckets: context.lecture.map((lecture) => ({
+                    kind: 'time',
+                    startTime: moment(lecture.start).subtract(10, 'minutes').toDate(),
+                    endTime: moment(lecture.start).add(lecture.duration, 'minutes').add(10, 'minutes').toDate(),
+                })),
+            };
         },
     },
     by_weeks: {
-        function: async (): Promise<Bucket[]> => {
+        function: async (): Promise<GenericBucketConfig<TimeBucket>> => {
             // TODO - where did we get the number of weeks
             const weeks = 5;
             const today = moment();
-            const bucekts: Bucket[] = [];
+            const buckets: TimeBucket[] = [];
 
             for (let i = 0; i < weeks; i++) {
                 const weeksBefore = today.clone().subtract(i, 'week');
-                bucekts.push({
+                buckets.push({
+                    kind: 'time',
                     startTime: weeksBefore.startOf('week').toDate(),
                     endTime: weeksBefore.endOf('week').toDate(),
                 });
             }
 
-            return await bucekts;
+            return await {
+                bucketKind: 'time',
+                buckets,
+            };
         },
     },
     by_months: {
-        function: async (): Promise<Bucket[]> => {
+        function: async (): Promise<GenericBucketConfig<TimeBucket>> => {
             // TODO - where did we get the number of months
 
             const months = 12;
             const today = moment();
-            const bucekts: Bucket[] = [];
+            const buckets: TimeBucket[] = [];
 
             for (let i = 0; i < months; i++) {
                 const monthsBefore = today.clone().subtract(i, 'month');
-                bucekts.push({
+                buckets.push({
+                    kind: 'time',
                     startTime: monthsBefore.startOf('month').toDate(),
                     endTime: monthsBefore.endOf('month').toDate(),
                 });
             }
 
-            return await bucekts;
+            return await {
+                bucketKind: 'time',
+                buckets,
+            };
+        },
+    },
+    // this is a filter bucket array, which means that it will only contain buckets for events related to certain action names
+    by_conducted_match_meeting: {
+        function: async (actionName): Promise<GenericBucketConfig<FilterBucket>> => {
+            const actions = await getActionsContext(actionName);
+            const buckets: FilterBucket[] = actions.map((action) => {
+                return {
+                    kind: 'filter',
+                    actionName: action,
+                };
+            });
+            return await {
+                bucketKind: 'filter',
+                buckets: buckets,
+            };
         },
     },
 };

--- a/common/achievement/create.ts
+++ b/common/achievement/create.ts
@@ -5,7 +5,13 @@ import { UserAchievementContext } from './types';
 
 async function doesUserAchievementAlreadyExist(templateId: number, userId: string, context?: UserAchievementContext) {
     // TODO - check if user achievement exist for one match or one subcourse
-    const userAchievement = await prisma.user_achievement.findFirst({ where: { templateId, userId } });
+    const userAchievement = await prisma.user_achievement.findFirst({
+        where: {
+            templateId,
+            userId,
+        },
+        select: { id: true, userId: true, context: true, template: true, achievedAt: true },
+    });
     if (!userAchievement) {
         return false;
     }
@@ -23,11 +29,9 @@ async function getOrCreateUserAchievement(template: Achievement_template, userId
 async function createUserAchievement(templateToCreate: Achievement_template, userId: string, context: UserAchievementContext) {
     switch (templateToCreate.type) {
         case 'SEQUENTIAL':
-            return await createSequentialAchievement(templateToCreate, userId, context);
-            break;
+            return await createAchievement(templateToCreate, userId, context);
         case 'TIERED':
-            // await createTieredAchievement(userAchievements, userId, context);
-            break;
+            return await createAchievement(templateToCreate, userId, context);
         case 'STREAK':
             // await createStreakAchievement(userAchievements[0], userId, context);
             break;
@@ -36,16 +40,14 @@ async function createUserAchievement(templateToCreate: Achievement_template, use
     }
 }
 
-async function createSequentialAchievement(templateToCreate: Achievement_template, userId: string, context: UserAchievementContext) {
+async function createAchievement(templateToCreate: Achievement_template, userId: string, context: UserAchievementContext) {
     const templatesByGroup = await getAchievementTemplates(TemplateSelectEnum.BY_GROUP);
     const userAchievementsByGroup = await prisma.user_achievement.findMany({
         where: { template: { group: templateToCreate.group } },
         orderBy: { template: { groupOrder: 'desc' } },
     });
 
-    // const lastStepIndex = userAchievementsByGroup.length > 0 ? templateToCreate.groupOrder : 0;
-    // const nextStepIndex = lastStepIndex + 1;
-    const nextStepIndex = userAchievementsByGroup.length > 0 ? templateToCreate.groupOrder : 1;
+    const nextStepIndex = userAchievementsByGroup.length > 0 ? templateToCreate.groupOrder + 1 : 1;
 
     const templatesForGroup = templatesByGroup.get(templateToCreate.group);
     if (templatesForGroup) {
@@ -60,10 +62,10 @@ async function createSequentialAchievement(templateToCreate: Achievement_templat
                 context: context ? JSON.stringify(context) : {},
                 template: { connect: { id: nextStepTemplate.id } },
             },
-            select: { userId: true, context: true, template: true },
+            select: { id: true, userId: true, context: true, template: true, achievedAt: true },
         });
         return createdUserAchievement;
     }
 }
 
-export { createUserAchievement, getOrCreateUserAchievement, createSequentialAchievement };
+export { createUserAchievement, getOrCreateUserAchievement, createAchievement };

--- a/common/achievement/index.ts
+++ b/common/achievement/index.ts
@@ -6,8 +6,9 @@ import { ActionID, SpecificNotificationContext } from '../notification/actions';
 import { NotificationContext } from '../notification/types';
 import { getTemplatesByAction } from './template';
 import { evaluateAchievement } from './evaluate';
-import { ActionEvent, ConditionDataAggregations, EventValue, UserAchievementContext, UserAchievementTemplate } from './types';
-import { createSequentialAchievement, getOrCreateUserAchievement } from './create';
+import { AchievementToCheck, ActionEvent, ConditionDataAggregations, EventValue, UserAchievementContext, UserAchievementTemplate } from './types';
+import { createAchievement, getOrCreateUserAchievement } from './create';
+import { Achievement_template } from '../../graphql/generated';
 
 const logger = getLogger('Achievement');
 
@@ -20,6 +21,18 @@ export async function actionTaken<ID extends ActionID>(user: User, actionId: ID,
         return;
     }
 
+    const templatesByGroups: Map<string, Achievement_template[]> = new Map();
+    for (const template of templatesForAction) {
+        if (!templatesByGroups.has(template.group)) {
+            templatesByGroups.set(template.group, []);
+        }
+        templatesByGroups.get(template.group).push(template);
+    }
+    templatesByGroups.forEach((group, key) => {
+        group.sort((a, b) => a.groupOrder - b.groupOrder);
+        templatesByGroups.set(key, group);
+    });
+
     const event: ActionEvent<ID> = {
         actionId,
         at: new Date(),
@@ -28,9 +41,18 @@ export async function actionTaken<ID extends ActionID>(user: User, actionId: ID,
     };
     await trackEvent(event, context);
 
-    for (const template of templatesForAction) {
-        const userAchievement = await getOrCreateUserAchievement(template, user.userID, {});
-        await checkUserAchievement(userAchievement as UserAchievementTemplate, user.userID, context);
+    for (const [key, group] of templatesByGroups) {
+        let achievementToCheck: AchievementToCheck;
+        for (const template of group) {
+            const userAchievement = await getOrCreateUserAchievement(template, user.userID, {});
+            if (userAchievement.achievedAt === null) {
+                achievementToCheck = userAchievement;
+                break;
+            }
+        }
+        if (achievementToCheck) {
+            await checkUserAchievement(achievementToCheck as UserAchievementTemplate, context);
+        }
     }
 
     return null;
@@ -63,16 +85,14 @@ async function trackEvent<ID extends ActionID>(event: ActionEvent<ID>, context: 
     return true;
 }
 
-async function checkUserAchievement<ID extends ActionID>(userAchievement: UserAchievementTemplate, userId: string, context: SpecificNotificationContext<ID>) {
+async function checkUserAchievement<ID extends ActionID>(userAchievement: UserAchievementTemplate | undefined, context: SpecificNotificationContext<ID>) {
     if (userAchievement) {
         const isConditionMet = await isAchievementConditionMet(userAchievement, context);
         if (isConditionMet) {
             const awardedAchievement = await awardUser(userAchievement.id);
             // if a sequential achievement has been reached, we create the next step
-            if (userAchievement.template.type === 'SEQUENTIAL') {
-                const userAchievementContext: UserAchievementContext = {};
-                await createSequentialAchievement(awardedAchievement.template, userId, userAchievementContext);
-            }
+            const userAchievementContext: UserAchievementContext = {};
+            await createAchievement(awardedAchievement.template, userAchievement.userId, userAchievementContext);
         }
     }
 }

--- a/common/achievement/metric.ts
+++ b/common/achievement/metric.ts
@@ -37,7 +37,9 @@ const batchOfMetrics = [
     createMetric('onboarding_coc_success', ['student_coc_updated'], () => {
         return 1;
     }),
-    createMetric('student_performed_match_appointment', ['joined_match_meeting'], () => {
+    // student_conducted_match_appointment is a tiered achievement and therefore needs to be initialized, in this case with tutor_match_requested
+    // later requests to this metric will onle be conducted by joined_match_meeting. This is secured by the filter bucket
+    createMetric('student_conducted_match_appointment', ['tutor_match_requested', 'joined_match_meeting'], () => {
         return 1;
     }),
 ];

--- a/common/achievement/types.ts
+++ b/common/achievement/types.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '@prisma/client';
 import { Achievement_event, Achievement_template, achievement_type_enum } from '../../graphql/generated';
 import { ActionID, SpecificNotificationContext } from '../notification/actions';
 import { User } from '../user';
@@ -15,20 +16,39 @@ export type FormulaFunction<ID extends ActionID> = (context: SpecificNotificatio
 
 export type EventValue = number[] | Achievement_event[];
 
-// A bucket is seen as for a period of time
-export interface Bucket {
+// Used to destinguish between different types of buckets
+export type GenericBucketConfig<T extends Bucket> = {
+    bucketKind: T['kind'];
+    buckets: T[];
+};
+// Combines all possible bucket configs
+export type BucketConfig = GenericBucketConfig<TimeBucket> | GenericBucketConfig<FilterBucket> | GenericBucketConfig<DefaultBucket>;
+
+export type DefaultBucket = {
+    kind: 'default';
+};
+// Bucket containing events from a specific time frame
+export type TimeBucket = {
+    kind: 'time';
     startTime: Date;
     endTime: Date;
-}
+};
+// Bucket containing events that match a specific actionName
+export type FilterBucket = {
+    kind: 'filter';
+    actionName: string;
+};
+// A bucket is seen as for a period of time
+export type Bucket = DefaultBucket | TimeBucket | FilterBucket;
 
-export interface BucketEvents extends Bucket {
+export type BucketEvents = Bucket & {
     events: Achievement_event[];
-}
-export interface BucketEventsWithAggr extends BucketEvents {
+};
+export type BucketEventsWithAggr = BucketEvents & {
     aggregation: number;
-}
+};
 
-type BucketFormulaFunction = (relation?: string) => Promise<Bucket[]>;
+type BucketFormulaFunction = (relation?: string) => Promise<BucketConfig>;
 
 export type BucketFormula = {
     function: BucketFormulaFunction;
@@ -75,4 +95,12 @@ export type Achievement_Event = {
     value: EventValue;
     action?: string;
     relation?: string; // e.g. "user/10", "subcourse/15", "match/20"
+};
+
+export type AchievementToCheck = {
+    userId: string;
+    id: number;
+    achievedAt: Date;
+    context: Prisma.JsonValue;
+    template: Achievement_template;
 };

--- a/common/achievement/util.ts
+++ b/common/achievement/util.ts
@@ -52,3 +52,9 @@ export async function getRelationContext(relation: string) {
 
     throw new Error(`Unknown Relation(${relation})`);
 }
+
+// this function is used to split the action names in a string to an array of action names for the filter bucket creator function to create buckets for the specific events
+export function getActionsContext(actionNames: string) {
+    const actions = actionNames.split(',');
+    return actions;
+}

--- a/graphql/user/mutations.ts
+++ b/graphql/user/mutations.ts
@@ -116,11 +116,13 @@ export class MutateUserResolver {
         return true;
     }
 
+    // joined_match_meeting triggers a tiered achievement and therefore needs a relationId to be passed to create a filter bucket from
     @Mutation((returns) => Boolean)
     @Authorized(Role.USER)
     async joinedMatchMeeting(@Ctx() context: GraphQLContext, matchId: number) {
         await Notification.actionTaken(context.user, 'joined_match_meeting', {
             matchId: String(matchId),
+            relationId: 'joined_match_meeting',
         });
         return true;
     }


### PR DESCRIPTION
closes https://github.com/corona-school/project-user/issues/1019

What was done:

1. Added a GenericBucketConfig type to determine between different bucket types for different use cases
2. added a bucket to filter actions by a certain action name. This is determined weather to use ore not to use it
3. createAchievement was unified for sequential and tiered achievements
4. different bucket creators for evaluation bucket kinds
5. sort algorithm to sort templates by groups