### PR TITLE
Feat: Soft delete course tags

### DIFF
--- a/graphql/authorizations.ts
+++ b/graphql/authorizations.ts
@@ -624,7 +624,7 @@ export const authorizationModelEnhanceMap: ModelsEnhanceMap = {
         },
     },
     Course_tag: {
-        fields: withPublicFields<CourseTag, 'id' | 'name' | 'category'>({
+        fields: withPublicFields<CourseTag, 'id' | 'name' | 'category' | 'active'>({
             identifier: nobody,
             _count: nobody,
             course_tags_course_tag: nobody,

--- a/graphql/course/fields.ts
+++ b/graphql/course/fields.ts
@@ -59,9 +59,12 @@ export class ExtendedFieldsCourseResolver {
 
     @Query((returns) => [CourseTag])
     @Authorized(Role.UNAUTHENTICATED)
-    async courseTags(@Arg('category') category: CourseCategory) {
+    async courseTags(@Ctx() context: GraphQLContext, @Arg('category') category: CourseCategory) {
+        const { user } = context;
+        const isAdmin = user.roles.includes(Role.ADMIN);
+        const userFilters = !isAdmin ? { active: true } : null;
         return await prisma.course_tag.findMany({
-            where: { category },
+            where: { category, ...userFilters },
         });
     }
 

--- a/graphql/course/mutations.ts
+++ b/graphql/course/mutations.ts
@@ -265,6 +265,23 @@ export class MutateCourseResolver {
         return tag;
     }
 
+    @Mutation((returns) => Boolean)
+    @Authorized(Role.ADMIN, Role.COURSE_SCREENER)
+    async courseTagActivate(@Ctx() context: GraphQLContext, @Arg('courseTagId') courseTagId: number, @Arg('active') active: boolean) {
+        const tag = await prisma.course_tag.findUnique({ where: { id: courseTagId } });
+        if (!tag) {
+            throw new UserInputError(`Unknown CourseTag(${courseTagId})`);
+        }
+
+        await prisma.course_tag.update({
+            where: { id: courseTagId },
+            data: { active },
+        });
+
+        logger.info(`User(${context.user.userID}) ${active ? 'activated' : 'deactivated'} CourseTag(${tag.id})`);
+        return true;
+    }
+
     @Mutation((returns) => GraphQLModel.Course_tag)
     @Authorized(Role.ADMIN, Role.COURSE_SCREENER)
     async courseTagDelete(@Ctx() context: GraphQLContext, @Arg('courseTagId') courseTagId: number) {

--- a/prisma/migrations/20240710090706_add_active_field_to_course_tag/migration.sql
+++ b/prisma/migrations/20240710090706_add_active_field_to_course_tag/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "course_tag" ADD COLUMN     "active" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -246,6 +246,7 @@ model course_tag {
   name                   String                   @db.VarChar
   category               String                   @db.VarChar
   course_tags_course_tag course_tags_course_tag[]
+  active                 Boolean                  @default(true)
 }
 
 model course_tags_course_tag {


### PR DESCRIPTION
## Ticket

https://github.com/corona-school/project-user/issues/1270

## What was done?

- Added `active` field on course_tag model
- Added mutation to activate/deactivate course_tags
- Return only active tags to all users except admins