### PR TITLE
refactor: achievement evaluation

### DIFF
--- a/common/achievement/evaluate.spec.ts
+++ b/common/achievement/evaluate.spec.ts
@@ -1,7 +1,7 @@
 import moment from 'moment-timezone';
-import { achievement_event, achievement_template_for_enum, lecture, match, subcourse } from '@prisma/client';
+import { achievement_event, lecture, match, subcourse } from '@prisma/client';
 import { prismaMock } from '../../jest/singletons';
-import { evaluateAchievement } from './evaluate';
+import { exportedForTesting } from './evaluate';
 import { ConditionDataAggregations } from './types';
 import { Prisma } from '@prisma/client';
 
@@ -39,7 +39,7 @@ describe('evaluate should throw errors for misconfiguration', () => {
         prismaMock.match.findMany.mockResolvedValue([]);
         prismaMock.subcourse.findMany.mockResolvedValue([]);
 
-        await expect(evaluateAchievement('student/1', 'x > 0', dataAggr, 0, undefined)).resolves.toBeUndefined();
+        await expect(exportedForTesting.evaluateAchievement('student/1', 'x > 0', dataAggr, 0, undefined)).rejects.toThrow();
     });
 });
 
@@ -86,7 +86,7 @@ describe('evaluate condition without default bucket aggregator', () => {
         prismaMock.match.findMany.mockResolvedValue([]);
         prismaMock.subcourse.findMany.mockResolvedValue([]);
 
-        const res = await evaluateAchievement(userId, condition, dataAggr, 0, undefined);
+        const res = await exportedForTesting.evaluateAchievement(userId, condition, dataAggr, 0, undefined);
 
         expect(res).toBeDefined();
         expect(res?.conditionIsMet).toBe(expectedResult);
@@ -210,7 +210,7 @@ describe('evaluate record value condition with time buckets', () => {
         prismaMock.match.findMany.mockResolvedValue(matches || []);
         prismaMock.subcourse.findMany.mockResolvedValue(subcourses || []);
 
-        const res = await evaluateAchievement(testUserId, condition, dataAggr, recordValue, undefined);
+        const res = await exportedForTesting.evaluateAchievement(testUserId, condition, dataAggr, recordValue, undefined);
 
         expect(res).toBeDefined();
         expect(res?.conditionIsMet).toBe(expectNewRecord);
@@ -397,7 +397,7 @@ describe('evaluate bucket with match / subcourse context', () => {
         prismaMock.match.findMany.mockResolvedValue(matches || []);
         prismaMock.subcourse.findMany.mockResolvedValue(subcourses || []);
 
-        const res = await evaluateAchievement(testUserId, condition, dataAggr, 0, undefined);
+        const res = await exportedForTesting.evaluateAchievement(testUserId, condition, dataAggr, 0, undefined);
 
         expect(res).toBeDefined();
         expect(res?.conditionIsMet).toBe(expectNewRecord);

--- a/common/achievement/get.ts
+++ b/common/achievement/get.ts
@@ -5,7 +5,10 @@ import { AchievementState, AchievementType, PublicAchievement, PublicStep } from
 import { getAchievementState, renderAchievementWithContext, transformPrismaJson } from './util';
 import { getAchievementImageURL } from './util';
 import { isDefined } from './util';
-import { isAchievementConditionMet } from '.';
+import { isAchievementConditionMet } from './evaluate';
+import { getLogger } from '../logger/logger';
+
+const logger = getLogger('Achievement');
 
 export async function getUserAchievementsWithTemplates(user: User) {
     const userAchievementsWithTemplates = await prisma.user_achievement.findMany({
@@ -156,36 +159,37 @@ const assembleAchievementData = async (userAchievements: achievements_with_templ
 
     let maxValue: number = achievementTemplates.length;
     let currentValue: number = currentAchievementIndex;
-    if (
-        userAchievements[currentAchievementIndex].template.type === AchievementType.STREAK ||
-        userAchievements[currentAchievementIndex].template.type === AchievementType.TIERED
-    ) {
-        const dataAggregationKeys = Object.keys(userAchievements[currentAchievementIndex].template.conditionDataAggregations as Prisma.JsonObject);
+    if (userAchievements[currentAchievementIndex].template.type === AchievementType.STREAK) {
         const evaluationResult = await isAchievementConditionMet(userAchievements[currentAchievementIndex]);
-        if (evaluationResult) {
-            currentValue = dataAggregationKeys.map((key) => evaluationResult.resultObject[key]).reduce((a, b) => a + b, 0);
-            maxValue =
-                userAchievements[currentAchievementIndex].template.type === AchievementType.STREAK
-                    ? userAchievements[currentAchievementIndex].recordValue !== null && userAchievements[currentAchievementIndex].recordValue > currentValue
-                        ? userAchievements[currentAchievementIndex].recordValue
-                        : currentValue
-                    : dataAggregationKeys
-                          .map((key) => {
-                              // TODO: check if we can remove valueToAchieve
-                              return Number((userAchievements[currentAchievementIndex].template.conditionDataAggregations as any)[key].valueToAchieve || 0);
-                          })
-                          .reduce((a, b) => a + b, 0);
-            if (
-                userAchievements[currentAchievementIndex].template.type === AchievementType.STREAK &&
-                currentValue < maxValue &&
-                userAchievements[currentAchievementIndex].achievedAt
-            ) {
-                await prisma.user_achievement.update({
-                    where: { id: userAchievements[currentAchievementIndex].id },
-                    data: { achievedAt: null, isSeen: false },
-                });
-            }
+        currentValue = evaluationResult.aggregationResult;
+        maxValue = userAchievements[currentAchievementIndex].recordValue;
+
+        // Streaks are usually invalidated if a user does not show up for a certain meeting / course / etc.
+        // This means we don't have an event to reevaluate the streak naturally.
+        // There are two ways to solve this:
+        // 1. We could reevaluate the streak every time the user opens the app.
+        // 2. We could create a cronjob that reevaluates all streaks every now and then.
+        // As the cron would be more complex and less efficient, we chose the first option, which is implemented here:
+        if (evaluationResult.shouldInvalidateStreak) {
+            logger.info('Streak will be invalidated', {
+                userId: user.userID,
+                achievementId: userAchievements[currentAchievementIndex].id,
+                currentValue,
+                maxValue,
+            });
+            await prisma.user_achievement.update({
+                where: { id: userAchievements[currentAchievementIndex].id },
+                data: { achievedAt: null, isSeen: false },
+            });
         }
+    }
+    if (userAchievements[currentAchievementIndex].template.type === AchievementType.TIERED) {
+        const evaluationResult = await isAchievementConditionMet(userAchievements[currentAchievementIndex]);
+        const {
+            template: { conditionDataAggregations },
+        } = userAchievements[currentAchievementIndex];
+        currentValue = evaluationResult.aggregationResult;
+        maxValue = Object.keys(conditionDataAggregations).reduce((acc, key) => acc + conditionDataAggregations[key].valueToAchieve, 0);
     }
 
     const state: AchievementState = getAchievementState(userAchievements, currentAchievementIndex);

--- a/integration-tests/15_achievements.ts
+++ b/integration-tests/15_achievements.ts
@@ -269,18 +269,6 @@ void test('Reward student regular learning', async () => {
     assert.notStrictEqual(achievement, null);
     assert.strictEqual(achievement!.recordValue, 1);
 
-    const date = new Date();
-    date.setDate(date.getDate() - 7);
-    await prisma.achievement_event.create({
-        data: {
-            userId: student.userID,
-            metric: metric,
-            value: 1,
-            createdAt: date,
-            action: 'student_joined_match_meeting',
-            relation: 'match/' + match.id,
-        },
-    });
     // request to set the achievements record value to 2 due to the past event generated
     await client.request(`
         mutation StudentJoinMatchMeeting { appointmentTrackJoin(appointmentId:${appointments[0].id}) }
@@ -301,7 +289,6 @@ void test('Reward student regular learning', async () => {
         where: {
             userId: student.userID,
             metric: metric,
-            relation: `match/${match.id}`,
         },
     });
 
@@ -360,18 +347,6 @@ void test('Reward pupil regular learning', async () => {
     assert.notStrictEqual(achievement, null);
     assert.strictEqual(achievement.recordValue, 1);
 
-    const date = new Date();
-    date.setDate(date.getDate() - 7);
-    await prisma.achievement_event.create({
-        data: {
-            userId: pupil.userID,
-            metric: metric,
-            value: 1,
-            createdAt: date,
-            action: 'pupil_joined_match_meeting',
-            relation: 'match/' + match.id,
-        },
-    });
     // request to set the achievements record value to 2 due to the past event generated
     await client.request(`
         mutation PupilJoinMatchMeeting { appointmentTrackJoin(appointmentId:${appointments[0].id}) }
@@ -380,7 +355,7 @@ void test('Reward pupil regular learning', async () => {
     await prisma.achievement_event.deleteMany({
         where: {
             userId: pupil.userID,
-            metric: 'pupil_match_regular_learning',
+            metric: 'pupil_match_learned_regular',
         },
     });
     await client.request(`


### PR DESCRIPTION
Right now, streaks will be reset to not achieved even tho the evaluation result equals to the record value. (Which is expected in many cases).

So this PR, ensures that we only reset the streak if the evaluation result < record value.