### PR TITLE
feature: migrate to webflow api v2

### DIFF
--- a/jobs/periodic/sync-to-webflow/diff.spec.ts
+++ b/jobs/periodic/sync-to-webflow/diff.spec.ts
@@ -1,8 +1,12 @@
-import { diff, hash } from './diff';
+import { diff } from './diff';
 import { WebflowMetadata } from './webflow-adapter';
 
 interface TestData extends WebflowMetadata {
-    data: string;
+    fieldData: {
+        hash?: string;
+        slug: string;
+        data: string;
+    };
 }
 
 function randomString(): string {
@@ -16,13 +20,15 @@ function randomBool(): boolean {
 function newTestObj(id: number, data: string): TestData {
     // We are randomizing the _id & _archived values, to make sure that they are ignored during hashing.
     const res: TestData = {
-        _id: randomString(),
-        _archived: randomBool(),
-        _draft: randomBool(),
-        slug: `${id}`,
-        data: data,
+        id: randomString(),
+        isArchived: randomBool(),
+        isDraft: randomBool(),
+        fieldData: {
+            slug: `${id}`,
+            data: data,
+        },
     };
-    res.hash = hash(res);
+    // res.fieldData.hash = hash(res);
     return res;
 }
 
@@ -43,7 +49,7 @@ describe('diff', () => {
 
         expect(result.new).toStrictEqual([]);
         expect(result.outdated).toStrictEqual([]);
-        expect(result.changed).toStrictEqual([{ ...right, _id: left._id }]);
+        expect(result.changed).toStrictEqual([{ ...right, id: left.id }]);
     });
     it('should create new object as id was not found', () => {
         const newObj = newTestObj(2, 'foo');
@@ -68,7 +74,7 @@ describe('diff', () => {
     it('should notice a diff in id even if the hash is the same', () => {
         const oldObj = newTestObj(1, 'foo');
         const newObj = structuredClone(oldObj) as TestData;
-        newObj.slug = '2';
+        newObj.fieldData.slug = '2';
 
         const left: TestData[] = [oldObj];
         const right: TestData[] = [newObj];

--- a/jobs/periodic/sync-to-webflow/diff.ts
+++ b/jobs/periodic/sync-to-webflow/diff.ts
@@ -26,10 +26,8 @@ export function diff<T extends WebflowMetadata>(left: T[], right: T[]): { new: T
         }
 
         const left = { ...leftMap[dbId].fieldData, hash: '' };
-        // if (leftMap[dbId].fieldData.hash != rightMap[dbId].fieldData.hash) {
-        if (!isEqual(left, { ...rightMap[dbId].fieldData, hash: '' })) {
-            console.log(JSON.stringify({ ...leftMap[dbId].fieldData, hash: '' }, null, 2));
-            console.log(JSON.stringify({ ...rightMap[dbId].fieldData, hash: '' }, null, 2));
+        const right = { ...rightMap[dbId].fieldData, hash: '' };
+        if (!isEqual(left, right)) {
             // We have to save the old item id, so that it can be used for the update operation
             rightMap[dbId].id = leftMap[dbId].id;
             changedEntries.push(rightMap[dbId]);

--- a/jobs/periodic/sync-to-webflow/diff.ts
+++ b/jobs/periodic/sync-to-webflow/diff.ts
@@ -1,17 +1,12 @@
-import { emptyMetadata, WebflowMetadata } from './webflow-adapter';
-import { sha1 } from 'object-hash';
-
-export function hash<T extends WebflowMetadata>(data: T): string {
-    const raw = { ...data, ...emptyMetadata };
-    return sha1(raw);
-}
+import { WebflowMetadata } from './webflow-adapter';
+import { isEqual } from 'lodash';
 
 export type DBIdMap<T> = { [key: number]: T };
 
 export function mapToDBId<T extends WebflowMetadata>(data: T[]): DBIdMap<T> {
     const res = {};
     for (const row of data) {
-        res[row.slug] = row;
+        res[row.fieldData.slug] = row;
     }
     return res;
 }
@@ -29,9 +24,14 @@ export function diff<T extends WebflowMetadata>(left: T[], right: T[]): { new: T
             outdatedEntries.push(leftMap[dbId]);
             continue;
         }
-        if (leftMap[dbId].hash != rightMap[dbId].hash) {
+
+        const left = { ...leftMap[dbId].fieldData, hash: '' };
+        // if (leftMap[dbId].fieldData.hash != rightMap[dbId].fieldData.hash) {
+        if (!isEqual(left, { ...rightMap[dbId].fieldData, hash: '' })) {
+            console.log(JSON.stringify({ ...leftMap[dbId].fieldData, hash: '' }, null, 2));
+            console.log(JSON.stringify({ ...rightMap[dbId].fieldData, hash: '' }, null, 2));
             // We have to save the old item id, so that it can be used for the update operation
-            rightMap[dbId]._id = leftMap[dbId]._id;
+            rightMap[dbId].id = leftMap[dbId].id;
             changedEntries.push(rightMap[dbId]);
         }
     }

--- a/jobs/periodic/sync-to-webflow/index.ts
+++ b/jobs/periodic/sync-to-webflow/index.ts
@@ -1,6 +1,6 @@
 import syncCourses from './sync-courses';
 import { getLogger } from '../../../common/logger/logger';
-import syncLectures from './sync-lectures';
+import { syncDeleteLectures, syncLectures } from './sync-lectures';
 
 const logger = getLogger('WebflowAPISync');
 
@@ -31,8 +31,10 @@ export default async function execute(): Promise<void> {
     try {
         logger.info('Run Webflow sync');
         validateEnvVars();
-        await syncLectures(logger);
+        const { itemsToDelete } = await syncLectures(logger);
         await syncCourses(logger);
+        // The outdated lectures have to be removed from the courses first
+        await syncDeleteLectures(logger, itemsToDelete);
         logger.info('Finished Webflow sync');
     } catch (e) {
         logger.error('Failed to sync Webflow data', e);

--- a/jobs/periodic/sync-to-webflow/sync-courses.ts
+++ b/jobs/periodic/sync-to-webflow/sync-courses.ts
@@ -168,7 +168,7 @@ function courseToDTO(logger: Logger, subcourse: WebflowSubcourse, lectureIds: DB
             image: {
                 fileId: 'placeholder', // not needed
                 url: image,
-                alt: '',
+                alt: image,
             },
         },
     };
@@ -178,16 +178,14 @@ function syncCourseImages(dbCourses: CourseDTO[], webflowCourses: CourseDTO[]) {
     const webflowCourseIdMap = mapToDBId(webflowCourses);
 
     for (const i in dbCourses) {
-        console.log('id', dbCourses[i].fieldData.slug);
         if (!webflowCourseIdMap[dbCourses[i].fieldData.slug]) {
             continue;
         }
-        console.log('hier');
         const webflowCourse = webflowCourseIdMap[dbCourses[i].fieldData.slug];
-        console.log(dbCourses[i].fieldData.image.url, webflowCourse.fieldData.image.url);
-        if (dbCourses[i].fieldData.image.url === webflowCourse.fieldData.image.url) {
-            console.log('found img');
-            dbCourses[i].fieldData.image === webflowCourse.fieldData.image;
+        // We are misusing the alt of the image to store the original link.
+        // Otherwise, we'll never know if webflow will change the link under the hood.
+        if (dbCourses[i].fieldData.image.alt === webflowCourse.fieldData.image.alt) {
+            dbCourses[i].fieldData.image = webflowCourse.fieldData.image;
         }
     }
 }

--- a/jobs/periodic/sync-to-webflow/sync-courses.ts
+++ b/jobs/periodic/sync-to-webflow/sync-courses.ts
@@ -1,5 +1,5 @@
 import { createNewItem, deleteItems, emptyMetadata, getCollectionItems, patchItem, publishItems, WebflowMetadata } from './webflow-adapter';
-import { diff, hash, mapToDBId, DBIdMap } from './diff';
+import { diff, mapToDBId, DBIdMap } from './diff';
 import { Logger } from '../../../common/logger/logger';
 import moment, { Moment } from 'moment';
 import { WebflowSubcourse, getWebflowSubcourses } from './queries';
@@ -12,37 +12,42 @@ const lectureCollectionId = process.env.WEBFLOW_LECTURE_COLLECTION_ID;
 const appBaseUrl = 'https://app.lern-fair.de/single-course';
 
 interface CourseDTO extends WebflowMetadata {
-    description: string;
-    instructor: string;
+    fieldData: {
+        slug?: string;
+        name?: string;
 
-    startingdate: string;
-    endingdate: string;
-    weekday: string;
-    courseduration: string; // like "45 min"
-    lecturecount: number;
-    time: string; // like 16:00 Uhr
-    appointments: string;
+        description: string;
+        instructor: string;
 
-    category: string;
-    link: string;
-    maxparticipants: number;
-    participantscount: number;
-    openslots: number;
-    subject: string;
+        startingdate: string;
+        endingdate: string;
+        weekday: string;
+        courseduration: string; // like "45 min"
+        lecturecount: number;
+        time: string; // like 16:00 Uhr
+        appointments: string;
 
-    mingrade: number;
-    maxgrade: number;
+        category: string;
+        link: string;
+        maxparticipants: number;
+        participantscount: number;
+        openslots: number;
+        subject: string;
 
-    lectures: string[];
+        mingrade: number;
+        maxgrade: number;
 
-    image: {
-        fileId: string;
-        url: string;
-        alt: string;
+        lectures: string[];
+
+        image: {
+            fileId: string;
+            url: string;
+            alt: string;
+        };
     };
 }
 
-function courseDTOFactory(data: any): WebflowMetadata {
+function courseDTOFactory(data: any): CourseDTO {
     // This is just some syntactic sugar to convert the api data to an internal interface.
     // Late on we could implement some checks here, to verify the data.
     return data;
@@ -97,7 +102,7 @@ function mapLecturesToCourse(logger: Logger, subcourse: WebflowSubcourse, lectur
     }
 
     // This will make sure that the attached lectures are sorted by their start date.
-    return result.sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime()).map((lecture) => lecture._id);
+    return result.sort((a, b) => new Date(a.fieldData.start).getTime() - new Date(b.fieldData.start).getTime()).map((lecture) => lecture.id);
 }
 
 // The description is a WYSIWYG editor that translates the information into HTML code, so we should do the same.
@@ -130,56 +135,75 @@ function courseToDTO(logger: Logger, subcourse: WebflowSubcourse, lectureIds: DB
     startDate.locale('de');
 
     const image = getCourseImageURL(subcourse.course);
-    const courseDTO: CourseDTO = {
+    return {
         ...emptyMetadata,
 
-        name: subcourse.course.name,
-        slug: `${subcourse.id}`, // We are using a string to be safe for any case.
+        fieldData: {
+            name: subcourse.course.name,
+            slug: `${subcourse.id}`, // We are using a string to be safe for any case.
 
-        description: parseDescription(subcourse.course.description),
-        instructor: generateInstructor(subcourse),
+            description: parseDescription(subcourse.course.description),
+            instructor: generateInstructor(subcourse),
 
-        startingdate: startDate.toISOString(),
-        endingdate: endDate.toISOString(),
-        weekday: startDate.format('dddd'),
-        courseduration: `${getTotalCouseDuration(subcourse)} min`, // TODO: maybe this can be done in a nicer way. Maybe with the help of moment?
-        lecturecount: subcourse.lecture.length,
-        time: startDate.format('HH:mm'),
-        appointments: listLectureStartDates(subcourse),
+            startingdate: startDate.toISOString(),
+            endingdate: endDate.toISOString(),
+            weekday: startDate.format('dddd'),
+            courseduration: `${getTotalCouseDuration(subcourse)} min`, // TODO: maybe this can be done in a nicer way. Maybe with the help of moment?
+            lecturecount: subcourse.lecture.length,
+            time: startDate.format('HH:mm'),
+            appointments: listLectureStartDates(subcourse),
 
-        category: subcourse.course.category,
-        link: `${appBaseUrl}/${subcourse.id}`,
-        maxparticipants: subcourse.maxParticipants,
-        participantscount: subcourse.subcourse_participants_pupil.length,
-        openslots: subcourse.maxParticipants - subcourse.subcourse_participants_pupil.length,
-        subject: translateSubject(subcourse.course.subject),
+            category: subcourse.course.category,
+            link: `${appBaseUrl}/${subcourse.id}`,
+            maxparticipants: subcourse.maxParticipants,
+            participantscount: subcourse.subcourse_participants_pupil.length,
+            openslots: subcourse.maxParticipants - subcourse.subcourse_participants_pupil.length,
+            subject: translateSubject(subcourse.course.subject),
 
-        mingrade: subcourse.minGrade,
-        maxgrade: subcourse.maxGrade,
+            mingrade: subcourse.minGrade,
+            maxgrade: subcourse.maxGrade,
 
-        lectures: mapLecturesToCourse(logger, subcourse, lectureIds),
+            lectures: mapLecturesToCourse(logger, subcourse, lectureIds),
 
-        image: {
-            fileId: 'placeholder', // not needed
-            url: image,
-            alt: '',
+            image: {
+                fileId: 'placeholder', // not needed
+                url: image,
+                alt: '',
+            },
         },
     };
-    courseDTO.hash = hash(courseDTO);
-    return courseDTO;
+}
+
+function syncCourseImages(dbCourses: CourseDTO[], webflowCourses: CourseDTO[]) {
+    const webflowCourseIdMap = mapToDBId(webflowCourses);
+
+    for (const i in dbCourses) {
+        console.log('id', dbCourses[i].fieldData.slug);
+        if (!webflowCourseIdMap[dbCourses[i].fieldData.slug]) {
+            continue;
+        }
+        console.log('hier');
+        const webflowCourse = webflowCourseIdMap[dbCourses[i].fieldData.slug];
+        console.log(dbCourses[i].fieldData.image.url, webflowCourse.fieldData.image.url);
+        if (dbCourses[i].fieldData.image.url === webflowCourse.fieldData.image.url) {
+            console.log('found img');
+            dbCourses[i].fieldData.image === webflowCourse.fieldData.image;
+        }
+    }
 }
 
 export default async function syncCourses(logger: Logger): Promise<void> {
     logger.addContext('CMSCollection', 'Group Courses');
 
     logger.info('Start course sync');
-    const webflowCourses = await getCollectionItems<WebflowMetadata>(collectionId, courseDTOFactory);
+    const webflowCourses = await getCollectionItems<CourseDTO>(collectionId, courseDTOFactory);
     const webflowLectures = await getCollectionItems<LectureDTO>(lectureCollectionId, lectureDTOFactory);
     const lectureDBIdMap = mapToDBId<LectureDTO>(webflowLectures);
 
     const subCourses = await getWebflowSubcourses();
     const dbCourses = subCourses.map((course) => courseToDTO(logger, course, lectureDBIdMap));
 
+    syncCourseImages(dbCourses, webflowCourses);
     const result = diff(webflowCourses, dbCourses);
     logger.debug('Webflow course diff', { result });
 
@@ -193,9 +217,10 @@ export default async function syncCourses(logger: Logger): Promise<void> {
     for (const row of result.changed) {
         await patchItem(collectionId, row);
     }
+    logger.info('updated items', { itemIds: result.changed.map((row) => row.id) });
 
     if (result.outdated.length > 0) {
-        const outdatedIds = result.outdated.map((row) => row._id);
+        const outdatedIds = result.outdated.map((row) => row.id);
         logger.info('delete outdated items', { itemIds: outdatedIds });
         await deleteItems(collectionId, outdatedIds);
     }

--- a/jobs/periodic/sync-to-webflow/sync-lectures.ts
+++ b/jobs/periodic/sync-to-webflow/sync-lectures.ts
@@ -1,5 +1,5 @@
 import { createNewItem, deleteItems, emptyMetadata, getCollectionItems, patchItem, publishItems, WebflowMetadata } from './webflow-adapter';
-import { diff, hash } from './diff';
+import { diff } from './diff';
 import { Logger } from '../../../common/logger/logger';
 import moment from 'moment';
 import { lecture } from '@prisma/client';
@@ -8,9 +8,14 @@ import { getWebflowSubcourses } from './queries';
 const lectureCollectionId = process.env.WEBFLOW_LECTURE_COLLECTION_ID;
 
 export interface LectureDTO extends WebflowMetadata {
-    start: string; // ISO Date String
-    end: string; // ISO Date String (start + duration)
-    duration: string;
+    fieldData: {
+        slug?: string;
+        name?: string;
+
+        start: string; // ISO Date String
+        end: string; // ISO Date String (start + duration)
+        duration: string;
+    };
 }
 
 export function lectureDTOFactory(data: any): LectureDTO {
@@ -23,20 +28,19 @@ function lectureToDTO(lecture: lecture): LectureDTO {
     const start = moment(lecture.start).locale('de');
     // We have to clone the start variable, because .add is mutating the object
     const end = start.clone().add(lecture.duration, 'minutes');
-    const lectureDto: LectureDTO = {
+    return {
         ...emptyMetadata,
-        slug: `${lecture.id}`,
-        start: start.toISOString(),
-        end: end.toISOString(),
-        duration: `${lecture.duration} min.`,
+        fieldData: {
+            name: `${lecture.id}`,
+            slug: `${lecture.id}`,
+            start: start.toISOString(),
+            end: end.toISOString(),
+            duration: `${lecture.duration} min.`,
+        },
     };
-    lectureDto.hash = hash(lectureDto);
-    // Lectures don't have any names, so to prevent collisions we are just using the hash, which should be unique.
-    lectureDto.name = lectureDto.hash;
-    return lectureDto;
 }
 
-export default async function syncLectures(logger: Logger): Promise<void> {
+export async function syncLectures(logger: Logger): Promise<{ itemsToDelete: WebflowMetadata[] }> {
     logger.addContext('CMSCollection', 'Lectures');
 
     logger.info('Start lecture sync');
@@ -58,18 +62,24 @@ export default async function syncLectures(logger: Logger): Promise<void> {
     logger.info('created new items', { itemIds: newIds });
 
     for (const row of result.changed) {
-        logger.info('patch item', { itemID: row._id });
+        logger.info('patch item', { itemID: row.id });
         await patchItem(lectureCollectionId, row);
-    }
-
-    if (result.outdated.length > 0) {
-        const outdatedIds = result.outdated.map((row) => row._id);
-        logger.info('delete outdated items', { itemIds: outdatedIds });
-        await deleteItems(lectureCollectionId, outdatedIds);
     }
 
     const publishedItems = await publishItems(lectureCollectionId);
     logger.info('publish new items', { itemIds: publishedItems });
 
     logger.info('finished lecture sync', { newItems: result.new.length, deletedItems: result.outdated.length });
+
+    return { itemsToDelete: result.outdated };
+}
+
+export async function syncDeleteLectures(logger: Logger, itemsToDelete: WebflowMetadata[]): Promise<void> {
+    if (itemsToDelete.length === 0) {
+        return;
+    }
+
+    const outdatedIds = itemsToDelete.map((row) => row.id);
+    logger.info('delete outdated items', { itemIds: outdatedIds });
+    await deleteItems(lectureCollectionId, outdatedIds);
 }

--- a/jobs/periodic/sync-to-webflow/webflow-adapter.ts
+++ b/jobs/periodic/sync-to-webflow/webflow-adapter.ts
@@ -1,5 +1,6 @@
 import { getLogger } from '../../../common/logger/logger';
 import moment from 'moment';
+import { isWebflowSyncDryRun } from '../../../utils/environment';
 
 const logger = getLogger('WebflowApiAdapter');
 const WEBFLOW_MAX_PUBLISH_ITEMS = 100;
@@ -104,6 +105,11 @@ async function request(req: Request): Promise<any> {
     if (req.data) {
         options.body = JSON.stringify(req.data);
         options.headers['Content-Type'] = 'application/json';
+    }
+
+    if (req.method !== 'GET' && isWebflowSyncDryRun()) {
+        logger.info(`Webflow sync dry run`, { url, options: { ...options, headers: { ...options.headers, authorization: '' } } });
+        return null;
     }
 
     const res = await fetch(url, options);

--- a/utils/environment.ts
+++ b/utils/environment.ts
@@ -21,3 +21,7 @@ export function getHostname(): string {
 export function isGamificationFeatureActive(): boolean {
     return JSON.parse(process.env.GAMIFICATION_ACTIVE || 'false');
 }
+
+export function isWebflowSyncDryRun(): boolean {
+    return JSON.parse(process.env.WEBFLOW_SYNC_DRY_RUN || 'true');
+}


### PR DESCRIPTION
https://github.com/corona-school/project-user/issues/1203

This PR updates the webflow sync to use the new V2 API. Previously, with V1, we used a hash to determine if a record had changed. Unfortunately, with the new API structure, this would mean that all records would need to be recreated. Therefore, I've replaced the hash mechanism with a comparator to ensure that we only recreate records if it's really necessary.

Additionally, I've introduced a new dry-run environment variable to allow testing the changes before executing real actions.