### PR TITLE
fix: fully delete webflow collection items

### DIFF
--- a/jobs/periodic/sync-to-webflow/webflow-adapter.ts
+++ b/jobs/periodic/sync-to-webflow/webflow-adapter.ts
@@ -56,6 +56,7 @@ export async function createNewItem<T extends WebflowMetadata>(collectionID: str
 export async function deleteItems(collectionId: string, itemIds: string[]) {
     for (const id of itemIds) {
         await request({ path: `v2/collections/${collectionId}/items/${id}/live`, method: 'DELETE' });
+        await request({ path: `v2/collections/${collectionId}/items/${id}`, method: 'DELETE' });
     }
 }
 


### PR DESCRIPTION
By definition `DELETE /items/{id}/live` is
```
Removing a published item will unpublish the item from the live site and set it to draft.
```

This is a problem as it might be published in the future again. Therefore, this PR will call `DELETE /items/{id}` afterwards to finally delete the draft.