### PR TITLE
feat: Defer course appointment reminders to publish, also schedule Reminders when joining a course, properly cancel them

### DIFF
--- a/common/appointment/cancel.ts
+++ b/common/appointment/cancel.ts
@@ -55,11 +55,13 @@ export async function cancelAppointment(user: User, appointment: Appointment, si
                     });
                     await Notification.actionTaken(userForPupil(participant.pupil), 'cancel_group_appointment_reminder', {
                         appointment: getAppointmentForNotification(appointment),
+                        uniqueId: appointment.id.toString(),
                     });
                 }
                 for (const instructor of instructors) {
                     await Notification.actionTaken(userForStudent(instructor.student), 'cancel_group_appointment_reminder', {
                         appointment: getAppointmentForNotification(appointment),
+                        uniqueId: appointment.id.toString(),
                     });
                 }
                 break;
@@ -72,9 +74,11 @@ export async function cancelAppointment(user: User, appointment: Appointment, si
                 });
                 await Notification.actionTaken(userForPupil(match.pupil), 'cancel_match_appointment_reminder', {
                     appointment: getAppointmentForNotification(appointment),
+                    uniqueId: appointment.id.toString(),
                 });
                 await Notification.actionTaken(userForStudent(match.student), 'cancel_match_appointment_reminder', {
                     appointment: getAppointmentForNotification(appointment),
+                    uniqueId: appointment.id.toString(),
                 });
 
                 break;

--- a/common/appointment/create.ts
+++ b/common/appointment/create.ts
@@ -163,10 +163,12 @@ export const createGroupAppointments = async (subcourseId: number, appointmentsT
 
         // Send out reminders 12 hours before the appointment start
         for (const appointment of createdGroupAppointments) {
-            await Notification.actionTakenAt(new Date(appointment.start), userForPupil(participant.pupil), 'pupil_group_appointment_starts', {
-                ...(await getContextForGroupAppointmentReminder(appointment, subcourse, subcourse.course)),
-                student: organizer,
-            });
+            await Notification.actionTakenAt(
+                new Date(appointment.start),
+                userForPupil(participant.pupil),
+                'pupil_group_appointment_starts',
+                await getContextForGroupAppointmentReminder(appointment, subcourse, subcourse.course)
+            );
         }
     }
 
@@ -174,10 +176,12 @@ export const createGroupAppointments = async (subcourseId: number, appointmentsT
         for (const appointment of createdGroupAppointments) {
             if (subcourse.published) {
                 // For unpublished courses, this is deferred to a later point
-                await Notification.actionTakenAt(new Date(appointment.start), userForStudent(instructor.student), 'student_group_appointment_starts', {
-                    ...(await getContextForGroupAppointmentReminder(appointment, subcourse, subcourse.course)),
-                    student: organizer,
-                });
+                await Notification.actionTakenAt(
+                    new Date(appointment.start),
+                    userForStudent(instructor.student),
+                    'student_group_appointment_starts',
+                    await getContextForGroupAppointmentReminder(appointment, subcourse, subcourse.course)
+                );
             }
         }
     }

--- a/common/appointment/create.ts
+++ b/common/appointment/create.ts
@@ -172,10 +172,13 @@ export const createGroupAppointments = async (subcourseId: number, appointmentsT
 
     for (const instructor of instructors) {
         for (const appointment of createdGroupAppointments) {
-            await Notification.actionTakenAt(new Date(appointment.start), userForStudent(instructor.student), 'student_group_appointment_starts', {
-                ...(await getContextForGroupAppointmentReminder(appointment, subcourse, subcourse.course)),
-                student: organizer,
-            });
+            if (subcourse.published) {
+                // For unpublished courses, this is deferred to a later point
+                await Notification.actionTakenAt(new Date(appointment.start), userForStudent(instructor.student), 'student_group_appointment_starts', {
+                    ...(await getContextForGroupAppointmentReminder(appointment, subcourse, subcourse.course)),
+                    student: organizer,
+                });
+            }
         }
     }
 

--- a/common/appointment/update.ts
+++ b/common/appointment/update.ts
@@ -58,10 +58,12 @@ export async function updateAppointment(
                     appointment: getAppointmentForNotification(updatedAppointment, /* original: */ appointment),
                     ...(await getNotificationContextForSubcourse(subcourse.course, subcourse)),
                 });
