### PR TITLE
fix: Add fallback when fetching zoom user by email does not work

### DIFF
--- a/common/zoom/user.ts
+++ b/common/zoom/user.ts
@@ -27,6 +27,12 @@ type ZAKResponse = {
     token: string;
 };
 
+type GetZoomUserArgs = {
+    id: student['id'];
+    email: student['email'];
+    zoomUserId?: student['zoomUserId'];
+};
+
 enum ZoomLicenseType {
     BASIC = 1,
     LICENSED = 2,
@@ -100,37 +106,55 @@ const createZoomUser = async (student: Pick<student, 'id' | 'firstname' | 'lastn
     return newUser;
 };
 
-async function getZoomUser(email: string): Promise<ZoomUser | null> {
+async function getZoomUser({ id, email, zoomUserId }: GetZoomUserArgs): Promise<ZoomUser | null> {
     assureZoomFeatureActive();
-
     const { access_token } = await getAccessToken();
-    const response = await zoomRetry(
-        () =>
-            fetch(`${zoomUserApiUrl}/${email}`, {
-                method: 'GET',
-                headers: {
-                    Authorization: `Bearer ${access_token}`,
-                    'Content-Type': 'application/json',
-                },
-            }),
-        3,
-        1000
-    );
 
-    if (response.status === 404) {
-        logger.info(`Zoom - No Zoom user found for student with email ${email}`);
-        return null;
-    } else if (!response.ok) {
-        throw new Error(`Zoom failed to get user: ${response.status} ${await response.text()}`);
+    const zoomFetchUser = (zoomIdOrEmail: string) => {
+        return zoomRetry(
+            () =>
+                fetch(`${zoomUserApiUrl}/${zoomIdOrEmail}`, {
+                    method: 'GET',
+                    headers: {
+                        Authorization: `Bearer ${access_token}`,
+                        'Content-Type': 'application/json',
+                    },
+                }),
+            2,
+            1000
+        );
+    };
+
+    const byEmailResponse = await zoomFetchUser(email);
+    if (byEmailResponse.status === 404) {
+        logger.info(`Zoom - No Zoom user found for Student(${id}) with email ${email}`);
+        if (!zoomUserId) {
+            return null;
+        }
+
+        /** Let's try with the user id because sometimes the zoom API works with one or the other... */
+        const byIdResponse = await zoomFetchUser(zoomUserId);
+        if (byIdResponse.status === 404) {
+            logger.info(`Zoom - No Zoom user found for Student(${id}) with zoomUserId ${zoomUserId}`);
+            return null;
+        } else if (!byIdResponse.ok) {
+            throw new Error(`Zoom failed to get Student(${id}) zoom user by zoomUserId: ${byIdResponse.status} ${await byIdResponse.text()}`);
+        }
+
+        logger.info(`Zoom - Retrieved Zoom user for Student(${id}) with zoomUserId ${zoomUserId}`);
+        const data = byIdResponse.json() as unknown as ZoomUser;
+        return data;
+    } else if (!byEmailResponse.ok) {
+        throw new Error(`Zoom failed to get Student(${id}) zoom user by email: ${byEmailResponse.status} ${await byEmailResponse.text()}`);
     }
 
-    logger.info(`Zoom - Retrieved Zoom user for student with email ${email}`);
-    const data = response.json() as unknown as ZoomUser;
+    logger.info(`Zoom - Retrieved Zoom user for Student(${id}) with email ${email}`);
+    const data = byEmailResponse.json() as unknown as ZoomUser;
     return data;
 }
 
-export async function getOrCreateZoomUser(student: Pick<student, 'id' | 'firstname' | 'lastname' | 'email'>) {
-    const existing = await getZoomUser(student.email);
+export async function getOrCreateZoomUser(student: Pick<student, 'id' | 'firstname' | 'lastname' | 'email' | 'zoomUserId'>) {
+    const existing = await getZoomUser(student);
     if (existing) {
         return existing;
     }


### PR DESCRIPTION
## Ticket

https://github.com/corona-school/project-user/issues/1192

## What was done?

Added a fallback to fetch users by `zoomUserId` when the email doesn't work. I decided to do this as a fallback because I saw on the zoom forum some reports of the same issue with `zoomUserId`... 