### PR TITLE
Remove group from ua

### DIFF
--- a/common/achievement/create.ts
+++ b/common/achievement/create.ts
@@ -94,8 +94,6 @@ async function createNextUserAchievement<ID extends ActionID>(
         const createdUserAchievement = await prisma.user_achievement.create({
             data: {
                 userId: userId,
-                group: nextStepTemplate.group,
-                groupOrder: nextStepTemplate.groupOrder,
                 context: context ? context : Prisma.JsonNull,
                 template: { connect: { id: nextStepTemplate.id } },
                 recordValue: nextStepTemplate.type === 'STREAK' ? 0 : null,

--- a/common/achievement/get.ts
+++ b/common/achievement/get.ts
@@ -43,7 +43,7 @@ const getNextStepAchievements = async (user: User): Promise<Achievement[]> => {
         userAchievementGroups[key].push(ua);
     });
     Object.keys(userAchievementGroups).forEach((groupName) => {
-        const group = userAchievementGroups[groupName].sort((a, b) => a.groupOrder - b.groupOrder);
+        const group = userAchievementGroups[groupName].sort((a, b) => a.template.groupOrder - b.template.groupOrder);
         group[group.length - 1].achievedAt && delete userAchievementGroups[groupName];
     });
     const achievements: Achievement[] = await generateReorderedAchievementData(userAchievementGroups, user);
@@ -122,7 +122,7 @@ const generateReorderedAchievementData = async (groups: { [group: string]: achie
     const achievements = await Promise.all(
         groupKeys.map(async (key) => {
             const group = groups[key];
-            const sortedGroupAchievements = group.sort((a, b) => a.groupOrder - b.groupOrder);
+            const sortedGroupAchievements = group.sort((a, b) => a.template.groupOrder - b.template.groupOrder);
             /**
              * This Assembles individual achievements for tiered milestones. Tiered achievements represent steps on the path to higher scores.
              * Unlike sequential achievements, each tier is processed separately and displayed on the frontend as a distinct achievement.

--- a/integration-tests/15_achievements.ts
+++ b/integration-tests/15_achievements.ts
@@ -43,11 +43,11 @@ void test('Reward student onboarding achievement sequence', async () => {
 
     const studentOnboarding1 = await prisma.user_achievement.findFirst({
         where: {
-            group: 'student_onboarding',
-            groupOrder: 1,
             achievedAt: { not: null },
             userId: user.userID,
+            template: { group: 'student_onboarding', groupOrder: 1 },
         },
+        include: { template: true },
     });
     assert.ok(studentOnboarding1);
 
@@ -63,11 +63,11 @@ void test('Reward student onboarding achievement sequence', async () => {
     `);
     const studentOnboarding2 = await prisma.user_achievement.findFirst({
         where: {
-            group: 'student_onboarding',
-            groupOrder: 3,
             achievedAt: { not: null },
             userId: user.userID,
+            template: { group: 'student_onboarding', groupOrder: 3 },
         },
+        include: { template: true },
     });
     assert.ok(studentOnboarding2);
 
@@ -85,18 +85,18 @@ void test('Reward student onboarding achievement sequence', async () => {
     `);
     const studentOnboarding3 = await prisma.user_achievement.findFirst({
         where: {
-            group: 'student_onboarding',
-            groupOrder: 4,
             achievedAt: { not: null },
             userId: user.userID,
+            template: { group: 'student_onboarding', groupOrder: 4 },
         },
+        include: { template: true },
     });
     const studentOnboarding4 = await prisma.user_achievement.findFirst({
         where: {
-            group: 'student_onboarding',
-            groupOrder: 5,
             userId: user.userID,
+            template: { group: 'student_onboarding', groupOrder: 5 },
         },
+        include: { template: true },
     });
     assert.ok(studentOnboarding3);
     assert.ok(studentOnboarding4);
@@ -111,11 +111,11 @@ void test('Reward pupil onboarding achievement sequence', async () => {
 
     const pupilOnboarding1 = await prisma.user_achievement.findFirst({
         where: {
-            group: 'pupil_onboarding',
-            groupOrder: 1,
             achievedAt: { not: null },
             userId: user.userID,
+            template: { group: 'pupil_onboarding', groupOrder: 1 },
         },
+        include: { template: true },
     });
     assert.ok(pupilOnboarding1);
     // Screening
@@ -124,18 +124,18 @@ void test('Reward pupil onboarding achievement sequence', async () => {
     `);
     const pupilOnboarding2 = await prisma.user_achievement.findFirst({
         where: {
-            group: 'pupil_onboarding',
-            groupOrder: 3,
             achievedAt: { not: null },
             userId: user.userID,
+            template: { group: 'pupil_onboarding', groupOrder: 3 },
         },
+        include: { template: true },
     });
     const pupilOnboarding3 = await prisma.user_achievement.findFirst({
         where: {
-            group: 'pupil_onboarding',
-            groupOrder: 4,
             userId: user.userID,
+            template: { group: 'pupil_onboarding', groupOrder: 4 },
         },
+        include: { template: true },
     });
     assert.ok(pupilOnboarding2);
     assert.ok(pupilOnboarding3);
@@ -180,9 +180,10 @@ void test('Reward student conducted match appointment', async () => {
 
     const studentJoinedMatchMeetingAchievements = await prisma.user_achievement.findMany({
         where: {
-            group: 'student_conduct_match_appointment',
             userId: user.userID,
+            template: { group: 'student_conduct_match_appointment' },
         },
+        include: { template: true },
     });
     assert.ok(studentJoinedMatchMeetingAchievements[0]);
     assert.notStrictEqual(studentJoinedMatchMeetingAchievements.length, 0);
@@ -225,9 +226,10 @@ void test('Reward pupil conducted match appointment', async () => {
     `);
     const pupilJoinedMatchMeetingAchievements = await prisma.user_achievement.findMany({
         where: {
-            group: 'pupil_conduct_match_appointment',
             userId: user.userID,
+            template: { group: 'pupil_conduct_match_appointment' },
         },
+        include: { template: true },
     });
     assert.ok(pupilJoinedMatchMeetingAchievements);
     assert.notStrictEqual(pupilJoinedMatchMeetingAchievements.length, 0);
@@ -289,10 +291,11 @@ void test('Reward student regular learning', async () => {
     const studentMatchRegularLearningRecord = await prisma.user_achievement.findFirst({
         where: {
             userId: user.userID,
-            group: 'student_match_regular_learning',
             achievedAt: { not: null },
             recordValue: 2,
+            template: { group: 'student_match_regular_learning' },
         },
+        include: { template: true },
     });
     assert.ok(studentMatchRegularLearningRecord);
 
@@ -310,10 +313,11 @@ void test('Reward student regular learning', async () => {
     const studentMatchRegularLearning = await prisma.user_achievement.findFirst({
         where: {
             userId: user.userID,
-            group: 'student_match_regular_learning',
             achievedAt: null,
             recordValue: 2,
+            template: { group: 'student_match_regular_learning' },
         },
+        include: { template: true },
     });
     assert.ok(studentMatchRegularLearning);
 });
@@ -387,10 +391,11 @@ void test('Reward pupil regular learning', async () => {
     const pupilMatchRegularLearning = await prisma.user_achievement.findFirst({
         where: {
             userId: user.userID,
-            group: 'pupil_match_regular_learning',
             achievedAt: null,
             recordValue: 2,
+            template: { group: 'pupil_match_regular_learning' },
         },
+        include: { template: true },
     });
     assert.ok(pupilMatchRegularLearning);
 });

--- a/prisma/migrations/20240128110055_remove_group_and_group_order_from_user_achievement/migration.sql
+++ b/prisma/migrations/20240128110055_remove_group_and_group_order_from_user_achievement/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `group` on the `user_achievement` table. All the data in the column will be lost.
+  - You are about to drop the column `groupOrder` on the `user_achievement` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "user_achievement" DROP COLUMN "group",
+DROP COLUMN "groupOrder";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -72,11 +72,6 @@ model user_achievement {
   templateId  Int
   template    achievement_template @relation(fields: [templateId], references: [id])
   userId      String
-  // the description of group and groupOrder can be found in the achievement_template. 
-  // It needs to be stored in user_achievement, as the group contains templating. 
-  // The correctly assigned achievement for a match / a course is therefore stored in the user_achievement.
-  group       String               @db.VarChar
-  groupOrder  Int
   isSeen      Boolean              @default(false)
   // achievedAt == null => not achieved, achievedAt != null => achieved
   achievedAt  DateTime?            @db.Timestamp(6)


### PR DESCRIPTION
The "Group" and "GroupOrder" fields in the user achievement were remnants from the initial version. Once we opted for on-demand rendering, these fields became unnecessary. Moreover, the group is no longer used for identification purposes either.