### PR TITLE
Fix: delete and recreate zoom user when changing emails

### DIFF
--- a/common/user/update.ts
+++ b/common/user/update.ts
@@ -1,8 +1,8 @@
-import { User, getUser, userForPupil, userForStudent, userSelection } from '.';
+import { User, getUser, userForPupil, userForStudent, userSelection, getStudent } from '.';
 import { pupil as Pupil, student as Student } from '@prisma/client';
 import { validateEmail } from '../../graphql/validators';
 import { prisma } from '../prisma';
-import { updateZoomUser } from '../zoom/user';
+import { changeEmail } from '../zoom/user';
 import { isZoomFeatureActive } from '../zoom/util';
 
 export async function updateUser(userId: string, { email }: Partial<Pick<User, 'email'>>) {
@@ -10,7 +10,7 @@ export async function updateUser(userId: string, { email }: Partial<Pick<User, '
     const user = await getUser(userId, /* active */ true);
     if (user.studentId) {
         if (isZoomFeatureActive()) {
-            await updateZoomUser(user);
+            await changeEmail(await getStudent(user), validatedEmail);
         }
 
         return userForStudent(


### PR DESCRIPTION
We need to delete and recreate a Zoom user when a Lern-Fair user changes their email address, as we cannot use the changeEmail endpoint because we're not using managed domains on Zoom.