### PR TITLE
feat: Include message in push notification

### DIFF
--- a/common/notification/channels/push.ts
+++ b/common/notification/channels/push.ts
@@ -7,7 +7,7 @@ import { User } from '../../user';
 import { RedundantError } from '../../util/error';
 import { Channel, Context, Notification } from '../types';
 import WebPush from 'web-push';
-import { getMessage } from '../messages';
+import { getMessage, hasMessage } from '../messages';
 
 const logger = getLogger('Push');
 
@@ -101,6 +101,10 @@ export const webpushChannel: Channel = {
 
     async canSend(notification: Notification, user: User) {
         if (!enabled) {
+            return false;
+        }
+
+        if (!(await hasMessage(notification.id))) {
             return false;
         }
 

--- a/common/notification/index.ts
+++ b/common/notification/index.ts
@@ -1,5 +1,5 @@
 import { mailjetChannel } from './channels/mailjet';
-import { NotificationID, NotificationContext, Context, Notification, ConcreteNotification, ConcreteNotificationState, Channel } from './types';
+import { NotificationID, NotificationContext, Context, Notification, ConcreteNotification, ConcreteNotificationState, Channel, getContext } from './types';
 import { prisma } from '../prisma';
 import { getNotification, getNotifications, getSampleContextExternal } from './notification';
 import { getFullName, User, queryUser, getUser } from '../user';
@@ -7,7 +7,7 @@ import { getLogger } from '../logger/logger';
 import { v4 as uuid } from 'uuid';
 import { AttachmentGroup, createAttachment, File, getAttachmentGroupByAttachmentGroupId, getAttachmentListHTML } from '../attachments';
 import { triggerHook } from './hook';
-import { USER_APP_DOMAIN, isDev } from '../util/environment';
+import { isDev } from '../util/environment';
 import { inAppChannel } from './channels/inapp';
 import { ActionID, getSampleContextForAction, SpecificNotificationContext } from './actions';
 import { Channels } from '../../graphql/types/preferences';
@@ -86,14 +86,6 @@ const getNotificationChannelPreferences = async (user: User, concreteNotificatio
 
     return result;
 };
-
-export function getContext(notificationContext: NotificationContext, user: User): Context {
-    return {
-        ...notificationContext,
-        user: { ...user, fullName: getFullName(user) },
-        USER_APP_DOMAIN,
-    };
-}
 
 async function deliverNotification(
     concreteNotification: ConcreteNotification,

--- a/common/notification/messages.ts
+++ b/common/notification/messages.ts
@@ -1,11 +1,10 @@
 import { message_translation_language_enum as TranslationLanguage } from '@prisma/client';
 import { getNotification, getSampleContext } from './notification';
-import { ConcreteNotification, Notification, NotificationContext, NotificationMessage, NotificationType, TranslationTemplate } from './types';
+import { ConcreteNotification, Notification, NotificationContext, NotificationMessage, NotificationType, TranslationTemplate, getContext } from './types';
 import { prisma } from '../prisma';
 import { compileTemplate, renderTemplate } from '../../utils/helpers';
 import { ClientError } from '../util/error';
 import { MessageTemplateType, NotificationMessageType } from '../../graphql/types/notificationMessage';
-import { getContext } from '.';
 import { getUser } from '../user';
 import { getLogger } from '../logger/logger';
 

--- a/common/notification/messages.ts
+++ b/common/notification/messages.ts
@@ -83,6 +83,11 @@ async function loadTemplate(notificationID: number, language: TranslationLanguag
     return template;
 }
 
+export async function hasMessage(notificationId: number) {
+    const template = await loadTemplate(notificationId, TranslationLanguage.de);
+    return !!template;
+}
+
 // Renders a Message for a certain Concrete Notification
 export async function getMessage(
     concreteNotification: Pick<ConcreteNotification, 'id' | 'notificationID' | 'userId' | 'context'>,

--- a/common/notification/messages.ts
+++ b/common/notification/messages.ts
@@ -85,7 +85,7 @@ async function loadTemplate(notificationID: number, language: TranslationLanguag
 
 // Renders a Message for a certain Concrete Notification
 export async function getMessage(
-    concreteNotification: ConcreteNotification,
+    concreteNotification: Pick<ConcreteNotification, 'id' | 'notificationID' | 'userId' | 'context'>,
     language: TranslationLanguage = TranslationLanguage.de
 ): Promise<NotificationMessageType | null> {
     const template = await loadTemplate(concreteNotification.notificationID, language);

--- a/common/notification/types.ts
+++ b/common/notification/types.ts
@@ -1,8 +1,9 @@
 // Prisma exports lowercase types, but we want capitalized types
 import { concrete_notification as ConcreteNotification, notification as Notification, student as Student, pupil as Pupil } from '.prisma/client';
 import { AttachmentGroup } from '../attachments';
-import { User } from '../user';
+import { User, getFullName } from '../user';
 import { ActionID } from './actions';
+import { USER_APP_DOMAIN } from '../util/environment';
 
 export type NotificationID = number; // either our own or we reuse them from Mailjet. Maybe we can structure them a bit better
 export type CategoryID = string; // categories as means to opt out from a certain category of mails
@@ -65,6 +66,14 @@ export interface NotificationContext extends NotificationContextExtensions {
 export interface Context extends NotificationContext {
     user: User & { fullName: string };
     USER_APP_DOMAIN: string;
+}
+
+export function getContext(notificationContext: NotificationContext, user: User): Context {
+    return {
+        ...notificationContext,
+        user: { ...user, fullName: getFullName(user) },
+        USER_APP_DOMAIN,
+    };
 }
 
 // Abstract away from the core: Channels are our Ports to external notification systems (Mailjet, SMS, ...)


### PR DESCRIPTION
It is not so easy to establish a backend connection in the webworker - thus it seems easier to just include the whole message to show in the push notification itself. As we decrypt the message using the client key, only the client can read it - so there should be no privacy problems - as users need to trust their browsers anyways.

https://github.com/corona-school/project-user/issues/606