### PR TITLE
fix: Prohibit usage of AuthorizedDeferred without context dependent roles

### DIFF
--- a/graphql/course/mutations.ts
+++ b/graphql/course/mutations.ts
@@ -175,7 +175,7 @@ export class MutateCourseResolver {
     }
 
     @Mutation((returns) => Boolean)
-    @AuthorizedDeferred(Role.ADMIN, Role.INSTRUCTOR)
+    @AuthorizedDeferred(Role.ADMIN, Role.OWNER)
     async courseDeleteInstructor(@Ctx() context: GraphQLContext, @Arg('courseId') courseId: number, @Arg('studentId') studentId: number): Promise<boolean> {
         const course = await getCourse(courseId);
         await hasAccess(context, 'Course', course);

--- a/graphql/match/mutations.ts
+++ b/graphql/match/mutations.ts
@@ -62,10 +62,9 @@ export class MutateMatchResolver {
     }
 
     @Mutation((returns) => Boolean)
-    @AuthorizedDeferred(Role.ADMIN)
-    async matchReactivate(@Ctx() context: GraphQLContext, @Arg('matchId', (type) => Int) matchId: number): Promise<boolean> {
+    @Authorized(Role.ADMIN)
+    async matchReactivate(@Arg('matchId', (type) => Int) matchId: number): Promise<boolean> {
         const match = await getMatch(matchId);
-        await hasAccess(context, 'Match', match);
         await reactivateMatch(match);
         const { conversation, conversationId } = await getMatcheeConversation({
             studentId: match.studentId,

--- a/graphql/subcourse/mutations.ts
+++ b/graphql/subcourse/mutations.ts
@@ -361,11 +361,11 @@ export class MutateSubcourseResolver {
     }
 
     @Mutation((returns) => Boolean)
-    @AuthorizedDeferred(Role.INSTRUCTOR)
+    @AuthorizedDeferred(Role.OWNER)
     async subcoursePromote(@Ctx() context: GraphQLContext, @Arg('subcourseId') subcourseId: number): Promise<boolean> {
         const subcourse = await getSubcourse(subcourseId);
-
         await hasAccess(context, 'Subcourse', subcourse);
+
         await sendPupilCoursePromotion(subcourse);
         await prisma.subcourse.update({ data: { alreadyPromoted: true }, where: { id: subcourse.id } });
         logger.info(`Subcourse(${subcourseId}) was manually promoted by instructor(${context.user.userID})`);


### PR DESCRIPTION
```
This suggests a programming mistake:

@AuthorizedDeferred(Role.INSTRUCTOR)
...
await hasAccess(course1);
```

This suggests the intent was to check access specific to a course, yet the access check is on generic roles. Usually one actually wants to use Role.OWNER instead