### PR TITLE
HOTFIX: Meetings with neither Zoom nor alternative meeting Link

### DIFF
--- a/common/appointment/create.ts
+++ b/common/appointment/create.ts
@@ -62,7 +62,7 @@ export const createMatchAppointments = async (matchId: number, appointmentsToBeC
 
     // we don't want to create a Zoom meeting if there's an override_meeting_link specified in the last appointment
     let hosts: ZoomUser[] | null = null;
-    if (isZoomFeatureActive() && lastAppointment?.override_meeting_link == null && !appointmentsToBeCreated[0].meetingLink) {
+    if (isZoomFeatureActive() && !lastAppointment?.override_meeting_link && !appointmentsToBeCreated[0].meetingLink) {
         hosts = await hostsForStudents([student]);
     }
 
@@ -148,7 +148,7 @@ export const createGroupAppointments = async (subcourseId: number, appointmentsT
                     organizerIds: instructors.map((i) => userForStudent(i.student).userID),
                     participantIds: participants.map((p) => userForPupil(p.pupil).userID),
                     zoomMeetingId,
-                    override_meeting_link: appointmentToBeCreated.meetingLink ?? lastAppointment?.override_meeting_link,
+                    override_meeting_link: (appointmentToBeCreated.meetingLink ?? lastAppointment?.override_meeting_link) || null,
                 },
             });
         })

--- a/graphql/appointment/fields.ts
+++ b/graphql/appointment/fields.ts
@@ -179,7 +179,7 @@ export class ExtendedFieldsLectureResolver {
         const isAdmin = user.roles.includes(Role.ADMIN);
 
         if (!appointment.zoomMeetingId) {
-            logger.error(`No zoom meeting id exist for appointment id ${appointment.id}`);
+            logger.info(`No zoom meeting id exist for appointment id ${appointment.id}`);
             return null;
         }
 


### PR DESCRIPTION
For some reason the UserApp passes in an empty string for the nullable meetingLink, as such no Zoom Meeting is created any longer for followup appointments, and users cannot join the meeting anymore.

So far affected 33 Meetings in the last 4 days

https://github.com/corona-school/project-user/issues/1150