### PR TITLE
fix: streak overview

### DIFF
--- a/common/achievement/util.ts
+++ b/common/achievement/util.ts
@@ -136,7 +136,7 @@ export function removeBucketsAfter(ts: Date, bucketEvents: BucketEvents[], keepB
         if (keepBucketsWithEvents && bucket.events.length > 0) {
             return true;
         }
-        return bucket.startTime <= ts;
+        return bucket.endTime <= ts;
     });
 }
 


### PR DESCRIPTION
Future buckets should only be taken into account if the end time is in the past. Otherwise, streaks might be invalidated even tho the user could still take an action to continue the streak.