### PR TITLE
feature: add dedicated relation field to user achievement table

### DIFF
--- a/common/achievement/types.ts
+++ b/common/achievement/types.ts
@@ -100,7 +100,7 @@ export type ActionEvent<ID extends ActionID> = {
 
 type ThenArg<T> = T extends PromiseLike<infer U> ? U : T;
 export type achievement_with_template = ThenArg<ReturnType<typeof getUserAchievementWithTemplate>>;
-export type AchievementToCheck = Pick<achievement_with_template, 'id' | 'userId' | 'achievedAt' | 'recordValue' | 'context' | 'template'>;
+export type AchievementToCheck = Pick<achievement_with_template, 'id' | 'userId' | 'achievedAt' | 'recordValue' | 'context' | 'template' | 'relation'>;
 
 export type EvaluationResult = {
     conditionIsMet: boolean;

--- a/common/courses/states.ts
+++ b/common/courses/states.ts
@@ -175,7 +175,7 @@ export async function cancelSubcourse(user: User, subcourse: Subcourse) {
             userId: {
                 in: courseInstructors.map((instructor) => userForStudent(instructor.student).userID),
             },
-            context: { path: ['relation'], equals: `subcourse/${subcourse.id}` },
+            relation: `subcourse/${subcourse.id}`,
         },
     });
 }

--- a/graphql/course/mutations.ts
+++ b/graphql/course/mutations.ts
@@ -115,7 +115,7 @@ export class MutateCourseResolver {
 
         for (const subcourse of subcourses) {
             const usersSubcourseAchievements = await prisma.user_achievement.findMany({
-                where: { context: { path: ['relation'], equals: `subcourse/${subcourse.id}` } },
+                where: { relation: `subcourse/${subcourse.id}` },
                 include: { template: true },
             });
             for (const achievement of usersSubcourseAchievements) {

--- a/graphql/subcourse/mutations.ts
+++ b/graphql/subcourse/mutations.ts
@@ -145,7 +145,7 @@ export class MutateSubcourseResolver {
         await prisma.user_achievement.deleteMany({
             where: {
                 userId: `student/${studentId}`,
-                context: { path: ['relation'], equals: `subcourse/${subcourseId}` },
+                relation: `subcourse/${subcourseId}`,
             },
         });
 

--- a/integration-tests/15_achievements.ts
+++ b/integration-tests/15_achievements.ts
@@ -263,7 +263,7 @@ void test('Reward student regular learning', async () => {
     const allAchievements = await prisma.user_achievement.findMany({
         where: {
             userId: user.userID,
-            context: { path: ['relation'], equals: `match/${match.id}` },
+            relation: `match/${match.id}`,
         },
         include: { template: true },
     });
@@ -352,7 +352,7 @@ void test('Reward pupil regular learning', async () => {
     const achievements = await prisma.user_achievement.findMany({
         where: {
             userId: user.userID,
-            context: { path: ['relation'], equals: `match/${match.id}` },
+            relation: `match/${match.id}`,
         },
         include: { template: true },
     });

--- a/prisma/migrations/20240128111430_add_relation_as_db_field/migration.sql
+++ b/prisma/migrations/20240128111430_add_relation_as_db_field/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "user_achievement" ADD COLUMN     "relation" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_achievement_relation_userId_templateId_key" ON "user_achievement"("relation", "userId", "templateId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -68,6 +68,7 @@ model achievement_template {
 
 model user_achievement {
   id          Int                  @id @default(autoincrement())
+  relation    String?
   // the id of the relating achievement_template
   templateId  Int
   template    achievement_template @relation(fields: [templateId], references: [id])
@@ -78,6 +79,7 @@ model user_achievement {
   // Streaks: we have to store the highest record for streaks
   recordValue Int?
   context     Json                 @db.Json
+  @@unique([relation, userId, templateId], name: "unique_user_achievement")
 }
 
 // Save (tracked) event as raw data in DB and evaluate at runtime


### PR DESCRIPTION
We identify user achievements by the templateID, userID, and relation. Previously, the relation was embedded within the JSON context, making it difficult to use or query. This PR moves the relation to a dedicated field in the user achievement table, allowing for easier querying and the creation of a unique index. This ensures we avoid accidentally creating multiple achievements for the same template and relation.

It should prevent issues like this from our UAT tests, where we've created multiple achievements of the same template for the same user and relation.

<img width="715" alt="image" src="https://github.com/corona-school/backend/assets/9447057/c18477ea-538c-4891-a816-7f921ea7798d">