-                await Notification.actionTakenAt(new Date(updatedAppointment.start), userForPupil(participant.pupil), 'pupil_group_appointment_starts', {
-                    ...(await getContextForGroupAppointmentReminder(updatedAppointment, subcourse, subcourse.course, /* original: */ appointment)),
-                    student,
-                });
+                await Notification.actionTakenAt(
+                    new Date(updatedAppointment.start),
+                    userForPupil(participant.pupil),
+                    'pupil_group_appointment_starts',
+                    await getContextForGroupAppointmentReminder(updatedAppointment, subcourse, subcourse.course, /* original: */ appointment)
+                );
             }
 
             for (const instructor of instructors) {
@@ -71,10 +73,7 @@ export async function updateAppointment(
                         new Date(updatedAppointment.start),
                         userForStudent(instructor.student),
                         'student_group_appointment_starts',
-                        {
-                            ...(await getContextForGroupAppointmentReminder(updatedAppointment, subcourse, subcourse.course, /* original: */ appointment)),
-                            student,
-                        }
+                        await getContextForGroupAppointmentReminder(updatedAppointment, subcourse, subcourse.course, /* original: */ appointment)
                     );
                 }
             }

--- a/common/appointment/update.ts
+++ b/common/appointment/update.ts
@@ -65,10 +65,18 @@ export async function updateAppointment(
             }
 
             for (const instructor of instructors) {
-                await Notification.actionTakenAt(new Date(updatedAppointment.start), userForStudent(instructor.student), 'student_group_appointment_starts', {
-                    ...(await getContextForGroupAppointmentReminder(updatedAppointment, subcourse, subcourse.course, /* original: */ appointment)),
-                    student,
-                });
+                if (subcourse.published) {
+                    // For unpublished courses, this is deferred to a later point
+                    await Notification.actionTakenAt(
+                        new Date(updatedAppointment.start),
+                        userForStudent(instructor.student),
+                        'student_group_appointment_starts',
+                        {
+                            ...(await getContextForGroupAppointmentReminder(updatedAppointment, subcourse, subcourse.course, /* original: */ appointment)),
+                            student,
+                        }
+                    );
+                }
             }
             break;
         }

