### PR TITLE
feat: Expose Chat Information via GraphQL, Allow Admins to activate / deactivate Chats

### DIFF
--- a/common/chat/conversation.ts
+++ b/common/chat/conversation.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { checkResponseStatus, convertConversationInfosToString, createOneOnOneId, userIdToTalkJsId } from './helper';
 import { User, userForPupil, userForStudent } from '../user';
 import { getPupil, getStudent } from '../../graphql/util';
-import { AllConversations, ChatAccess, ChatType, Conversation, ConversationInfos, SystemMessage, TJConversation } from './types';
+import { ChatAccess, ChatType, Conversation, ConversationInfos, SystemMessage, TJConversation } from './types';
 import { getLogger } from '../logger/logger';
 import assert from 'assert';
 import { assureChatFeatureActive } from './util';
@@ -91,7 +91,7 @@ const getMatcheeConversation = async (matchees: { studentId: number; pupilId: nu
     return { conversation, conversationId };
 };
 
-const getAllConversations = async (direction: ConversationDirectionEnum = ConversationDirectionEnum.ASC, startingAfter?: string): Promise<AllConversations> => {
+const getAllConversations = async (direction: ConversationDirectionEnum = ConversationDirectionEnum.ASC, startingAfter?: string): Promise<TJConversation[]> => {
     assert(TALKJS_SECRET_KEY, `No TalkJS secret key found to get all conversations.`);
     assureChatFeatureActive();
     const apiURL = `${TALKJS_CONVERSATION_API_URL}?limit=30&orderBy=lastActivity&orderDirection=${direction}`;
@@ -113,7 +113,7 @@ const getAllConversations = async (direction: ConversationDirectionEnum = Conver
 
     const result = await response.json();
     logger.info(`Got all conversations`, { result });
-    return result;
+    return result.data;
 };
 
 async function getLastUnreadConversation(user: User): Promise<{ data: Conversation[] }> {

--- a/common/chat/deactivation.ts
+++ b/common/chat/deactivation.ts
@@ -1,0 +1,101 @@
+import moment from 'moment';
+import { markConversationAsReadOnly, sendSystemMessage, updateConversation } from './conversation';
+import { countChatParticipants, checkChatMembersAccessRights } from './helper';
+import systemMessages from './localization';
+import { TJConversation, FinishedReason, SystemMessage } from './types';
+import { prisma } from '../prisma';
+import { getLogger } from '../logger/logger';
+
+const logger = getLogger('Chat Deactivation');
+
+// one to one chats (if match) whose match was dissolved 30 days ago should be "disabled" (readonly).
+// This will allow users to continue writing for another 30 days after match disolving.
+async function isActiveMatch(id: number): Promise<boolean> {
+    const today = moment().endOf('day');
+    const match = await prisma.match.findUniqueOrThrow({ where: { id } });
+    const dissolvedAtPlus30Days = moment(match.dissolvedAt).add(30, 'days');
+    return !dissolvedAtPlus30Days.isBefore(today);
+}
+
+async function isActiveSubcourse(id: number): Promise<boolean> {
+    const today = moment().endOf('day');
+    const subcourse = await prisma.subcourse.findUniqueOrThrow({ where: { id }, include: { lecture: true } });
+    const isSubcourseCancelled = subcourse.cancelled;
+
+    if (isSubcourseCancelled) {
+        return false;
+    }
+
+    const lastLecture = subcourse.lecture.sort((a, b) => moment(a.start).milliseconds() - moment(b.start).milliseconds()).pop();
+    const lastLecturePlus30Days = moment(lastLecture.start).add(30, 'days');
+    const is30DaysBeforeToday = lastLecturePlus30Days.isBefore(today);
+    return !is30DaysBeforeToday;
+}
+
+export function isConversationReadOnly(conversation: TJConversation) {
+    const countParticipants = countChatParticipants(conversation);
+    const { readMembers } = checkChatMembersAccessRights(conversation);
+    return readMembers.length === countParticipants;
+}
+
+function isMatchConversation(conversation: TJConversation) {
+    return !!conversation.custom.match;
+}
+
+export async function deactivateConversation(conversation: TJConversation) {
+    // Prevent users from writing new messages
+    await markConversationAsReadOnly(conversation.id);
+
+    // Inform users about the deactivation
+    const systemMessage = isMatchConversation(conversation) ? SystemMessage.ONE_ON_ONE_OVER : SystemMessage.GROUP_OVER;
+    await sendSystemMessage(systemMessages.de.deactivated, conversation.id, systemMessage);
+
+    // Store the deactivation reason in the Chat, in case we need this somewhen
+    await updateConversation({
+        id: conversation.id,
+        custom: {
+            finished: isMatchConversation(conversation) ? FinishedReason.MATCH_DISSOLVED : FinishedReason.COURSE_OVER,
+        },
+    });
+
+    logger.info('Deactivated Conversation', { conversationId: conversation.id, systemMessage });
+}
+
+// Whether a Chat should be deactivated by the background job soon as the corresponding
+// match or subcourse ended some time ago
+export async function shouldMarkChatAsReadonly(conversation: TJConversation) {
+    let shouldMarkAsReadonly = true;
+
+    if (conversation.custom.subcourse) {
+        const subcourseIds: number[] = JSON.parse(conversation.custom.subcourse);
+        const allSubcoursesActive = await Promise.all(subcourseIds.map((id) => isActiveSubcourse(id)));
+        const allInactive = allSubcoursesActive.every((active) => active === false);
+        logger.info(`Conversation ${conversation.id} belongs to subcourses which are ${allInactive ? 'all inactive' : 'active'}`, {
+            conversationId: conversation.id,
+        });
+        shouldMarkAsReadonly &&= allInactive;
+    }
+
+    if (conversation.custom.prospectSubcourse) {
+        const prospectSubcourses: number[] = JSON.parse(conversation.custom.prospectSubcourse);
+        const allProspectSubcoursesActive = await Promise.all(prospectSubcourses.map((id) => isActiveSubcourse(id)));
+        const allInactive = allProspectSubcoursesActive.every((active) => active === false);
+        logger.info(`Conversation ${conversation.id} belongs to subcourses which are all ${allInactive ? 'all inactive' : 'active'}`, {
+            conversationId: conversation.id,
+        });
+        shouldMarkAsReadonly &&= allInactive;
+    }
+
+    if (conversation.custom.match) {
+        const match = JSON.parse(conversation.custom.match);
+        const matchId = match.matchId;
+        const isMatchActive = await isActiveMatch(matchId);
+        logger.info(`Conversation ${conversation.id} belongs to Match(${matchId}) which is all ${isMatchActive ? 'active' : 'inactive'}`, {
+            conversationId: conversation.id,
+            matchId,
+        });
+        shouldMarkAsReadonly &&= !isMatchActive;
+    }
+
+    return shouldMarkAsReadonly;
+}

--- a/common/chat/deactivation.ts
+++ b/common/chat/deactivation.ts
@@ -72,6 +72,7 @@ export async function shouldMarkChatAsReadonly(conversation: TJConversation) {
         const allInactive = allSubcoursesActive.every((active) => active === false);
         logger.info(`Conversation ${conversation.id} belongs to subcourses which are ${allInactive ? 'all inactive' : 'active'}`, {
             conversationId: conversation.id,
+            subcourseIds,
         });
         shouldMarkAsReadonly &&= allInactive;
     }
@@ -82,6 +83,7 @@ export async function shouldMarkChatAsReadonly(conversation: TJConversation) {
         const allInactive = allProspectSubcoursesActive.every((active) => active === false);
         logger.info(`Conversation ${conversation.id} belongs to subcourses which are all ${allInactive ? 'all inactive' : 'active'}`, {
             conversationId: conversation.id,
+            prospectSubcourses,
         });
         shouldMarkAsReadonly &&= allInactive;
     }

--- a/common/chat/types.ts
+++ b/common/chat/types.ts
@@ -75,7 +75,3 @@ export enum FinishedReason {
     COURSE_OVER = 'course_over',
     REACTIVATE = 'reactivated',
 }
-
-export type AllConversations = {
-    data: TJConversation[];
-};

--- a/common/chat/types.ts
+++ b/common/chat/types.ts
@@ -74,4 +74,5 @@ export enum FinishedReason {
     MATCH_DISSOLVED = 'match_dissolved',
     COURSE_OVER = 'course_over',
     REACTIVATE = 'reactivated',
+    REACTIVATE_BY_ADMIN = 'reactivated_by_admin',
 }

--- a/graphql/chat/fields.ts
+++ b/graphql/chat/fields.ts
@@ -1,4 +1,4 @@
-import { Authorized, FieldResolver, ObjectType, Resolver, Root } from 'type-graphql';
+import { Authorized, Field, FieldResolver, ObjectType, Resolver, Root } from 'type-graphql';
 import { isConversationReadOnly, shouldMarkChatAsReadonly } from '../../common/chat/deactivation';
 import { TJConversation } from '../../common/chat/types';
 import { Role } from '../roles';
@@ -7,12 +7,16 @@ import { GraphQLJSON } from 'graphql-scalars';
 
 @ObjectType()
 export class Chat {
+    @Field()
+    conversationId: string;
+
     conversation: TJConversation;
 }
 
 export async function getChat(conversationID: string): Promise<Chat | null> {
     try {
-        return { conversation: await getConversation(conversationID) };
+        const conversation = await getConversation(conversationID);
+        return { conversation, conversationId: conversation.id };
     } catch (error) {
         return null;
     }
@@ -20,12 +24,6 @@ export async function getChat(conversationID: string): Promise<Chat | null> {
 
 @Resolver((of) => Chat)
 export class FieldsChatResolver {
-    @FieldResolver((returns) => String)
-    @Authorized(Role.ADMIN)
-    conversationId(@Root() chat: Chat) {
-        return chat.conversation.id;
-    }
-
     @FieldResolver((returns) => Date)
     @Authorized(Role.ADMIN)
     createdAt(@Root() chat: Chat) {

--- a/graphql/chat/fields.ts
+++ b/graphql/chat/fields.ts
@@ -1,0 +1,33 @@
+import { Authorized, FieldResolver, ObjectType, Resolver, Root } from 'type-graphql';
+import { isConversationReadOnly, shouldMarkChatAsReadonly } from '../../common/chat/deactivation';
+import { TJConversation } from '../../common/chat/types';
+import { Role } from '../roles';
+import { getConversation } from '../../common/chat';
+
+@ObjectType()
+export class Chat {
+    conversation: TJConversation;
+}
+
+export async function getChat(conversationID: string): Promise<Chat | null> {
+    try {
+        return { conversation: await getConversation(conversationID) };
+    } catch (error) {
+        return null;
+    }
+}
+
+@Resolver((of) => Chat)
+export class FieldsChatResolver {
+    @FieldResolver((returns) => Boolean)
+    @Authorized(Role.ADMIN)
+    async shouldMarkAsReadonly(@Root() chat: Chat) {
+        return await shouldMarkChatAsReadonly(chat.conversation);
+    }
+
+    @FieldResolver((returns) => Boolean)
+    @Authorized(Role.ADMIN)
+    isReadonly(@Root() chat: Chat) {
+        return isConversationReadOnly(chat.conversation);
+    }
+}

--- a/graphql/chat/fields.ts
+++ b/graphql/chat/fields.ts
@@ -3,6 +3,7 @@ import { isConversationReadOnly, shouldMarkChatAsReadonly } from '../../common/c
 import { TJConversation } from '../../common/chat/types';
 import { Role } from '../roles';
 import { getConversation } from '../../common/chat';
+import { GraphQLJSON } from 'graphql-scalars';
 
 @ObjectType()
 export class Chat {
@@ -19,6 +20,30 @@ export async function getChat(conversationID: string): Promise<Chat | null> {
 
 @Resolver((of) => Chat)
 export class FieldsChatResolver {
+    @FieldResolver((returns) => String)
+    @Authorized(Role.ADMIN)
+    conversationId(@Root() chat: Chat) {
+        return chat.conversation.id;
+    }
+
+    @FieldResolver((returns) => Date)
+    @Authorized(Role.ADMIN)
+    createdAt(@Root() chat: Chat) {
+        return chat.conversation.createdAt;
+    }
+
+    @FieldResolver((returns) => String)
+    @Authorized(Role.ADMIN)
+    subject(@Root() chat: Chat) {
+        return chat.conversation.subject;
+    }
+
+    @FieldResolver((returns) => GraphQLJSON, { nullable: true })
+    @Authorized(Role.ADMIN)
+    customData(@Root() chat: Chat) {
+        return chat.conversation.custom;
+    }
+
     @FieldResolver((returns) => Boolean)
     @Authorized(Role.ADMIN)
     async shouldMarkAsReadonly(@Root() chat: Chat) {

--- a/graphql/match/fields.ts
+++ b/graphql/match/fields.ts
@@ -7,6 +7,8 @@ import { getStudent, getPupil } from '../util';
 import { getOverlappingSubjects } from '../../common/match/util';
 import { Subject } from '../types/subject';
 import { GraphQLContext } from '../context';
+import { Chat } from '../chat/fields';
+import { getMatcheeConversation } from '../../common/chat';
 
 @Resolver((of) => Match)
 export class ExtendedFieldsMatchResolver {
@@ -81,5 +83,16 @@ export class ExtendedFieldsMatchResolver {
             },
             orderBy: { start: 'asc' },
         });
+    }
+
+    @FieldResolver((returns) => Chat, { nullable: true })
+    @Authorized(Role.ADMIN)
+    async chat(@Root() match: Required<Match>) {
+        try {
+            const { conversation } = await getMatcheeConversation(match);
+            return { conversation } as Chat;
+        } catch (error) {
+            return null;
+        }
     }
 }

--- a/graphql/match/fields.ts
+++ b/graphql/match/fields.ts
@@ -90,7 +90,7 @@ export class ExtendedFieldsMatchResolver {
     async chat(@Root() match: Required<Match>) {
         try {
             const { conversation } = await getMatcheeConversation(match);
-            return { conversation } as Chat;
+            return { conversation, conversationId: conversation.id } as Chat;
         } catch (error) {
             return null;
         }

--- a/graphql/subcourse/fields.ts
+++ b/graphql/subcourse/fields.ts
@@ -17,6 +17,7 @@ import { gradeAsInt } from '../../common/util/gradestrings';
 import { subcourseSearch } from '../../common/courses/search';
 import { GraphQLInt } from 'graphql';
 import { getCourseCapacity } from '../../common/courses/util';
+import { Chat, getChat } from '../chat/fields';
 
 @ObjectType()
 class Participant {
@@ -496,5 +497,15 @@ export class ExtendedFieldsSubcourseResolver {
             },
             orderBy: { start: 'asc' },
         });
+    }
+
+    @FieldResolver((returns) => Chat, { nullable: true })
+    @Authorized(Role.ADMIN)
+    async chat(@Root() subcourse: Required<Subcourse>) {
+        if (!subcourse.conversationId) {
+            return null;
+        }
+
+        return await getChat(subcourse.conversationId);
     }
 }

--- a/jobs/periodic/flag-old-conversations/index.ts
+++ b/jobs/periodic/flag-old-conversations/index.ts
@@ -1,120 +1,24 @@
-import moment from 'moment';
-import { getMatch, getSubcourse } from '../../../graphql/util';
 import { ConversationDirectionEnum, getAllConversations, markConversationAsReadOnly, sendSystemMessage, updateConversation } from '../../../common/chat';
 import { getLogger } from '../../../common/logger/logger';
-import { Lecture } from '../../../graphql/generated';
-import { FinishedReason, SystemMessage, TJConversation } from '../../../common/chat/types';
-import systemMessages from '../../../common/chat/localization';
-import { checkChatMembersAccessRights, countChatParticipants } from '../../../common/chat/helper';
+import { TJConversation } from '../../../common/chat/types';
+import { deactivateConversation, isConversationReadOnly, shouldMarkChatAsReadonly } from '../../../common/chat/deactivation';
 
 const logger = getLogger('FlagOldConversationsAsRO');
 
-enum ConversationType {
-    GROUP = 'group',
-    ONE_ON_ONE = 'one_on_one',
-}
-
-type conversationsToDeactivate = {
-    id: string;
-    conversationType: ConversationType;
-};
-
-// one to one chats (if match) whose match was dissolved 30 days ago should be "disabled" (readonly).
-// This will allow users to continue writing for another 30 days after match disolving.
-async function isActiveMatch(id: number): Promise<boolean> {
-    const today = moment().endOf('day');
-    const match = await getMatch(id);
-    const dissolvedAtPlus30Days = moment(match.dissolvedAt).add(30, 'days');
-    return !dissolvedAtPlus30Days.isBefore(today);
-}
-
-async function isActiveSubcourse(id: number): Promise<boolean> {
-    const today = moment().endOf('day');
-    const subcourse = await getSubcourse(id, true);
-    const isSubcourseCancelled = subcourse.cancelled;
-
-    if (isSubcourseCancelled) {
-        return false;
-    }
-
-    const lastLecutre = subcourse.lecture.sort((a: Lecture, b: Lecture) => moment(a.start).milliseconds() - moment(b.start).milliseconds()).pop();
-    const lastLecturePlus30Days = moment(lastLecutre.start).add(30, 'days');
-    const is30DaysBeforeToday = lastLecturePlus30Days.isBefore(today);
-    return !is30DaysBeforeToday;
-}
-
-function isConversationReadOnly(conversation: TJConversation) {
-    const countParticipants = countChatParticipants(conversation);
-    const { readMembers } = checkChatMembersAccessRights(conversation);
-    return readMembers.length === countParticipants;
-}
-
-async function finishConversation(convo: conversationsToDeactivate, finishReason: FinishedReason, systemMessageType: SystemMessage) {
-    const updateConversationInfo = {
-        id: convo.id,
-        custom: {
-            finished: finishReason,
-        },
-    };
-
-    await sendSystemMessage(systemMessages.de.deactivated, convo.id, systemMessageType);
-    await updateConversation(updateConversationInfo);
-
-    logger.info('Mark conversation as readonly', { conversationId: convo.id, conversationType: convo.conversationType });
-}
-
 async function paginateConversations(orderDirection: ConversationDirectionEnum) {
     let startingAfter: string = undefined;
-    const conversationsToFlag: conversationsToDeactivate[] = [];
+    const conversationsToFlag: TJConversation[] = [];
 
     do {
-        const conversationsResponse = await getAllConversations(orderDirection, startingAfter);
-        const conversations = conversationsResponse.data;
-
+        const conversations = await getAllConversations(orderDirection, startingAfter);
         for (const conversation of conversations) {
-            let shouldMarkAsReadonly = true;
-
             if (isConversationReadOnly(conversation)) {
                 logger.info(`Conversation ${conversation.id} is already readonly.`);
                 continue;
             }
 
-            if (conversation.custom.subcourse) {
-                const subcourseIds: number[] = JSON.parse(conversation.custom.subcourse);
-                const allSubcoursesActive = await Promise.all(subcourseIds.map((id) => isActiveSubcourse(id)));
-                const allInactive = allSubcoursesActive.every((active) => active === false);
-                logger.info(`Conversation ${conversation.id} belongs to subcourses which are ${allInactive ? 'all inactive' : 'active'}`, {
-                    conversationId: conversation.id,
-                });
-                shouldMarkAsReadonly &&= allInactive;
-            }
-
-            if (conversation.custom.prospectSubcourse) {
-                const prospectSubcourses: number[] = JSON.parse(conversation.custom.prospectSubcourse);
-                const allProspectSubcoursesActive = await Promise.all(prospectSubcourses.map((id) => isActiveSubcourse(id)));
-                const allInactive = allProspectSubcoursesActive.every((active) => active === false);
-                logger.info(`Conversation ${conversation.id} belongs to subcourses which are all ${allInactive ? 'all inactive' : 'active'}`, {
-                    conversationId: conversation.id,
-                });
-                shouldMarkAsReadonly &&= allInactive;
-            }
-
-            if (conversation.custom.match) {
-                const match = JSON.parse(conversation.custom.match);
-                const matchId = match.matchId;
-                const isMatchActive = await isActiveMatch(matchId);
-                logger.info(`Conversation ${conversation.id} belongs to Match(${matchId}) which is all ${isMatchActive ? 'active' : 'inactive'}`, {
-                    conversationId: conversation.id,
-                    matchId,
-                });
-                shouldMarkAsReadonly &&= !isMatchActive;
-            }
-
-            if (shouldMarkAsReadonly) {
-                conversationsToFlag.push({
-                    id: conversation.id,
-                    conversationType: conversation.custom.match ? ConversationType.ONE_ON_ONE : ConversationType.GROUP,
-                });
+            if (await shouldMarkChatAsReadonly(conversation)) {
+                conversationsToFlag.push(conversation);
             }
         }
 
@@ -128,15 +32,11 @@ export default async function flagInactiveConversationsAsReadonly() {
     const conversationsToFlag = await paginateConversations(ConversationDirectionEnum.ASC);
 
     if (conversationsToFlag.length > 0) {
-        for (const convo of conversationsToFlag) {
-            await markConversationAsReadOnly(convo.id);
-            if (convo.conversationType === ConversationType.ONE_ON_ONE) {
-                await finishConversation(convo, FinishedReason.MATCH_DISSOLVED, SystemMessage.ONE_ON_ONE_OVER);
-            } else {
-                await finishConversation(convo, FinishedReason.COURSE_OVER, SystemMessage.GROUP_OVER);
-            }
-            logger.info('Mark converstation as readonly', { conversationId: convo.id, conversationType: convo.conversationType });
+        for (const conversation of conversationsToFlag) {
+            await deactivateConversation(conversation);
         }
+
+        logger.info(`Marked ${conversationsToFlag.length} conversations as readonly`);
     } else {
         logger.info('No conversation to mark as readonly');
     }

--- a/jobs/periodic/flag-old-conversations/index.ts
+++ b/jobs/periodic/flag-old-conversations/index.ts
@@ -1,6 +1,6 @@
 import { ConversationDirectionEnum, getAllConversations, markConversationAsReadOnly, sendSystemMessage, updateConversation } from '../../../common/chat';
 import { getLogger } from '../../../common/logger/logger';
-import { TJConversation } from '../../../common/chat/types';
+import { FinishedReason, TJConversation } from '../../../common/chat/types';
 import { deactivateConversation, isConversationReadOnly, shouldMarkChatAsReadonly } from '../../../common/chat/deactivation';
 
 const logger = getLogger('FlagOldConversationsAsRO');
@@ -11,6 +11,13 @@ export default async function flagInactiveConversationsAsReadonly() {
     for await (const conversation of getAllConversations()) {
         if (isConversationReadOnly(conversation)) {
             logger.info(`Conversation ${conversation.id} is already readonly.`);
+            continue;
+        }
+
+        if (conversation.custom?.finished === FinishedReason.REACTIVATE_BY_ADMIN) {
+            logger.info(`Converdation ${conversation.id} was reactivated by an admin, do not deactivate again automatically`, {
+                conversationId: conversation.id,
+            });
             continue;
         }
 


### PR DESCRIPTION
I currently have no clue why the background job sometimes wrongly deactivates chats. Thus to get a better idea, expose Chat information via GraphQL so that we can look into it. Also provide mutations for manually activating and reactivating chats, if manually reactivated the deactivation job will ignore it.