### PR TITLE
fix: Add push in Channels type

### DIFF
--- a/graphql/types/preferences.ts
+++ b/graphql/types/preferences.ts
@@ -5,6 +5,8 @@ import { Field, InputType, ObjectType } from 'type-graphql';
 export class Channels {
     @Field()
     email: boolean;
+    @Field({ nullable: true })
+    push?: boolean;
 
     [otherChannel: string]: boolean;
 }


### PR DESCRIPTION
Should fix the error:
```
GraphQLError: Variable \"$preferences\" got invalid value { email: true, push: true } at \"preferences.appointment\"; Field \"push\" is not defined by type \"ChannelInput\".
```
when changing preferences