### PR TITLE
fix: Retry Lock if rolled back by DB

### DIFF
--- a/jobs/execute.ts
+++ b/jobs/execute.ts
@@ -50,8 +50,9 @@ export async function runJob(jobName: JobName): Promise<boolean> {
                         });
 
                         if (runningJob) {
-                            logger.warn(
+                            logger.error(
                                 `Cannot concurrently execute Job '${jobName}' as it is already running on '${runningJob.worker}' since ${runningJob.startedAt}`,
+                                undefined,
                                 { jobName, runningJob }
                             );
                             lockStatus = LockStatus.CONFLICT;
@@ -81,11 +82,9 @@ export async function runJob(jobName: JobName): Promise<boolean> {
         }
 
         if (lockStatus === LockStatus.ROLLBACK) {
-            logger.error(
-                `Failed to aquire Lock after at most 5 retries - This might leave the system in a locked state requiring manual cleanup!`,
-                new Error(),
-                { jobName }
-            );
+            logger.error(`Failed to aquire Lock after at most 5 retries - This might leave the system in a locked state requiring manual cleanup!`, undefined, {
+                jobName,
+            });
             return false;
         }
 


### PR DESCRIPTION
If the DB transaction succeeded we know if another job is running or not and can abort / continue accordingly.

If the transaction was rolled back by the DB due to a deadlock, we do not know if two transactions on the same job name collided or unrelated transactions collided (due to limitations in Postgres deadlock detection). Thus in that case it makes sense to retry, as usually one concurrent transaction should be aborted, so if we try again there should be no concurrent transaction