### PR TITLE
fix: Filter out canceled appointments

### DIFF
--- a/common/courses/states.ts
+++ b/common/courses/states.ts
@@ -155,7 +155,7 @@ export async function canPublish(subcourse: Subcourse): Promise<Decision> {
         return { allowed: false, reason: 'course-not-allowed' };
     }
 
-    const lectures = await prisma.lecture.findMany({ where: { subcourseId: subcourse.id } });
+    const lectures = await prisma.lecture.findMany({ where: { subcourseId: subcourse.id, isCanceled: false } });
     if (lectures.length == 0) {
         return { allowed: false, reason: 'no-lectures' };
     }


### PR DESCRIPTION
## What was done?

Filter out canceled appointments when checking if a course can be published.

_(I'll merge it to test it on STG as well before releasing it)_ Please review anyway :)