### PR TITLE
feat: filter out deactivated chats from the cronjob

### DIFF
--- a/common/chat/conversation.ts
+++ b/common/chat/conversation.ts
@@ -95,7 +95,7 @@ async function* getAllConversations(onlyActive?: boolean): AsyncIterable<TJConve
     assert(TALKJS_SECRET_KEY, `No TalkJS secret key found to get all conversations.`);
     assureChatFeatureActive();
 
-    const filter = { custom: { finished: '!exists' } };
+    const filter = { custom: { finished: ['!oneOf', ['course_over', 'match_dissolved']] } };
 
     const encodedFilter = encodeURIComponent(JSON.stringify(filter));
 

--- a/common/chat/conversation.ts
+++ b/common/chat/conversation.ts
@@ -91,15 +91,21 @@ const getMatcheeConversation = async (matchees: { studentId: number; pupilId: nu
     return { conversation, conversationId };
 };
 
-async function* getAllConversations(): AsyncIterable<TJConversation> {
+async function* getAllConversations(onlyActive?: boolean): AsyncIterable<TJConversation> {
     assert(TALKJS_SECRET_KEY, `No TalkJS secret key found to get all conversations.`);
     assureChatFeatureActive();
+
+    const filter = { custom: { finished: '!exists' } };
+
+    const encodedFilter = encodeURIComponent(JSON.stringify(filter));
 
     let startingAfter: string = undefined;
 
     do {
         const LIMIT = 30;
-        let url = `${TALKJS_CONVERSATION_API_URL}?limit=${LIMIT}&orderBy=lastActivity&orderDirection=ASC`;
+        let url = onlyActive
+            ? `${TALKJS_CONVERSATION_API_URL}?filter=${encodedFilter}&limit=${LIMIT}&orderBy=lastActivity&orderDirection=ASC`
+            : `${TALKJS_CONVERSATION_API_URL}?limit=${LIMIT}&orderBy=lastActivity&orderDirection=ASC`;
         if (startingAfter) {
             url += `&startingAfter=${startingAfter}`;
         }

--- a/jobs/periodic/flag-old-conversations/index.ts
+++ b/jobs/periodic/flag-old-conversations/index.ts
@@ -8,7 +8,7 @@ const logger = getLogger('FlagOldConversationsAsRO');
 export default async function flagInactiveConversationsAsReadonly() {
     const conversationsToFlag: TJConversation[] = [];
 
-    for await (const conversation of getAllConversations()) {
+    for await (const conversation of getAllConversations(true)) {
         logger.info(`Checking conversation ${conversation.id}`, { conversation });
 
         if (isConversationReadOnly(conversation)) {


### PR DESCRIPTION
# Description
- Closes https://github.com/corona-school/project-user/issues/1093

Already deactivated chats should not be requested, so we added a filter to the talkjs request.

## ✅ What was done
- [x] add filter for deactivated chats 
- [x] reactivated chats have also a finished state...
 
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Tested on different browsers.