### PR TITLE
fix: Prohibit mails to unverified accounts, exclude unverified pupils from course promotions

### DIFF
--- a/common/courses/notifications.ts
+++ b/common/courses/notifications.ts
@@ -112,7 +112,13 @@ export async function sendPupilCoursePromotion(subcourse: Prisma.subcourse, coun
     }
 
     const pupils = await prisma.pupil.findMany({
-        where: { active: true, isParticipant: true, grade: { in: grades }, subcourse_participants_pupil: { none: { subcourseId: subcourse.id } } },
+        where: {
+            active: true,
+            verification: null,
+            isParticipant: true,
+            grade: { in: grades },
+            subcourse_participants_pupil: { none: { subcourseId: subcourse.id } },
+        },
     });
 
     const courseSubject = course.subject;

--- a/common/notification/index.ts
+++ b/common/notification/index.ts
@@ -467,8 +467,24 @@ export async function _actionTakenAt<ID extends ActionID>(
         return;
     }
 
+    // Prevent that we accidentally contact inactive or unverified accounts
+    // DO NOT TOUCH THIS! We are legally required to not send emails to deactivated accounts!
+
     if (!user.active) {
         logger.debug(`No action '${actionId}' taken for User(${user.userID}) as the account is deactivated`);
+        return;
+    }
+
+    const userData = await queryUser(user, { createdAt: true, verification: true, verifiedAt: true });
+    // During the registration process, users might get emails before they are verified
+    // We generally allow this for 30 days, but then require verification at some point
+    const oldAccount = +userData.createdAt < +Date.now() - 30 * 24 * HOURS_TO_MS;
+    // Some actions are always allowed to trigger notifications, so that users can recover their account even after 30 days:
+    const isAlwaysAllowed = actionId === 'user-authenticate' || actionId === 'user-password-reset' || actionId === 'user-verify-email';
+
+    // NOTE: Due to historic reasons, there are users with both unset verifiedAt and verification
+    if (!isAlwaysAllowed && oldAccount && !userData.verifiedAt && userData.verification) {
+        logger.error(`Tried to trigger action '${actionId}' for unverified User(${user.userID}) who is unverified for more than 30 days`);
         return;
     }
 

--- a/graphql/concrete_notification/mutations.ts
+++ b/graphql/concrete_notification/mutations.ts
@@ -98,7 +98,7 @@ export class MutateConcreteNotificationsResolver {
         return true;
     }
 
