### PR TITLE
Fix: check if user has zoomUserId 

### DIFF
--- a/common/user/update.ts
+++ b/common/user/update.ts
@@ -10,7 +10,10 @@ export async function updateUser(userId: string, { email }: Partial<Pick<User, '
     const user = await getUser(userId, /* active */ true);
     if (user.studentId) {
         if (isZoomFeatureActive()) {
-            await changeEmail(await getStudent(user), validatedEmail);
+            const student = await getStudent(user);
+            if (student.zoomUserId) {
+                await changeEmail(student, validatedEmail);
+            }
         }
 
         return userForStudent(


### PR DESCRIPTION
Check if user has zoomUserId before recreating Zoom account on email change