### PR TITLE
fix: Make push subscription idempotent

### DIFF
--- a/common/notification/channels/push.ts
+++ b/common/notification/channels/push.ts
@@ -48,6 +48,15 @@ export async function getPushSubscriptions(user: User) {
 }
 
 export async function addPushSubcription(user: User, subscription: CreatePushSubscription): Promise<PushSubscription> {
+    const existing = await prisma.push_subscription.findFirst({
+        where: { userID: user.userID, endpoint: subscription.endpoint },
+    });
+
+    if (existing) {
+        logger.info(`User(${user.userID}) added existing subscription`, { subscription, existing });
+        return existing;
+    }
+
     const result = await prisma.push_subscription.create({
         data: { ...subscription, userID: user.userID },
     });

--- a/common/notification/channels/push.ts
+++ b/common/notification/channels/push.ts
@@ -53,6 +53,15 @@ export async function addPushSubcription(user: User, subscription: CreatePushSub
     });
 
     if (existing) {
+        if (JSON.stringify(existing.keys) !== JSON.stringify(subscription.keys) || existing.expirationTime !== subscription.expirationTime) {
+            await prisma.push_subscription.update({
+                where: { id: existing.id },
+                data: { keys: subscription.keys, expirationTime: subscription.expirationTime },
+            });
+
+            logger.info(`User(${user.userID}) updated existing subscription`);
+        }
+
         logger.info(`User(${user.userID}) added existing subscription`, { subscription, existing });
         return existing;
     }

--- a/common/notification/index.ts
+++ b/common/notification/index.ts
@@ -164,7 +164,7 @@ async function deliverNotification(
         logger.warn(
             `Failed to send ConcreteNotification(${concreteNotification.id}) of Notification(${notification.id}) to User(${
                 user.userID
-            }) via Channels (${activeChannels.map((it) => it.type).join(', ')})`,
+            }) via Channels (${activeChannels.map((it) => it.type).join(', ')}) - ${error?.message}`,
             error
         );
 


### PR DESCRIPTION
The client does not know whether the push subscription was already added successfully before, lets just readd it in that case