--- a/common/courses/participants.ts
+++ b/common/courses/participants.ts
@@ -228,12 +228,6 @@ export async function joinSubcourse(subcourse: Subcourse, pupil: Pupil, strict: 
         logger.info(`Pupil(${pupil.id}) joined Subcourse(${subcourse.id}`);
         await logTransaction('participantJoinedCourse', pupil, { subcourseID: subcourse.id });
 
-        const firstLecture = await prisma.lecture.findMany({
-            where: { subcourseId: subcourse.id },
-            orderBy: { start: 'asc' },
-            take: 1,
-        });
-
         await addGroupAppointmentsParticipant(subcourse.id, pupilUser.userID);
         if (isChatFeatureActive() && subcourse.conversationId) {
             await addParticipant(pupilUser, subcourse.conversationId, subcourse.groupChatType as ChatType);
@@ -241,8 +235,6 @@ export async function joinSubcourse(subcourse: Subcourse, pupil: Pupil, strict: 
 
         try {
             const course = await getCourseOfSubcourse(subcourse);
-            const courseStart = moment(firstLecture[0].start);
-            const authToken = await createSecretEmailToken(userForPupil(pupil), undefined, moment().add(7, 'days'));
 
             const context = await getNotificationContextForSubcourse(course, subcourse);
             if (leftWaitingList) {

--- a/common/courses/states.ts
+++ b/common/courses/states.ts
@@ -136,10 +136,12 @@ export async function publishSubcourse(subcourse: Prisma.subcourseGetPayload<{ i
 
     for (const { student: instructor } of subcourse.subcourse_instructors_student) {
         for (const appointment of subcourseAppointments) {
-            await Notification.actionTakenAt(new Date(appointment.start), userForStudent(instructor), 'student_group_appointment_starts', {
-                ...(await getContextForGroupAppointmentReminder(appointment, subcourse, course)),
-                student: instructor,
-            });
+            await Notification.actionTakenAt(
+                new Date(appointment.start),
+                userForStudent(instructor),
+                'student_group_appointment_starts',
+                await getContextForGroupAppointmentReminder(appointment, subcourse, course)
+            );
         }
     }
 }

--- a/common/courses/states.ts
+++ b/common/courses/states.ts
@@ -23,6 +23,7 @@ import { addGroupAppointmentsOrganizer } from '../appointment/participants';
 import { sendPupilCoursePromotion, sendSubcourseCancelNotifications } from './notifications';
 import * as Notification from '../../common/notification';
 import { deleteAchievementsForSubcourse } from '../../common/achievement/delete';
+import { getContextForGroupAppointmentReminder } from '../appointment/util';
 
 const logger = getLogger('Course States');
 
@@ -130,6 +131,17 @@ export async function publishSubcourse(subcourse: Prisma.subcourseGetPayload<{ i
             })
         )
     );
+
+    const subcourseAppointments = await prisma.lecture.findMany({ where: { isCanceled: false, subcourseId: subcourse.id } });
+
+    for (const { student: instructor } of subcourse.subcourse_instructors_student) {
+        for (const appointment of subcourseAppointments) {
+            await Notification.actionTakenAt(new Date(appointment.start), userForStudent(instructor), 'student_group_appointment_starts', {
+                ...(await getContextForGroupAppointmentReminder(appointment, subcourse, course)),
+                student: instructor,
+            });
+        }
+    }
 }
 
 /* ---------------- Subcourse Cancel ------------ */

--- a/common/notification/actions.ts
+++ b/common/notification/actions.ts
@@ -580,37 +580,49 @@ const _notificationActions = {
     },
     pupil_match_appointment_starts: {
         description: 'Remind pupil of upcoming match appointment',
-        sampleContext: { appointment: sampleAppointment, matchId: '1', student: { firstname: 'Student' } },
+        sampleContext: {
+            uniqueId: 'REQUIRED',
+            appointment: sampleAppointment,
+            matchId: '1',
+            student: { firstname: 'Student' },
+        },
     },
     student_match_appointment_starts: {
         description: 'Remind student of upcoming match appointment',
-        sampleContext: { appointment: sampleAppointment, matchId: '1', pupil: { firstname: 'Pupil' } },
+        sampleContext: {
+            uniqueId: 'REQUIRED',
+            appointment: sampleAppointment,
+            matchId: '1',
+            pupil: { firstname: 'Pupil' },
+        },
     },
     pupil_group_appointment_starts: {
         description: 'Remind pupil of upcoming group appointment',
         sampleContext: {
+            uniqueId: 'REQUIRED',
             appointment: sampleAppointment,
-            student: { firstname: 'Student' },
             ...sampleCourse,
         },
     },
     student_group_appointment_starts: {
         description: 'Remind student of upcoming group appointment',
         sampleContext: {
+            uniqueId: 'REQUIRED',
             appointment: sampleAppointment,
-            student: { firstname: 'Student' },
             ...sampleCourse,
         },
     },
     cancel_group_appointment_reminder: {
         description: 'Cancel / group appointment reminder',
         sampleContext: {
+            uniqueId: 'REQUIRED',
             appointment: sampleAppointment,
         },
     },
     cancel_match_appointment_reminder: {
         description: 'Cancel / match appointment reminder',
         sampleContext: {
+            uniqueId: 'REQUIRED',
             appointment: sampleAppointment,
         },
     },

--- a/common/notification/actions.ts
+++ b/common/notification/actions.ts
@@ -504,21 +504,14 @@ const _notificationActions = {
         },
     },
     student_add_appointment_group: {
-        description: 'Student / Group Appointment Added',
-        sampleContext: {
-            student: sampleUser,
-            ...sampleCourse,
-        },
-    },
-    student_add_appointments_group: {
-        description: 'Student / Group Appointments Added',
+        description: 'Participant / Instructor added Group Appointment',
         sampleContext: {
             student: sampleUser,
             ...sampleCourse,
         },
     },
     student_add_appointment_match: {
-        description: 'Student / Match Appointment Added',
+        description: 'Tutee / Tutor added Match Appointment',
         sampleContext: {
             student: sampleUser,
             matchId: '1',
@@ -540,7 +533,7 @@ const _notificationActions = {
         },
     },
     student_cancel_appointment_group: {
-        description: 'Student / Group Appointment Cancelled',
+        description: 'Participant / Group Appointment Cancelled by Instructor',
         sampleContext: {
             appointment: sampleAppointment,
             student: sampleUser,


### PR DESCRIPTION
- Appointment reminders for courses are scheduled when the course is published. Thus instructors do not get reminders for unpublished courses
- Also schedule reminders when a participant or instructor joins a course, and cancel them when they leave it
- Properly only cancel the reminders belonging to a single appointment, previously it would just cancel all reminders for all appointments