### PR TITLE
fix: Add filters to get courses that were actually given

### DIFF
--- a/jobs/periodic/notification-courses-ended-yesterday/index.ts
+++ b/jobs/periodic/notification-courses-ended-yesterday/index.ts
@@ -18,6 +18,11 @@ export default async function execute() {
                     },
                 },
             },
+            cancelled: false,
+            course: {
+                courseState: 'allowed',
+            },
+            published: true,
         },
         include: {
             course: true,


### PR DESCRIPTION
## Ticket

https://github.com/corona-school/project-user/issues/1213

## What was done?

Updated the filters on the `notification-courses-ended-yesterday` job to exclude subcourses that were cancelled, denied, not published.