### PR TITLE
feat: Allow Pupils to have two matches

### DIFF
--- a/common/match/request.ts
+++ b/common/match/request.ts
@@ -11,8 +11,7 @@ const logger = getLogger('Match');
 
 const PUPIL_MAX_REQUESTS = 1;
 const STUDENT_MAX_REQUESTS = 3;
-const PUPIL_MAX_MATCHES = 1;
-const PUPIL_MAX_DISSOLVED_MATCHES = 5;
+const PUPIL_MAX_MATCHES = 2;
 
 type RequestBlockReasons = 'not-tutee' | 'not-tutor' | 'not-screened' | 'max-requests' | 'max-matches' | 'max-dissolved-matches';
 
@@ -31,18 +30,12 @@ export async function canPupilRequestMatch(pupil: Pupil): Promise<Decision<Reque
         return { allowed: true };
     }
 
-    const lastYear = new Date();
-    lastYear.setFullYear(lastYear.getFullYear() - 1);
-
     const activeMatchCount = await prisma.match.count({ where: { pupilId: pupil.id, dissolved: false } });
     if (pupil.openMatchRequestCount + activeMatchCount >= PUPIL_MAX_MATCHES) {
         return { allowed: false, reason: 'max-matches', limit: PUPIL_MAX_MATCHES };
     }
 
-    /* const dissolvedMatchCountLastYear = await prisma.match.count({ where: { pupilId: pupil.id, dissolved: true, createdAt: { gte: lastYear } } });
-    if (pupil.openMatchRequestCount + activeMatchCount + dissolvedMatchCountLastYear >= PUPIL_MAX_DISSOLVED_MATCHES) {
-        return { allowed: false, reason: 'max-dissolved-matches', limit: PUPIL_MAX_DISSOLVED_MATCHES };
-    } */
+    // previously we also had max-dissolved-matches - this was removed a long time ago
 
     return { allowed: true };
 }


### PR DESCRIPTION
If pupils have an active match, they can request another match (and need to be screened again etc.).

resolves https://github.com/corona-school/project-user/issues/1143