### PR TITLE
feat: Report match

### DIFF
--- a/common/notification/channels/mailjet.ts
+++ b/common/notification/channels/mailjet.ts
@@ -99,7 +99,7 @@ async function sendMessage(message: SendParamsMessage) {
     let sandboxMode = false;
 
     if (process.env.MAILJET_LIVE === 'TEST') {
-        message.Subject = `TESTEMAIL`;
+        message.Subject = `(TESTEMAIL) ${message.Subject}`;
         logger.warn(`Mail is in Test Mode`);
     } else if (process.env.MAILJET_LIVE != '1') {
         logger.warn(`Mail is in Sandbox Mode`);


### PR DESCRIPTION
## Ticket

https://github.com/corona-school/project-user/issues/1132

## Frontend PR

https://github.com/corona-school/user-app/pull/504

## What was done?

- Added a new `matchReport` mutation that extracts all the needed information for the report from the given matchId. Then, it builds an email and sends it to the support team.
- Adjusted the test email mode to include the subject

I tested both flows and the final email will look something like this:

<img width="1266" alt="Bildschirmfoto 2024-03-20 um 10 47 02" src="https://github.com/corona-school/backend/assets/161815068/def0902f-ca51-4304-a469-9f4ac9682859">
