### PR TITLE
Feat: Add actions for sus screening after registration

### DIFF
--- a/common/notification/actions.ts
+++ b/common/notification/actions.ts
@@ -115,6 +115,18 @@ const _notificationActions = {
         description: 'Pupil / Screening was disputed (a Screener saved some info but did not take a decision)',
         sampleContext: {},
     },
+    pupil_screening_after_registration_succeeded: {
+        description: 'Pupil / Screening after registration was successful',
+        sampleContext: {},
+    },
+    pupil_screening_after_registration_rejected: {
+        description: 'Pupil / Screening after registration was rejected',
+        sampleContext: {},
+    },
+    pupil_screening_after_registration_missed: {
+        description: 'Pupil / Screening after registration was missed',
+        sampleContext: {},
+    },
     pupil_registration_finished: {
         description: 'Pupil / Registration finished',
         sampleContext: {},

--- a/common/pupil/screening.ts
+++ b/common/pupil/screening.ts
@@ -59,7 +59,7 @@ export async function updatePupilScreening(screener: Screener, pupilScreeningId:
         return;
     }
 
-    const validScreeningCount = await prisma.pupil_screening.count({ where: { pupilId: screening.pupilId, invalidated: false } });
+    const validScreeningCount = await prisma.pupil_screening.count({ where: { pupilId: screening.pupilId } });
     const isFirstScreening = validScreeningCount === 1;
     const asUser = userForPupil(screening.pupil);
     switch (screeningUpdate.status) {
@@ -84,11 +84,9 @@ export async function updatePupilScreening(screener: Screener, pupilScreeningId:
             break;
 
         case PupilScreeningStatus.pending:
-            if (isFirstScreening) {
-                await Notification.actionTaken(asUser, 'pupil_screening_after_registration_missed', {});
-            } else {
-                await Notification.actionTaken(asUser, 'pupil_screening_missed', {});
-            }
+            /**
+             * Notifications for missed screenings are handled in `pupil/mutations.ts` `pupilMissedScreening`
+             */
             break;
     }
 }

--- a/graphql/pupil/mutations.ts
+++ b/graphql/pupil/mutations.ts
@@ -339,7 +339,16 @@ export class MutatePupilResolver {
         @Arg('comment') comment: string
     ): Promise<boolean> {
         const screener = await getSessionScreener(context);
+        const { pupil, pupilId } = await prisma.pupil_screening.findUniqueOrThrow({ where: { id: pupilScreeningId }, include: { pupil: true } });
         await updatePupilScreening(screener, pupilScreeningId, { status: PupilScreeningStatus.pending, comment });
+        const validScreeningCount = await prisma.pupil_screening.count({ where: { pupilId } });
+        const asUser = userForPupil(pupil);
+        const isFirstScreening = validScreeningCount === 1;
+        if (isFirstScreening) {
+            await Notification.actionTaken(asUser, 'pupil_screening_after_registration_missed', {});
+        } else {
+            await Notification.actionTaken(asUser, 'pupil_screening_missed', {});
+        }
         return true;
     }
 

--- a/graphql/pupil/mutations.ts
+++ b/graphql/pupil/mutations.ts
@@ -339,9 +339,7 @@ export class MutatePupilResolver {
         @Arg('comment') comment: string
     ): Promise<boolean> {
         const screener = await getSessionScreener(context);
-        const { pupil } = await prisma.pupil_screening.findUniqueOrThrow({ where: { id: pupilScreeningId }, include: { pupil: true } });
         await updatePupilScreening(screener, pupilScreeningId, { status: PupilScreeningStatus.pending, comment });
-        await Notification.actionTaken(userForPupil(pupil), 'pupil_screening_missed', {});
         return true;
     }
 


### PR DESCRIPTION
## Ticket

https://github.com/corona-school/project-user/issues/1168

## What was done

- Added the new actions
- Updated the logic to trigger these new actions _(only on their first screening)_

Tested it locally and the new actions are being executed as expected only on the first screening