### PR TITLE
fix: Allow tutors to access zoomMeetingUrl field

### DIFF
--- a/graphql/appointment/fields.ts
+++ b/graphql/appointment/fields.ts
@@ -173,7 +173,7 @@ export class ExtendedFieldsLectureResolver {
         return await getZoomMeeting(appointment);
     }
     @FieldResolver((returns) => String, { nullable: true })
-    @Authorized(Role.ADMIN, Role.APPOINTMENT_PARTICIPANT, Role.INSTRUCTOR, Role.TUTOR)
+    @Authorized(Role.ADMIN, Role.APPOINTMENT_PARTICIPANT, Role.OWNER)
     async zoomMeetingUrl(@Ctx() context: GraphQLContext, @Root() appointment: Required<Appointment>) {
         const { user } = context;
         const isAdmin = user.roles.includes(Role.ADMIN);

--- a/graphql/appointment/fields.ts
+++ b/graphql/appointment/fields.ts
@@ -173,7 +173,7 @@ export class ExtendedFieldsLectureResolver {
         return await getZoomMeeting(appointment);
     }
     @FieldResolver((returns) => String, { nullable: true })
-    @Authorized(Role.ADMIN, Role.APPOINTMENT_PARTICIPANT, Role.INSTRUCTOR)
+    @Authorized(Role.ADMIN, Role.APPOINTMENT_PARTICIPANT, Role.INSTRUCTOR, Role.TUTOR)
     async zoomMeetingUrl(@Ctx() context: GraphQLContext, @Root() appointment: Required<Appointment>) {
         const { user } = context;
         const isAdmin = user.roles.includes(Role.ADMIN);


### PR DESCRIPTION
## Ticket

https://github.com/corona-school/project-user/issues/1164

## What was done?

- Allow Tutors to access the `zoomMeetingUrl` field, Replaced Instructor with `Role.OWNER`

I tested it locally before and after, and now users that are tutors _but not instructors_, can access the `zoomMeetingUrl` field, meaning that the appointment detail page works again for them.