### PR TITLE
Refactor: Remove wix id from transaction log

### DIFF
--- a/common/transactionlog/log.ts
+++ b/common/transactionlog/log.ts
@@ -55,7 +55,6 @@ export async function logTransaction<Type extends LogType>(logtype: Type, user: 
             data: {
                 logtype,
                 createdAt: new Date(),
-                user: user?.wix_id ?? 'unknown',
                 userID: user?.userID ?? 'unknown',
                 data: JSON.stringify(data),
             },

--- a/common/user/index.ts
+++ b/common/user/index.ts
@@ -22,9 +22,6 @@ export type User = {
     pupilId?: number;
     studentId?: number;
     screenerId?: number;
-
-    // TODO: Remove after userID migration
-    wix_id?: string;
 };
 export const userSelection = { id: true, firstname: true, lastname: true, email: true, active: true, lastLogin: true };
 
@@ -108,8 +105,6 @@ function userForType(user: Pupil | Student | Screener, type: 'student' | 'pupil'
         active: user.active,
         lastLogin: user.lastLogin,
         [`${type}Id`]: user.id,
-        // TODO: Remove after userID migration
-        wix_id: (user as Pupil | Student)?.wix_id || '',
     };
 }
 

--- a/integration-tests/12_notifications.ts
+++ b/integration-tests/12_notifications.ts
@@ -422,7 +422,7 @@ void test('Notification sent via Mailjet', async () => {
             pupil.userID
         }","firstname":"${pupil.firstname}","lastname":"${pupil.lastname}","email":"${pupil.email.toLowerCase()}","active":true,"lastLogin":"*","pupilId":${
             pupil.pupil.id
-        },"wix_id":"","fullName":"${pupil.firstname} ${
+        },"fullName":"${pupil.firstname} ${
             pupil.lastname
         }"},"USER_APP_DOMAIN":"*","attachmentGroup":"","authToken":"*"},"CustomID":"*","TemplateErrorReporting":{"Email":"backend@lern-fair.de"},"CustomCampaign":"Backend Notification ${id}"}]}`,
         responseStatus: 200,
@@ -492,7 +492,7 @@ void test('Notification sent via Mailjet to overrideEmail', async () => {
             pupil.userID
         }","firstname":"${pupil.firstname}","lastname":"${pupil.lastname}","email":"${pupil.email.toLowerCase()}","active":true,"lastLogin":"*","pupilId":${
             pupil.pupil.id
-        },"wix_id":"","fullName":"${pupil.firstname} ${
+        },"fullName":"${pupil.firstname} ${
             pupil.lastname
         }"},"USER_APP_DOMAIN":"*","attachmentGroup":"","authToken":"*"},"CustomID":"*","TemplateErrorReporting":{"Email":"backend@lern-fair.de"},"CustomCampaign":"Backend Notification ${id}"}]}`,
         responseStatus: 200,

--- a/prisma/migrations/20240412131406_remove_wix_id_from_transaction_log/migration.sql
+++ b/prisma/migrations/20240412131406_remove_wix_id_from_transaction_log/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `user` on the `log` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "log" DROP COLUMN "user";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -360,8 +360,6 @@ model log {
   id        Int              @id(map: "PK_350604cbdf991d5930d9e618fbd") @default(autoincrement())
   logtype   log_logtype_enum @default(misc)
   createdAt DateTime         @default(now()) @db.Timestamp(6)
-  // Instead of the UserID, this uses the WixID of pupils and students (which also happens to be a unique identifier)
-  user      String           @db.VarChar
   userID    String?           @db.VarChar
   // This is usually valid JSON:
   data      String           @db.VarChar


### PR DESCRIPTION
## Ticket

https://github.com/corona-school/project-user/issues/1160

## What was done?

- Add prisma migration to drop the `user` column (aka `wix_id`) from the transaction log
- Remove todos and code referencing user column