### PR TITLE
refactor: Track Appointment Meeting Join

### DIFF
--- a/common/appointment/tracking.ts
+++ b/common/appointment/tracking.ts
@@ -1,0 +1,44 @@
+import { lecture as Appointment } from '@prisma/client';
+import { User } from '../user';
+import { prisma } from '../prisma';
+import * as Notification from '../notification';
+import { getLogger } from '../logger/logger';
+
+const logger = getLogger('Appointment Tracking');
+
+// To track achievements we trigger actions whenever a user
+// joins an appointment meeting
+export async function trackUserJoinAppointmentMeeting(user: User, appointment: Appointment) {
+    if (appointment.subcourseId) {
+        const subcourse = await prisma.subcourse.findUniqueOrThrow({ where: { id: appointment.subcourseId }, include: { lecture: true } });
+        if (user.studentId) {
+            const lecturesCount = subcourse.lecture.reduce((acc, lecture) => acc + (lecture.isCanceled ? 0 : 1), 0);
+            await Notification.actionTaken(user, 'student_joined_subcourse_meeting', {
+                relation: `subcourse/${subcourse.id}`,
+                subcourseLecturesCount: lecturesCount.toString(),
+            });
+        } else if (user.pupilId) {
+            const lecturesCount = subcourse.lecture.reduce((acc, lecture) => acc + (lecture.declinedBy.includes(user.userID) ? 0 : 1), 0);
+            await Notification.actionTaken(user, 'pupil_joined_subcourse_meeting', {
+                relation: `subcourse/${subcourse.id}`,
+                subcourseLecturesCount: lecturesCount.toString(),
+            });
+        }
+
+        logger.info(`Tracked User(${user.userID}) joining Appointment(${appointment.id}) for Subcourse(${subcourse.id})`);
+    } else if (appointment.matchId) {
+        if (user.studentId) {
+            await Notification.actionTaken(user, 'student_joined_match_meeting', {
+                relation: `match/${appointment.matchId}`,
+            });
+        } else if (user.pupilId) {
+            await Notification.actionTaken(user, 'pupil_joined_match_meeting', {
+                relation: `match/${appointment.matchId}`,
+            });
+        }
+
+        logger.info(`Tracked User(${user.userID}) joining Appointment(${appointment.id}) for a Match(${appointment.matchId})`);
+    } else {
+        logger.info(`Did not track User(${user.userID}) joining Appointment(${appointment.id}) as it is neither associated to a subcourse or match`);
+    }
+}

--- a/graphql/appointment/mutations.ts
+++ b/graphql/appointment/mutations.ts
@@ -169,7 +169,7 @@ export class MutateAppointmentResolver {
     }
 
     @Mutation(() => Boolean)
-    @Authorized(Role.OWNER, Role.APPOINTMENT_PARTICIPANT)
+    @AuthorizedDeferred(Role.OWNER, Role.APPOINTMENT_PARTICIPANT)
     async appointmentTrackJoin(@Ctx() context: GraphQLContext, @Arg('appointmentId') appointmentId: number) {
         const appointment = await getLecture(appointmentId);
         await hasAccess(context, 'Lecture', appointment);

--- a/graphql/appointment/mutations.ts
+++ b/graphql/appointment/mutations.ts
@@ -22,6 +22,7 @@ import { updateAppointment } from '../../common/appointment/update';
 import { cancelAppointment } from '../../common/appointment/cancel';
 import { PrerequisiteError, RedundantError } from '../../common/util/error';
 import { GraphQLInt } from 'graphql';
+import { trackUserJoinAppointmentMeeting } from '../../common/appointment/tracking';
 
 const logger = getLogger('MutateAppointmentsResolver');
 
@@ -164,6 +165,17 @@ export class MutateAppointmentResolver {
     )
     async appointmentOverrideMeetingLink(@Arg('lectureWhere') lectureWhere: LectureWhereInput, @Arg('overrideLink') overrideLink: string) {
         await prisma.lecture.updateMany({ where: lectureWhere, data: { override_meeting_link: overrideLink.length === 0 ? null : overrideLink } });
+        return true;
+    }
+
+    @Mutation(() => Boolean)
+    @Authorized(Role.OWNER, Role.APPOINTMENT_PARTICIPANT)
+    async appointmentTrackJoin(@Ctx() context: GraphQLContext, @Arg('appointmentId') appointmentId: number) {
+        const appointment = await getLecture(appointmentId);
+        await hasAccess(context, 'Lecture', appointment);
+
+        await trackUserJoinAppointmentMeeting(context.user, appointment);
+
         return true;
     }
 }

