### PR TITLE
fix: use live endpoint to remove webflow collection item

### DIFF
--- a/jobs/periodic/sync-to-webflow/webflow-adapter.ts
+++ b/jobs/periodic/sync-to-webflow/webflow-adapter.ts
@@ -55,7 +55,7 @@ export async function createNewItem<T extends WebflowMetadata>(collectionID: str
 
 export async function deleteItems(collectionId: string, itemIds: string[]) {
     for (const id of itemIds) {
-        await request({ path: `v2/collections/${collectionId}/items/${id}`, method: 'DELETE' });
+        await request({ path: `v2/collections/${collectionId}/items/${id}/live`, method: 'DELETE' });
     }
 }
 


### PR DESCRIPTION
This PR should fix the issue of old courses on the website. It will ensure that deleted collection items will be unpublished automatically.