### PR TITLE
fix: If pupils leave a course, add other pupils from the waiting list & Avoid annoying course instructors with notifications

### DIFF
--- a/common/courses/participants.ts
+++ b/common/courses/participants.ts
@@ -15,6 +15,7 @@ import { ChatType } from '../chat/types';
 import { isChatFeatureActive } from '../chat/util';
 import { getCourseOfSubcourse, getSubcourseInstructors, removeSubcourseProspect } from './util';
 import { getNotificationContextForSubcourse } from '../courses/notifications';
+import { getLastLecture } from './lectures';
 
 const delay = (time: number) => new Promise((res) => setTimeout(res, time));
 
@@ -122,6 +123,7 @@ type CourseDecision =
     | 'grade-to-low'
     | 'grade-to-high'
     | 'already-started'
+    | 'already-ended'
     | 'already-participant'
     | 'already-on-waitinglist';
 
@@ -160,6 +162,13 @@ async function subcourseJoinable(subcourse: Subcourse): Promise<Decision<CourseD
     if (firstLecture[0].start < new Date() && !subcourse.joinAfterStart) {
         return { allowed: false, reason: 'already-started' };
     }
+
+    const lastLecture = await getLastLecture(subcourse);
+    if (lastLecture.start < new Date()) {
+        return { allowed: false, reason: 'already-ended' };
+    }
+
+    return { allowed: true };
 }
 
 // Whether the pupil could join the course if the course was not full (i.e. pupils can still join the waitinglist)

--- a/graphql/subcourse/mutations.ts
+++ b/graphql/subcourse/mutations.ts
@@ -283,7 +283,7 @@ export class MutateSubcourseResolver {
         }
 
         // Joining the subcourse will automatically remove the pupil from the waitinglist
-        await joinSubcourse(subcourse, pupil, true);
+        await joinSubcourse(subcourse, pupil, true, /* notifyIfFull */ false);
         logger.info(`Pupil(${pupilId}) joined Subcourse(${subcourseId}) from waitinglist`);
         return true;
     }
@@ -314,7 +314,7 @@ export class MutateSubcourseResolver {
                 include: { lecture: true, subcourse_instructors_student: false },
             });
         }
-        await joinSubcourse(subcourse, pupil, true);
+        await joinSubcourse(subcourse, pupil, true, /* notifyIfFull */ false);
         logger.info(`Pupil(${pupilId}) joined Subcourse(${subcourseId}) from prospects`);
         return true;
     }


### PR DESCRIPTION
- If a pupil leaves a course, the course is joinable and there are pupils on the waiting list, add pupils from the waiting list
- If a course is filled by the system, do not send a notification to the instructor (either the instructor themself requested it, support did it on behalf of the instructor, or we fill the subcourse after a pupil left the subcourse, so it was full and now is full again)

resolves https://github.com/corona-school/project-user/issues/1271