### PR TITLE
feature: Add firstAppointmentId resolver for match and user

### DIFF
--- a/common/appointment/get.ts
+++ b/common/appointment/get.ts
@@ -4,6 +4,7 @@ import { prisma } from '../prisma';
 import { User } from '../user';
 
 type QueryDirection = 'last' | 'next';
+type Edge = 'first' | 'last';
 
 /**
  * The current maximum duration of an appointment is 4 hours.
@@ -40,8 +41,9 @@ export const hasAppointmentsForUser = async (user: User): Promise<boolean> => {
     });
     return appointmentsCount > 0;
 };
-export const getLastAppointmentId = async (user: User): Promise<number> => {
-    const lastAppointment = await prisma.lecture.findFirst({
+export const getEdgeAppointmentId = async (user: User, edge: Edge): Promise<number> => {
+    const isFirst = edge === 'first';
+    const edgeAppointment = await prisma.lecture.findFirst({
         where: {
             isCanceled: false,
             NOT: {
@@ -65,10 +67,10 @@ export const getLastAppointmentId = async (user: User): Promise<number> => {
                 },
             ],
         },
-        orderBy: [{ start: 'desc' }],
+        orderBy: [isFirst ? { start: 'asc' } : { start: 'desc' }],
         take: 1,
     });
-    return lastAppointment?.id;
+    return edgeAppointment?.id;
 };
 
 export const getAppointmentsForUser = async (user: User, take: number, skip: number, cursor?: number, direction?: QueryDirection): Promise<Appointment[]> => {
@@ -210,8 +212,9 @@ export const getAppointmentsForMatch = async (
     return appointments;
 };
 
-export const getLastMatchAppointmentId = async (matchId: Match['id'], userId: User['userID']) => {
-    const lastAppointment = await prisma.lecture.findFirst({
+export const getEdgeMatchAppointmentId = async (matchId: Match['id'], userId: User['userID'], edge: Edge) => {
+    const isFirst = edge === 'first';
+    const edgeAppointment = await prisma.lecture.findFirst({
         where: {
             isCanceled: false,
             NOT: {
@@ -219,8 +222,8 @@ export const getLastMatchAppointmentId = async (matchId: Match['id'], userId: Us
             },
             matchId,
         },
-        orderBy: [{ start: 'desc' }],
+        orderBy: [isFirst ? { start: 'asc' } : { start: 'desc' }],
         take: 1,
     });
-    return lastAppointment?.id;
+    return edgeAppointment?.id;
 };

--- a/graphql/match/fields.ts
+++ b/graphql/match/fields.ts
@@ -9,7 +9,7 @@ import { Subject } from '../types/subject';
 import { GraphQLContext } from '../context';
 import { Chat } from '../chat/fields';
 import { getMatcheeConversation } from '../../common/chat';
-import { getAppointmentsForMatch, getLastMatchAppointmentId } from '../../common/appointment/get';
+import { getAppointmentsForMatch, getEdgeMatchAppointmentId } from '../../common/appointment/get';
 
 @Resolver((of) => Match)
 export class ExtendedFieldsMatchResolver {
@@ -78,8 +78,14 @@ export class ExtendedFieldsMatchResolver {
 
     @FieldResolver((returns) => Int, { nullable: true })
     @Authorized(Role.ADMIN, Role.OWNER)
+    async firstAppointmentId(@Ctx() context: GraphQLContext, @Root() match: Match): Promise<number> {
+        return await getEdgeMatchAppointmentId(match.id, context.user.userID, 'first');
+    }
+
+    @FieldResolver((returns) => Int, { nullable: true })
+    @Authorized(Role.ADMIN, Role.OWNER)
     async lastAppointmentId(@Ctx() context: GraphQLContext, @Root() match: Match): Promise<number> {
-        return await getLastMatchAppointmentId(match.id, context.user.userID);
+        return await getEdgeMatchAppointmentId(match.id, context.user.userID, 'last');
     }
 
     @FieldResolver((returns) => Chat, { nullable: true })

--- a/graphql/user/fields.ts
+++ b/graphql/user/fields.ts
@@ -21,7 +21,7 @@ import { JSONResolver } from 'graphql-scalars';
 import { ACCUMULATED_LIMIT, LimitedQuery, LimitEstimated } from '../complexity';
 import { DEFAULT_PREFERENCES } from '../../common/notification/defaultPreferences';
 import { findUsers } from '../../common/user/search';
-import { getAppointmentsForUser, getLastAppointmentId, hasAppointmentsForUser } from '../../common/appointment/get';
+import { getAppointmentsForUser, getEdgeAppointmentId, hasAppointmentsForUser } from '../../common/appointment/get';
 import { getMyContacts, UserContactType } from '../../common/chat/contacts';
 import { generateMeetingSDKJWT, isZoomFeatureActive } from '../../common/zoom/util';
 import { getUserZAK, getZoomUsers } from '../../common/zoom/user';
@@ -260,8 +260,14 @@ export class UserFieldsResolver {
 
     @FieldResolver((returns) => Int, { nullable: true })
     @Authorized(Role.ADMIN, Role.OWNER)
+    async firstAppointmentId(@Root() user: User): Promise<number> {
+        return await getEdgeAppointmentId(user, 'first');
+    }
+
+    @FieldResolver((returns) => Int, { nullable: true })
+    @Authorized(Role.ADMIN, Role.OWNER)
     async lastAppointmentId(@Root() user: User): Promise<number> {
-        return await getLastAppointmentId(user);
+        return await getEdgeAppointmentId(user, 'last');
     }
 
     // ------------- Achievements ------------


### PR DESCRIPTION
## What was done?

- Added a firstAppointmentId resolver (based on the existing `lastAppointmentId`)
- Renamed existing `getLastAppointmentId` utility function -> `getEdgeAppointmentId `

This is related to [this frontend PR](https://github.com/corona-school/user-app/pull/521)