### PR TITLE
fix: Slack Table Generation

### DIFF
--- a/common/slack/blocks.ts
+++ b/common/slack/blocks.ts
@@ -6,33 +6,44 @@ export interface SlackBlock {
     fields?: { type: 'mrkdwn'; text: string }[];
 }
 
-// Unfortunately Slack only supports tables with two columns:
-export function table(name: string, colA: string, colB: string, entries: [string, string][]): SlackBlock {
-    return {
-        type: 'section',
-        text: { type: 'mrkdwn', text: name },
-        fields: [
-            {
-                type: 'mrkdwn',
-                text: bold(colA),
-            },
-            {
-                type: 'mrkdwn',
-                text: bold(colB),
-            },
-            ...entries.flatMap(
-                (entry) =>
-                    [
-                        {
-                            type: 'mrkdwn',
-                            text: entry[0],
-                        },
-                        {
-                            type: 'mrkdwn',
-                            text: entry[1],
-                        },
-                    ] as const
-            ),
-        ],
-    };
+// Unfortunately Slack only supports tables with two columns, and with a maximum of 10 rows
+export function table(name: string, colA: string, colB: string, entries: [string, string][]): SlackBlock[] {
+    const result: SlackBlock[] = [];
+
+    for (let i = 0; i < entries.length; i += 4) {
+        const chunk = entries.slice(i, i + 4);
+        result.push({
+            type: 'section',
+            text: { type: 'mrkdwn', text: i === 0 ? name : ' ' },
+            fields: [
+                ...(i === 0
+                    ? ([
+                          {
+                              type: 'mrkdwn',
+                              text: bold(colA),
+                          },
+                          {
+                              type: 'mrkdwn',
+                              text: bold(colB),
+                          },
+                      ] as const)
+                    : []),
+                ...chunk.flatMap(
+                    (entry) =>
+                        [
+                            {
+                                type: 'mrkdwn',
+                                text: entry[0],
+                            },
+                            {
+                                type: 'mrkdwn',
+                                text: entry[1],
+                            },
+                        ] as const
+                ),
+            ],
+        });
+    }
+
+    return result;
 }

--- a/jobs/slack-statistics.ts
+++ b/jobs/slack-statistics.ts
@@ -145,7 +145,7 @@ export async function postStatisticsToSlack() {
 
     await sendToSlack(SLACK_CHANNEL.PublicStatistics, {
         blocks: [
-            table(`Statistiken vom ${begin} zum ${end}`, 'Name', 'Wert', [
+            ...table(`Statistiken vom ${begin} zum ${end}`, 'Name', 'Wert', [
                 ['Anzahl registrierter Schüler*innen', '' + pupilRegisteredCount],
                 ['Anzahl registrierter Helfer*innen', '' + studentsRegisteredCount],
                 ['Anzahl erfolgreicher Screenings Schüler*innen', '' + pupilScreeningSuccessCount + ' von ' + pupilScreeningCount],
@@ -155,9 +155,9 @@ export async function postStatisticsToSlack() {
                 ['Anzahl erstellter Kurse', '' + subcourseCreatedCount],
                 ['Anzahl Match-Termine', '' + matchAppointmentCount],
             ]),
-            table('Von uns gehört durch... (Helfer*innen)', 'Name', 'Wert', tutorKnowsCoronaSchoolFromTable),
-            table('Von uns gehört durch... (Kursleiter*innen)', 'Name', 'Wert', instructorKnowsCoronaSchoolFromTable),
-            table('Anzahl der belegten Plätze in den aktuellen Kursen', 'Name', 'Wert', subcourseSeatsTakenTable),
+            ...table('Von uns gehört durch... (Helfer*innen)', 'Name', 'Wert', tutorKnowsCoronaSchoolFromTable),
+            ...table('Von uns gehört durch... (Kursleiter*innen)', 'Name', 'Wert', instructorKnowsCoronaSchoolFromTable),
+            ...table('Anzahl der belegten Plätze in den aktuellen Kursen', 'Name', 'Wert', subcourseSeatsTakenTable),
         ],
     });
 }


### PR DESCRIPTION
For some reason Slack only allows 10 entries per table. Thus we just split them into multiple tables with empty headline :/