### PR TITLE
fix: Allow larger GraphQL Requests

### DIFF
--- a/web/server.ts
+++ b/web/server.ts
@@ -50,6 +50,7 @@ export const server = (async function setupWebserver() {
             verify: (req: WithRawBody<IncomingMessage>, res, buf) => {
                 req.rawBody = buf;
             },
+            limit: '10MB',
         })
     );
     app.use(cookieParser());


### PR DESCRIPTION
The default limit of 100kB is too small for our campaign tool. 10MB shouldn't be too heavy.