--- a/graphql/match/mutations.ts
+++ b/graphql/match/mutations.ts
@@ -92,24 +92,4 @@ export class MutateMatchResolver {
         }
         throw new AuthenticationError(`User is not allowed to create ad-hoc meeting for match ${matchId}`);
     }
-
-    @Mutation((returns) => Boolean)
-    @AuthorizedDeferred(Role.ADMIN, Role.OWNER)
-    async matchMeetingJoin(@Ctx() context: GraphQLContext, @Arg('matchId') matchId: number) {
-        const { user } = context;
-        const match = await prisma.match.findUnique({ where: { id: matchId }, include: { pupil: true, student: true } });
-        await hasAccess(context, 'Match', match);
-
-        if (user.studentId) {
-            await Notification.actionTaken(user, 'student_joined_match_meeting', {
-                relation: `match/${matchId}`,
-            });
-        } else if (user.pupilId) {
-            await Notification.actionTaken(user, 'pupil_joined_match_meeting', {
-                relation: `match/${matchId}`,
-            });
-        }
-
-        return true;
-    }
 }

--- a/graphql/ownership.ts
+++ b/graphql/ownership.ts
@@ -32,9 +32,6 @@ export const isOwnedBy: { [Name in ResolverModelNames]?: (user: GraphQLUser, ent
         return !!instructor;
     },
     Lecture: async (user, lecture) => {
-        if (!user.studentId) {
-            return false;
-        }
         const isOrganizer = (await prisma.lecture.count({ where: { id: lecture.id, organizerIds: { has: user.userID } } })) > 0;
         return isOrganizer;
     },

--- a/graphql/subcourse/mutations.ts
+++ b/graphql/subcourse/mutations.ts
@@ -385,28 +385,4 @@ export class MutateSubcourseResolver {
         logger.info(`Subcourse(${subcourseId}) was manually promoted by instructor(${context.user.userID})`);
         return true;
     }
-
-    @Mutation((returns) => Boolean)
-    @AuthorizedDeferred(Role.ADMIN, Role.OWNER)
-    async subcourseMeetingJoin(@Ctx() context: GraphQLContext, @Arg('subcourseId') subcourseId: number) {
-        const { user } = context;
-        const subcourse = await prisma.subcourse.findUniqueOrThrow({ where: { id: subcourseId }, include: { course: true, lecture: true } });
-        await hasAccess(context, 'Subcourse', subcourse);
-
-        if (user.studentId) {
-            const lecturesCount = subcourse.lecture.reduce((acc, lecture) => acc + (lecture.isCanceled ? 0 : 1), 0);
-            await Notification.actionTaken(user, 'student_joined_subcourse_meeting', {
-                relation: `subcourse/${subcourseId}`,
-                subcourseLecturesCount: lecturesCount.toString(),
-            });
-        } else if (user.pupilId) {
-            const lecturesCount = subcourse.lecture.reduce((acc, lecture) => acc + (lecture.declinedBy.includes(user.userID) ? 0 : 1), 0);
-            await Notification.actionTaken(user, 'pupil_joined_subcourse_meeting', {
-                relation: `subcourse/${subcourseId}`,
-                subcourseLecturesCount: lecturesCount.toString(),
-            });
-        }
-
-        return true;
-    }
 }


### PR DESCRIPTION
We tried to abstract away courses and matches with "appointments", so in my eyes it does not make sense to now introduce "match meetings" and "course meetings" if we can also just have "appointment meetings". Also in the future we could do plausibility checks. 

This also removes the need to pass around subcourseId and matchId everywhere in https://github.com/corona-school/user-app/pull/420