### PR TITLE
Feat: SuS Screening rejection adjustments

### DIFF
--- a/common/notification/actions.ts
+++ b/common/notification/actions.ts
@@ -487,6 +487,10 @@ const _notificationActions = {
         description: 'Pupil / Account deactivated',
         sampleContext: {},
     },
+    pupil_account_deactivated_by_admin: {
+        description: 'Pupil / Account deactivated by admin',
+        sampleContext: {},
+    },
     student_account_deactivated: {
         description: 'Student / Account deactivated',
         sampleContext: {},

--- a/common/notification/hooks.ts
+++ b/common/notification/hooks.ts
@@ -18,6 +18,11 @@ registerStudentHook('cancel-remission-request', 'Cancels the remission request(s
 });
 
 import { deletePupilMatchRequest } from '../match/request';
+import { deactivatePupil } from '../pupil/activation';
 registerPupilHook('revoke-pupil-match-request', 'Match Request is taken back, pending Pupil Screenings are invalidated', async (pupil) => {
     await deletePupilMatchRequest(pupil);
+});
+
+registerPupilHook('deactivate-pupil', 'Account gets deactivated, matches are dissolved, courses are left', async (pupil) => {
+    await deactivatePupil(pupil);
 });

--- a/common/notification/hooks.ts
+++ b/common/notification/hooks.ts
@@ -24,5 +24,5 @@ registerPupilHook('revoke-pupil-match-request', 'Match Request is taken back, pe
 });
 
 registerPupilHook('deactivate-pupil', 'Account gets deactivated, matches are dissolved, courses are left', async (pupil) => {
-    await deactivatePupil(pupil);
+    await deactivatePupil(pupil, true, 'deactivated by admin', true);
 });

--- a/common/pupil/activation.ts
+++ b/common/pupil/activation.ts
@@ -27,12 +27,16 @@ export async function activatePupil(pupil: Pupil) {
     return updatedPupil;
 }
 
-export async function deactivatePupil(pupil: Pupil, reason?: string) {
+export async function deactivatePupil(pupil: Pupil, silent = false, reason?: string, byAdmin = false) {
     if (!pupil.active) {
         throw new RedundantError('Pupil was already deactivated');
     }
 
-    await Notification.actionTaken(userForPupil(pupil), 'pupil_account_deactivated', {});
+    if (!silent) {
+        const action = byAdmin ? 'pupil_account_deactivated_by_admin' : 'pupil_account_deactivated';
+        await Notification.actionTaken(userForPupil(pupil), action, {});
+    }
+
     await Notification.cancelRemindersFor(userForPupil(pupil));
     // Setting 'active' to false will not send out any notifications during deactivation
     pupil.active = false;

--- a/graphql/me/mutation.ts
+++ b/graphql/me/mutation.ts
@@ -162,7 +162,7 @@ export class MutateMeResolver {
     async meDeactivate(@Ctx() context: GraphQLContext, @Arg('reason', { nullable: true }) reason?: string) {
         if (isSessionPupil(context)) {
             const pupil = await getSessionPupil(context);
-            const updatedPupil = await deactivatePupil(pupil, reason);
+            const updatedPupil = await deactivatePupil(pupil, false, reason, false);
 
             const roles: Role[] = [];
             await evaluatePupilRoles(updatedPupil, roles);

--- a/graphql/pupil/mutations.ts
+++ b/graphql/pupil/mutations.ts
@@ -272,7 +272,7 @@ export class MutatePupilResolver {
     @Authorized(Role.ADMIN, Role.SCREENER)
     async pupilDeactivate(@Arg('pupilId') pupilId: number): Promise<boolean> {
         const pupil = await getPupil(pupilId);
-        await deactivatePupil(pupil);
+        await deactivatePupil(pupil, false, 'deactivated by admin', true);
         return true;
     }
 

--- a/jobs/periodic/redact-inactive-accounts/deactivate-inactive-accounts.ts
+++ b/jobs/periodic/redact-inactive-accounts/deactivate-inactive-accounts.ts
@@ -19,7 +19,7 @@ export async function deactivateInactiveAccounts() {
     });
 
     for (const pupil of persons.pupils) {
-        await deactivatePupil(pupil, DEACTIVATION_MESSAGE);
+        await deactivatePupil(pupil, false, DEACTIVATION_MESSAGE, false);
     }
 
     for (const student of persons.students) {


### PR DESCRIPTION
## Ticket

https://github.com/corona-school/project-user/issues/1187

## What was done?

- Added a new action to trigger when admins/screeners deactivate a pupil account
- Added a `deactivate-pupil` hook _(Later will be attached to some notifications)_
- Added a `silent` and `byAdmin` options to the `deactivatePupil` to customize the notification behavior