### PR TITLE
Exclude unscreened pupils from course promotions and campaigns

### DIFF
--- a/common/courses/notifications.ts
+++ b/common/courses/notifications.ts
@@ -119,7 +119,6 @@ export async function sendPupilCoursePromotion(subcourse: Prisma.subcourse, coun
             isParticipant: true,
             pupil_screening: {
                 some: {
-                    invalidated: false,
                     status: 'success',
                 },
             },

--- a/common/courses/notifications.ts
+++ b/common/courses/notifications.ts
@@ -117,6 +117,12 @@ export async function sendPupilCoursePromotion(subcourse: Prisma.subcourse, coun
             active: true,
             verification: null,
             isParticipant: true,
+            pupil_screening: {
+                some: {
+                    invalidated: false,
+                    status: 'success',
+                },
+            },
             grade: { in: grades },
             subcourse_participants_pupil: { none: { subcourseId: subcourse.id } },
         },

--- a/graphql/user/fields.ts
+++ b/graphql/user/fields.ts
@@ -175,7 +175,17 @@ export class UserFieldsResolver {
             // Make sure only active users with verified email are returned
             const pupils = await prisma.pupil.findMany({
                 select: { firstname: true, lastname: true, email: true, id: true },
-                where: { ...pupilQuery, active: true, verification: null },
+                where: {
+                    ...pupilQuery,
+                    active: true,
+                    verification: null,
+                    pupil_screening: {
+                        some: {
+                            invalidated: false,
+                            status: 'success',
+                        },
+                    },
+                },
             });
             result.push(...pupils.map(userForPupil));
         }

--- a/graphql/user/fields.ts
+++ b/graphql/user/fields.ts
@@ -181,7 +181,6 @@ export class UserFieldsResolver {
                     verification: null,
                     pupil_screening: {
                         some: {
-                            invalidated: false,
                             status: 'success',
                         },
                     },


### PR DESCRIPTION
Exclude unscreened pupils from course promotions and campaigns

Closes https://github.com/corona-school/project-user/issues/1166.

The issue also mentions helpers, but as far as I can tell we already exclude unscreened helpers in campaigns: https://github.com/corona-school/backend/blob/19860a2694b3ad0ade309aac0cd286b87a96ffc5/graphql/user/fields.ts#L203-L207