-    @Mutation((returns) => GraphQLJSON)
+    @Mutation((returns) => GraphQLJSON, { nullable: true })
     @Authorized(Role.ADMIN)
     @Deprecated('TEST ONLY, DO NOT USE!')
     async _actionTakenAt(

--- a/integration-tests/01_user.ts
+++ b/integration-tests/01_user.ts
@@ -9,7 +9,7 @@ const setup = test('Setup Configuration', async () => {
     await adminClient.request(`mutation ResetRateLimits { _resetRateLimits }`);
 });
 
-const createMockVerification = test('Create Mock Email Verify Notification', async () => {
+export const createMockVerification = test('Create Mock Email Verify Notification', async () => {
     await setup;
     return await createMockNotification('user-verify-email', 'UserVerifyEmailNotification');
 });

--- a/integration-tests/13_deactivation.ts
+++ b/integration-tests/13_deactivation.ts
@@ -1,14 +1,15 @@
 import { pupilOneWithPassword } from './05_auth';
 import { test } from './base';
-import { createNewPupil, createNewStudent, createInactivityMockNotification } from './01_user';
-import { adminClient } from './base/clients';
+import { createNewPupil, createNewStudent, createInactivityMockNotification, createMockVerification } from './01_user';
+import { adminClient, createUserClient } from './base/clients';
 import { prisma } from '../common/prisma';
 import { DEACTIVATE_ACCOUNTS_INACTIVITY_DAYS, deactivateInactiveAccounts } from '../jobs/periodic/redact-inactive-accounts/deactivate-inactive-accounts';
 import { sendInactivityNotification, NOTIFY_AFTER_DAYS } from '../jobs/periodic/redact-inactive-accounts/send-inactivity-notification';
 import moment from 'moment';
 import assert from 'assert';
-import { cleanupMockedNotifications, createMockNotification } from './base/notifications';
+import { assertUserReceivedNotification, cleanupMockedNotifications, createMockNotification } from './base/notifications';
 import { expectFetch } from './base/mock';
+import { randomBytes } from 'crypto';
 
 void test('Pupil Account Deactivation', async () => {
     const { client, pupil, password } = await pupilOneWithPassword;
@@ -259,4 +260,94 @@ void test('User should not receive notifications after deactivation', async () =
         },
     });
     assert.strictEqual(sentNotificationsAfter, 1);
+});
+
+void test('User should not receive notifications after being unverified for 30 days', async () => {
+    const client = createUserClient();
+    const userRandom = randomBytes(5).toString('base64');
+
+    await client.request(`
+        mutation RegisterStudent {
+            meRegisterStudent(data: {
+                firstname: "firstname:${userRandom}"
+                lastname: "lastname:${userRandom}"
+                email: "test+${userRandom}@lern-fair.de"
+                newsletter: false
+                registrationSource: normal
+            }) {
+                id
+            }
+        }
+    `);
+
+    const { me: student } = await client.request(`
+        query GetBasics {
+            me {
+                userID
+                firstname
+                lastname
+                email
+                student { id }
+            }
+            myRoles
+        }
+    `);
+
+    // Directly after Registration the user gets notifications
+
+    const mockNotification = await createMockNotification('TEST2', 'Instant');
+
+    await adminClient.request(`mutation TriggerAction {
+        _actionTakenAt(action: "TEST2", at: "${new Date().toISOString()}" context: { a: "a" } dryRun: false, userID: "${student.userID}")
+    }`);
+
+    const sentNotificationsBefore = await prisma.concrete_notification.count({
+        where: {
+            notificationID: mockNotification.id,
+            userId: student.userID,
+        },
+    });
+    assert.strictEqual(sentNotificationsBefore, 1);
+
+    // if the account is 30 days old, no notification is sent
+    await prisma.student.update({
+        where: { id: student.student.id },
+        data: { createdAt: new Date(Date.now() - 31 * 24 * 60 * 60 * 1000) },
+    });
+
+    await adminClient.request(`mutation TriggerAction {
+        _actionTakenAt(action: "TEST2", at: "${new Date().toISOString()}" context: { a: "a" } dryRun: false, userID: "${student.userID}")
+    }`);
+
+    const sentNotificationsAfter = await prisma.concrete_notification.count({
+        where: {
+            notificationID: mockNotification.id,
+            userId: student.userID,
+        },
+    });
+    assert.strictEqual(sentNotificationsAfter, 1);
+
+    // And if the user then verifies their account, they get notifications again
+
+    await client.request(`mutation RequestVerifyToken { tokenRequest(email: "TEST+${userRandom}@lern-fair.de", action: "user-verify-email")}`);
+
+    const mockEmailVerification = await createMockVerification;
+    const {
+        context: { token },
+    } = await assertUserReceivedNotification(mockEmailVerification, `student/${student.student.id}`);
+    assert(token, 'User received email verification token');
+
+    await client.request(`mutation LoginForEmailVerify { loginToken(token: "${token}")}`);
+
+    await adminClient.request(`mutation TriggerAction {
+        _actionTakenAt(action: "TEST2", at: "${new Date().toISOString()}" context: { a: "a" } dryRun: false, userID: "${student.userID}")
+    }`);
+
+    const sentNotificationsAfterVerification = await prisma.concrete_notification.count({
+        where: {
+            notificationID: mockNotification.id,
+            userId: student.userID,
+        },
+    });
+    assert.strictEqual(sentNotificationsAfterVerification, 2);
 });


### PR DESCRIPTION
For sure we need to allow certain mails be sent to unverified accounts, especially the mail to verify the account :) 
Also we already start sending some mails directly after the registration, I guess we might want to send them even if the account was not yet verified. Thus this introduces a grace period of 30 days where an unverified account can still get notifications, afterwards we do not send notifications anymore. Also exclude verification & password reset, just in case someone wants to regain access after these 30 days.