### PR TITLE
feat: Matching algo performance + Exclude duplicate matchings

### DIFF
--- a/common/match/matching.perf.pupil.json
+++ b/common/match/matching.perf.pupil.json
@@ -1,6269 +1,7314 @@
 [
   {
+    "id": 28401,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "13. Klasse",
     "requestAt": "2022-08-25 17:51:28.769"
   },
   {
+    "id": 22015,
     "subjects": "[{\"name\":\"Mathematik\"},{\"name\":\"Chemie\"}]",
     "state": "bw",
     "grade": "13. Klasse",
     "requestAt": "2022-09-22 08:39:47.383"
   },
   {
+    "id": 27343,
     "subjects": "[{\"name\":\"Englisch\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Mathematik\",\"minGrade\":1,\"maxGrade\":13}]",
     "state": "nw",
     "grade": "7. Klasse",
     "requestAt": "2022-10-21 20:40:39.821"
   },
   {
+    "id": 28535,
     "subjects": "[{\"name\":\"Englisch\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Mathematik\",\"minGrade\":1,\"maxGrade\":13}]",
     "state": "th",
     "grade": "12. Klasse",
     "requestAt": "2022-10-26 16:13:28.125"
   },
   {
+    "id": 13978,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "7. Klasse",
     "requestAt": "2022-11-04 09:15:00.443"
   },
   {
+    "id": 13978,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "7. Klasse",
     "requestAt": "2022-11-04 09:15:00.443"
   },
   {
+    "id": 25692,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "bb",
     "grade": "12. Klasse",
     "requestAt": "2022-11-11 11:01:12.448"
   },
   {
+    "id": 14047,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "5. Klasse",
     "requestAt": "2022-11-11 11:04:39.991"
   },
   {
+    "id": 15243,
     "subjects": "[{\"name\":\"Französisch\"},{\"name\":\"Englisch\"},{\"name\":\"Deutsch\"},{\"name\":\"Mathematik\"}]",
     "state": "bw",
     "grade": "8. Klasse",
     "requestAt": "2022-11-15 08:32:17.028"
   },
   {
+    "id": 28363,
     "subjects": "[{\"name\":\"Deutsch\"},{\"name\":\"Mathematik\"},{\"name\":\"Spanisch\"},{\"name\":\"Musik\"},{\"name\":\"Chemie\"},{\"name\":\"Politik\"},{\"name\":\"Geschichte\"}]",
     "state": "mv",
     "grade": "12. Klasse",
     "requestAt": "2022-11-15 08:41:06.569"
   },
   {
+    "id": 22419,
     "subjects": "[{\"name\":\"Mathematik\"}]",
     "state": "sn",
     "grade": "11. Klasse",
     "requestAt": "2022-11-16 22:12:09.291"
   },
   {
+    "id": 22419,
     "subjects": "[{\"name\":\"Mathematik\"}]",
     "state": "sn",
     "grade": "11. Klasse",
     "requestAt": "2022-11-16 22:12:09.291"
   },
   {
+    "id": 27048,
     "subjects": "[{\"name\":\"Deutsch\"},{\"name\":\"Englisch\"}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2022-11-18 08:38:44.62"
   },
   {
+    "id": 27048,
     "subjects": "[{\"name\":\"Deutsch\"},{\"name\":\"Englisch\"}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2022-11-18 08:38:44.62"
   },
   {
+    "id": 28382,
     "subjects": "[{\"name\":\"Deutsch\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Französisch\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Mathematik\",\"minGrade\":1,\"maxGrade\":13}]",
     "state": "be",
     "grade": "7. Klasse",
     "requestAt": "2022-11-22 09:27:28.797"
   },
   {
+    "id": 28382,
     "subjects": "[{\"name\":\"Deutsch\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Französisch\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Mathematik\",\"minGrade\":1,\"maxGrade\":13}]",
     "state": "be",
     "grade": "7. Klasse",
     "requestAt": "2022-11-22 09:27:28.797"
   },
   {
+    "id": 20622,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "6. Klasse",
     "requestAt": "2022-11-23 21:19:06.215"
   },
   {
+    "id": 20623,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "by",
     "grade": "5. Klasse",
     "requestAt": "2022-11-23 21:25:48.876"
   },
   {
+    "id": 20623,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "by",
     "grade": "5. Klasse",
     "requestAt": "2022-11-23 21:25:48.876"
   },
   {
+    "id": 28608,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "13. Klasse",
     "requestAt": "2022-11-25 08:21:01.309"
   },
   {
+    "id": 26505,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "8. Klasse",
     "requestAt": "2022-11-25 08:46:04.468"
   },
   {
+    "id": 26016,
     "subjects": "[{\"name\":\"Spanisch\"},{\"name\":\"Deutsch\"},{\"name\":\"Mathematik\"}]",
     "state": "he",
     "grade": "9. Klasse",
     "requestAt": "2022-12-02 09:14:00.496"
   },
   {
+    "id": 7983,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
     "state": "be",
     "grade": "10. Klasse",
     "requestAt": "2022-12-28 14:28:05.649"
   },
   {
+    "id": 25833,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2023-01-06 10:33:08.376"
   },
   {
+    "id": 19164,
     "subjects": "[{\"name\":\"Mathematik\"},{\"name\":\"Deutsch\"},{\"name\":\"Englisch\"}]",
     "state": "he",
     "grade": "9. Klasse",
     "requestAt": "2023-01-10 11:00:52.529"
   },
   {
+    "id": 27596,
     "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2023-01-18 08:03:17.14"
   },
   {
+    "id": 27596,
     "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2023-01-18 08:03:17.14"
   },
   {
+    "id": 25837,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":null},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Informatik\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "6. Klasse",
     "requestAt": "2023-01-27 08:55:21.84"
   },
   {
+    "id": 27320,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2023-01-27 08:58:56.654"
   },
   {
+    "id": 27320,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2023-01-27 08:58:56.654"
   },
   {
+    "id": 26789,
     "subjects": "[{\"name\":\"Spanisch\"}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2023-02-01 10:03:49.042"
   },
   {
+    "id": 20301,
     "subjects": "[{\"name\":\"Deutsch\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Mathematik\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Englisch\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Physik\",\"minGrade\":1,\"maxGrade\":13}]",
     "state": "nw",
     "grade": "6. Klasse",
     "requestAt": "2023-02-01 19:48:12.471"
   },
   {
+    "id": 26288,
     "subjects": "[{\"name\":\"Mathematik\"},{\"name\":\"Deutsch\"}]",
     "state": "he",
     "grade": "6. Klasse",
     "requestAt": "2023-02-15 18:03:24.829"
   },
   {
+    "id": 16513,
     "subjects": "[{\"name\":\"Französisch\"},{\"name\":\"Mathematik\"}]",
     "state": "sl",
     "grade": "7. Klasse",
     "requestAt": "2023-02-21 09:09:56.146"
   },
   {
+    "id": 28415,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\"}]",
     "state": "nw",
     "grade": "2. Klasse",
     "requestAt": "2023-02-25 18:23:13.4"
   },
   {
+    "id": 28851,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "11. Klasse",
     "requestAt": "2023-02-27 08:49:58.433"
   },
   {
+    "id": 28799,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":null},{\"name\":\"Spanisch\",\"mandatory\":true},{\"name\":\"Erdkunde\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "13. Klasse",
     "requestAt": "2023-02-27 10:17:19.676"
   },
   {
+    "id": 13084,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "9. Klasse",
     "requestAt": "2023-02-27 21:04:14.284"
   },
   {
+    "id": 5543,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "8. Klasse",
     "requestAt": "2023-02-27 21:07:36.518"
   },
   {
+    "id": 26158,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "3. Klasse",
     "requestAt": "2023-02-27 21:53:04.704"
   },
   {
+    "id": 10271,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "5. Klasse",
     "requestAt": "2023-02-28 03:04:44.218"
   },
   {
+    "id": 10612,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":null}]",
     "state": "bw",
     "grade": "10. Klasse",
     "requestAt": "2023-02-28 05:17:16.361"
   },
   {
+    "id": 27287,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "5. Klasse",
     "requestAt": "2023-02-28 07:07:48.659"
   },
   {
+    "id": 17225,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "6. Klasse",
     "requestAt": "2023-02-28 08:46:14.703"
   },
   {
+    "id": 17812,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":null},{\"name\":\"Englisch\",\"mandatory\":null},{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "7. Klasse",
     "requestAt": "2023-02-28 11:10:30.77"
   },
   {
+    "id": 4126,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "6. Klasse",
     "requestAt": "2023-02-28 16:27:25.675"
   },
   {
+    "id": 12606,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false}]",
     "state": "other",
     "grade": "10. Klasse",
     "requestAt": "2023-02-28 16:46:59.211"
   },
   {
+    "id": 4737,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":null},{\"name\":\"Deutsch\",\"mandatory\":null},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2023-02-28 19:10:06.539"
   },
   {
+    "id": 28875,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "by",
     "grade": "7. Klasse",
     "requestAt": "2023-02-28 20:40:59.631"
   },
   {
+    "id": 28876,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "6. Klasse",
     "requestAt": "2023-02-28 20:48:07.644"
   },
   {
+    "id": 25061,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "5. Klasse",
     "requestAt": "2023-02-28 20:52:24.875"
   },
   {
+    "id": 28878,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "ni",
     "grade": "13. Klasse",
     "requestAt": "2023-03-01 10:32:43.534"
   },
   {
+    "id": 25833,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2023-03-01 21:28:12.264"
   },
   {
+    "id": 18563,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":null}]",
     "state": "bw",
     "grade": "12. Klasse",
     "requestAt": "2023-03-02 16:48:26.477"
   },
   {
+    "id": 27398,
     "subjects": "[{\"name\":\"Deutsch\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Mathematik\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Musik\",\"minGrade\":1,\"maxGrade\":13}]",
     "state": "rp",
     "grade": "4. Klasse",
     "requestAt": "2023-03-02 20:15:01.751"
   },
   {
+    "id": 25910,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "4. Klasse",
     "requestAt": "2023-03-03 13:34:38.399"
   },
   {
+    "id": 26813,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "he",
     "grade": "7. Klasse",
     "requestAt": "2023-03-03 20:54:07.542"
   },
   {
+    "id": 27679,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "by",
     "grade": "8. Klasse",
     "requestAt": "2023-03-05 11:59:53.975"
   },
   {
+    "id": 28356,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "be",
     "grade": "3. Klasse",
     "requestAt": "2023-03-06 07:01:44.071"
   },
   {
+    "id": 28581,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Sachkunde\",\"mandatory\":null},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "3. Klasse",
     "requestAt": "2023-03-07 00:48:15.224"
   },
   {
+    "id": 28922,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2023-03-07 14:56:32.487"
   },
   {
+    "id": 28932,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "6. Klasse",
     "requestAt": "2023-03-09 14:35:07.244"
   },
   {
+    "id": 28249,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2023-03-10 05:56:22.014"
   },
   {
+    "id": 26851,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "sn",
     "grade": "9. Klasse",
     "requestAt": "2023-03-10 08:07:28.48"
   },
   {
+    "id": 28934,
     "subjects": "[{\"name\":\"Wirtschaft\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2023-03-10 14:53:08.082"
   },
   {
+    "id": 27131,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "9. Klasse",
     "requestAt": "2023-03-10 15:39:05.209"
   },
   {
+    "id": 28935,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "9. Klasse",
     "requestAt": "2023-03-10 15:51:58.837"
   },
   {
+    "id": 11124,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "by",
     "grade": "12. Klasse",
     "requestAt": "2023-03-12 19:16:20.093"
   },
   {
+    "id": 26070,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "10. Klasse",
     "requestAt": "2023-03-13 09:17:29.385"
   },
   {
+    "id": 28249,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2023-03-15 15:41:26.667"
   },
   {
+    "id": 25848,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "he",
     "grade": "6. Klasse",
     "requestAt": "2023-03-17 20:52:26.525"
   },
   {
+    "id": 26054,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "7. Klasse",
     "requestAt": "2023-03-18 12:05:22.636"
   },
   {
+    "id": 26227,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "6. Klasse",
     "requestAt": "2023-03-19 21:57:41.744"
   },
   {
+    "id": 28952,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2023-03-21 15:10:30.89"
   },
   {
+    "id": 22303,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "ni",
     "grade": "11. Klasse",
     "requestAt": "2023-03-21 17:15:42.878"
   },
   {
+    "id": 28955,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "6. Klasse",
     "requestAt": "2023-03-21 22:16:43.212"
   },
   {
+    "id": 28563,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "4. Klasse",
     "requestAt": "2023-03-22 06:34:03.322"
   },
   {
+    "id": 28964,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "9. Klasse",
     "requestAt": "2023-03-25 12:35:54.169"
   },
   {
+    "id": 28965,
     "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2023-03-25 20:00:43.034"
   },
   {
+    "id": 28823,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "be",
     "grade": "9. Klasse",
     "requestAt": "2023-03-26 13:58:25.263"
   },
   {
+    "id": 26250,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "ni",
     "grade": "12. Klasse",
     "requestAt": "2023-03-27 10:34:48.426"
   },
   {
+    "id": 27137,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "5. Klasse",
     "requestAt": "2023-03-27 10:34:49.12"
   },
   {
+    "id": 26928,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "bb",
     "grade": "6. Klasse",
     "requestAt": "2023-03-27 17:18:33.875"
   },
   {
+    "id": 26158,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "3. Klasse",
     "requestAt": "2023-03-27 19:38:58.598"
   },
   {
+    "id": 25530,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "4. Klasse",
     "requestAt": "2023-03-29 07:23:04.292"
   },
   {
+    "id": 4390,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "other",
     "grade": "10. Klasse",
     "requestAt": "2023-03-29 08:30:02.098"
   },
   {
+    "id": 26911,
     "subjects": "[{\"name\":\"Latein\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "6. Klasse",
     "requestAt": "2023-03-29 09:02:32.853"
   },
   {
+    "id": 26640,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "6. Klasse",
     "requestAt": "2023-04-01 07:34:33.978"
   },
   {
+    "id": 27887,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "3. Klasse",
     "requestAt": "2023-04-01 16:31:30.751"
   },
   {
+    "id": 28976,
     "subjects": "[{\"name\":\"Wirtschaft\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2023-04-02 08:47:35.345"
   },
   {
+    "id": 4451,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "by",
     "grade": "11. Klasse",
     "requestAt": "2023-04-03 04:53:25.117"
   },
   {
+    "id": 23301,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "7. Klasse",
     "requestAt": "2023-04-03 06:19:57.448"
   },
   {
+    "id": 11435,
     "subjects": "[{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "11. Klasse",
     "requestAt": "2023-04-03 06:21:47.12"
   },
   {
+    "id": 17478,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2023-04-03 08:19:00.749"
   },
   {
+    "id": 27751,
     "subjects": "[{\"name\":\"Mathematik\"}]",
     "state": "bw",
     "grade": "4. Klasse",
     "requestAt": "2023-04-03 13:04:25.388"
   },
   {
+    "id": 27572,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "6. Klasse",
     "requestAt": "2023-04-03 17:23:26.534"
   },
   {
+    "id": 26289,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "7. Klasse",
     "requestAt": "2023-04-05 16:30:20.471"
   },
   {
+    "id": 25926,
     "subjects": "[{\"name\":\"Deutsch\"},{\"name\":\"Englisch\"}]",
     "state": "sh",
     "grade": "13. Klasse",
     "requestAt": "2023-04-07 08:25:22.699"
   },
   {
+    "id": 27493,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "by",
     "grade": "4. Klasse",
     "requestAt": "2023-04-07 11:04:19.992"
   },
   {
+    "id": 29009,
     "subjects": "[{\"name\":\"Latein\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":false}]",
     "state": "sh",
     "grade": "9. Klasse",
     "requestAt": "2023-04-07 17:23:47.915"
   },
   {
+    "id": 28943,
     "subjects": "[{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Italienisch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Politik\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2023-04-08 13:50:54.17"
   },
   {
+    "id": 29011,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
     "state": "ni",
     "grade": "5. Klasse",
     "requestAt": "2023-04-09 21:07:11.894"
   },
   {
+    "id": 27984,
     "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2023-04-12 15:01:02.806"
   },
   {
+    "id": 27398,
     "subjects": "[{\"name\":\"Deutsch\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Mathematik\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Musik\",\"minGrade\":1,\"maxGrade\":13}]",
     "state": "rp",
     "grade": "4. Klasse",
     "requestAt": "2023-04-12 15:11:10.761"
   },
   {
+    "id": 26714,
     "subjects": "[{\"name\":\"Mathematik\",\"minGrade\":1,\"maxGrade\":13}]",
     "state": "sn",
     "grade": "6. Klasse",
     "requestAt": "2023-04-24 16:53:42.247"
   },
   {
+    "id": 27984,
     "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2023-04-24 17:32:52.476"
   },
   {
+    "id": 28019,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":null},{\"name\":\"Sachkunde\",\"mandatory\":null},{\"name\":\"Musik\",\"mandatory\":null},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "ni",
     "grade": "3. Klasse",
     "requestAt": "2023-04-27 12:03:47.647"
   },
   {
+    "id": 12364,
     "subjects": "[{ \"name\": \"Mathematik\" },{ \"name\": \"Deutsch\" },{ \"name\": \"Englisch\" }]",
     "state": "by",
     "grade": "7. Klasse",
     "requestAt": "2023-05-09 16:26:03.605"
   },
   {
+    "id": 12364,
     "subjects": "[{ \"name\": \"Mathematik\" },{ \"name\": \"Deutsch\" },{ \"name\": \"Englisch\" }]",
     "state": "by",
     "grade": "7. Klasse",
     "requestAt": "2023-05-09 16:26:03.605"
   },
   {
+    "id": 13807,
     "subjects": "[{\"name\":\"Latein\"}]",
     "state": "bw",
     "grade": "10. Klasse",
     "requestAt": "2023-05-10 15:38:54.198"
   },
   {
+    "id": 28935,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "9. Klasse",
     "requestAt": "2023-05-15 12:56:03.398"
   },
   {
+    "id": 28934,
     "subjects": "[{\"name\":\"Wirtschaft\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2023-05-15 16:31:41.456"
   },
   {
+    "id": 5313,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2023-05-16 15:29:17.127"
   },
   {
+    "id": 24066,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "be",
     "grade": "6. Klasse",
     "requestAt": "2023-05-16 16:46:03.22"
   },
   {
+    "id": 28774,
     "subjects": "[{\"name\":\"Deutsch\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Englisch\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Latein\",\"minGrade\":1,\"maxGrade\":13}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2023-05-16 16:47:51.24"
   },
   {
+    "id": 28794,
     "subjects": "[{\"name\":\"Mathematik\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Englisch\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Deutsch\",\"minGrade\":1,\"maxGrade\":13}]",
     "state": "he",
     "grade": "10. Klasse",
     "requestAt": "2023-05-17 14:33:14.591"
   },
   {
+    "id": 16815,
     "subjects": "[{\"name\":\"Englisch\"}]",
     "state": "nw",
     "grade": "11. Klasse",
     "requestAt": "2023-05-18 13:05:50.833"
   },
   {
+    "id": 28848,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "sn",
     "grade": "12. Klasse",
     "requestAt": "2023-05-19 18:21:58.937"
   },
   {
+    "id": 28550,
     "subjects": "[{\"name\":\"Biologie\",\"mandatory\":true},{\"name\":\"Erdkunde\",\"mandatory\":false}]",
     "state": "hh",
     "grade": "12. Klasse",
     "requestAt": "2023-05-25 08:05:01.939"
   },
   {
+    "id": 28925,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "he",
     "grade": "8. Klasse",
     "requestAt": "2023-05-26 08:21:22.623"
   },
   {
+    "id": 10612,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":null}]",
     "state": "bw",
     "grade": "10. Klasse",
     "requestAt": "2023-06-12 17:30:17.481"
   },
   {
+    "id": 11091,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Spanisch\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
     "state": "be",
     "grade": "13. Klasse",
     "requestAt": "2023-06-17 12:49:28.536"
   },
   {
+    "id": 19623,
     "subjects": "[{\"name\":\"Informatik\",\"mandatory\":true}]",
     "state": "hb",
     "grade": "13. Klasse",
     "requestAt": "2023-06-18 12:28:13.9"
   },
   {
+    "id": 27493,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "by",
     "grade": "4. Klasse",
     "requestAt": "2023-06-20 18:20:24.726"
   },
   {
+    "id": 16237,
     "subjects": "[{\"name\":\"Mathematik\"}]",
     "state": "bw",
     "grade": "10. Klasse",
     "requestAt": "2023-06-23 09:34:16.544"
   },
   {
+    "id": 15142,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":null},{\"name\":\"Latein\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "7. Klasse",
     "requestAt": "2023-06-28 11:29:18.397"
   },
   {
+    "id": 28637,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":null},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "6. Klasse",
     "requestAt": "2023-06-28 11:37:44.187"
   },
   {
+    "id": 14665,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":null},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "13. Klasse",
     "requestAt": "2023-06-28 11:42:08.514"
   },
   {
+    "id": 13712,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "by",
     "grade": "9. Klasse",
     "requestAt": "2023-06-28 12:04:32.057"
   },
   {
+    "id": 12074,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "he",
     "grade": "9. Klasse",
     "requestAt": "2023-06-28 12:10:46.35"
   },
   {
+    "id": 13480,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "bb",
     "grade": "9. Klasse",
     "requestAt": "2023-06-28 13:46:08.298"
   },
   {
+    "id": 28415,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\"}]",
     "state": "nw",
     "grade": "2. Klasse",
     "requestAt": "2023-06-28 20:20:30.554"
   },
   {
+    "id": 5648,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Politik\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
     "state": "ni",
     "grade": "10. Klasse",
     "requestAt": "2023-07-10 18:45:37.641"
   },
   {
+    "id": 13598,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Biologie\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "6. Klasse",
     "requestAt": "2023-07-11 09:07:16.118"
   },
   {
+    "id": 26071,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"minGrade\":1,\"maxGrade\":13}]",
     "state": "nw",
     "grade": "4. Klasse",
     "requestAt": "2023-07-11 19:13:30.586"
   },
   {
+    "id": 26071,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"minGrade\":1,\"maxGrade\":13}]",
     "state": "nw",
     "grade": "4. Klasse",
     "requestAt": "2023-07-11 19:13:30.586"
   },
   {
+    "id": 28976,
     "subjects": "[{\"name\":\"Wirtschaft\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2023-07-13 15:32:38.5"
   },
   {
+    "id": 4451,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "by",
     "grade": "11. Klasse",
     "requestAt": "2023-07-17 15:30:02.401"
   },
   {
+    "id": 21566,
     "subjects": "[{\"name\":\"Erdkunde\"},{\"name\":\"Mathematik\"},{\"name\":\"Englisch\"},{\"name\":\"Biologie\"},{\"name\":\"Deutsch\"}]",
     "state": "rp",
     "grade": "9. Klasse",
     "requestAt": "2023-07-24 08:09:19.222"
   },
   {
+    "id": 29304,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "by",
     "grade": "6. Klasse",
     "requestAt": "2023-07-31 10:41:09.494"
   },
   {
+    "id": 27379,
     "subjects": "[{\"name\":\"Latein\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "11. Klasse",
     "requestAt": "2023-08-01 12:04:31.98"
   },
   {
+    "id": 29305,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "he",
     "grade": "6. Klasse",
     "requestAt": "2023-08-01 19:49:41.058"
   },
   {
+    "id": 29306,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "9. Klasse",
     "requestAt": "2023-08-03 14:22:14.915"
   },
   {
+    "id": 20281,
     "subjects": "[{\"name\":\"Englisch\"}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2023-08-03 14:51:59.492"
   },
   {
+    "id": 26070,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "10. Klasse",
     "requestAt": "2023-08-04 13:04:17.194"
   },
   {
+    "id": 19151,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "ni",
     "grade": "5. Klasse",
     "requestAt": "2023-08-05 21:49:49.113"
   },
   {
+    "id": 29223,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "he",
     "grade": "3. Klasse",
     "requestAt": "2023-08-06 09:21:27.505"
   },
   {
+    "id": 25940,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "6. Klasse",
     "requestAt": "2023-08-06 20:33:22.771"
   },
   {
+    "id": 28563,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "4. Klasse",
     "requestAt": "2023-08-07 18:15:21.508"
   },
   {
+    "id": 25570,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "11. Klasse",
     "requestAt": "2023-08-08 00:17:21.887"
   },
   {
+    "id": 13385,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Musik\",\"mandatory\":false},{\"name\":\"Kunst\",\"mandatory\":false}]",
     "state": "he",
     "grade": "5. Klasse",
     "requestAt": "2023-08-08 09:04:35.377"
   },
   {
+    "id": 27046,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2023-08-08 15:28:06.932"
   },
   {
+    "id": 26911,
     "subjects": "[{\"name\":\"Latein\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "6. Klasse",
     "requestAt": "2023-08-09 17:41:57.161"
   },
   {
+    "id": 28934,
     "subjects": "[{\"name\":\"Wirtschaft\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2023-08-10 14:33:37.579"
   },
   {
+    "id": 29339,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2023-08-10 18:23:32.921"
   },
   {
+    "id": 27320,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2023-08-11 12:27:34.987"
   },
   {
+    "id": 27984,
     "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2023-08-11 12:32:28.866"
   },
   {
+    "id": 13978,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "7. Klasse",
     "requestAt": "2023-08-12 02:13:22.915"
   },
   {
+    "id": 25977,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2023-08-13 09:58:45.124"
   },
   {
+    "id": 28848,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "sn",
     "grade": "12. Klasse",
     "requestAt": "2023-08-13 18:16:52.163"
   },
   {
+    "id": 27369,
     "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2023-08-14 15:18:42.711"
   },
   {
+    "id": 29346,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "ni",
     "grade": "13. Klasse",
     "requestAt": "2023-08-14 15:22:52.827"
   },
   {
+    "id": 9563,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false}]",
     "state": "ni",
     "grade": "11. Klasse",
     "requestAt": "2023-08-14 17:57:44.1"
   },
   {
+    "id": 1500,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false}]",
     "state": "th",
     "grade": "9. Klasse",
     "requestAt": "2023-08-14 19:44:26.803"
   },
   {
+    "id": 25833,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2023-08-15 05:59:40.563"
   },
   {
+    "id": 29348,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "ni",
     "grade": "3. Klasse",
     "requestAt": "2023-08-15 12:47:58.4"
   },
   {
+    "id": 19325,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2023-08-16 15:23:34.597"
   },
   {
+    "id": 29181,
     "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2023-08-16 15:41:08.601"
   },
   {
+    "id": 29360,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "he",
     "grade": "4. Klasse",
     "requestAt": "2023-08-16 16:40:13.916"
   },
   {
+    "id": 29369,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "4. Klasse",
     "requestAt": "2023-08-17 09:27:20.782"
   },
   {
+    "id": 29370,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "3. Klasse",
     "requestAt": "2023-08-17 09:33:10.991"
   },
   {
+    "id": 21464,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2023-08-18 11:02:07.918"
   },
   {
+    "id": 29328,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "ni",
     "grade": "12. Klasse",
     "requestAt": "2023-08-19 13:28:39.864"
   },
   {
+    "id": 27434,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "7. Klasse",
     "requestAt": "2023-08-19 16:50:51.728"
   },
   {
+    "id": 10397,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "ni",
     "grade": "8. Klasse",
     "requestAt": "2023-08-20 14:36:02.342"
   },
   {
+    "id": 29378,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true},{\"name\":\"Informatik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "he",
     "grade": "13. Klasse",
     "requestAt": "2023-08-20 17:32:16.858"
   },
   {
+    "id": 29024,
     "subjects": "[{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "12. Klasse",
     "requestAt": "2023-08-21 07:21:33.97"
   },
   {
+    "id": 13084,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "9. Klasse",
     "requestAt": "2023-08-21 14:23:03.606"
   },
   {
+    "id": 29387,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "he",
     "grade": "10. Klasse",
     "requestAt": "2023-08-22 17:20:49.489"
   },
   {
+    "id": 28392,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
     "state": "be",
     "grade": "12. Klasse",
     "requestAt": "2023-08-22 18:00:24.329"
   },
   {
+    "id": 26808,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Latein\",\"mandatory\":true}]",
     "state": "by",
     "grade": "6. Klasse",
     "requestAt": "2023-08-23 09:50:32.68"
   },
   {
+    "id": 26471,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "13. Klasse",
     "requestAt": "2023-08-23 16:42:18.087"
   },
   {
+    "id": 28801,
     "subjects": "[{\"name\":\"Physik\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Latein\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Informatik\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false}]",
     "state": "sn",
     "grade": "10. Klasse",
     "requestAt": "2023-08-23 20:33:50.639"
   },
   {
+    "id": 14546,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2023-08-24 11:58:08.356"
   },
   {
+    "id": 29391,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "6. Klasse",
     "requestAt": "2023-08-24 15:06:56.805"
   },
   {
+    "id": 19325,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2023-08-24 17:12:57.661"
   },
   {
+    "id": 27700,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":null},{\"name\":\"Russisch\",\"mandatory\":null},{\"name\":\"Informatik\",\"mandatory\":null}]",
     "state": "bw",
     "grade": "9. Klasse",
     "requestAt": "2023-08-25 08:20:45.827"
   },
   {
+    "id": 13879,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2023-08-25 09:46:23.359"
   },
   {
+    "id": 23588,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":null},{\"name\":\"Biologie\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2023-08-25 09:51:02.788"
   },
   {
+    "id": 19320,
     "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true}]",
     "state": "hh",
     "grade": "13. Klasse",
     "requestAt": "2023-08-25 10:14:10.9"
   },
   {
+    "id": 13879,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2023-08-25 10:43:34.318"
   },
   {
+    "id": 22767,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "he",
     "grade": "4. Klasse",
     "requestAt": "2023-08-25 11:29:21.642"
   },
   {
+    "id": 804,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "9. Klasse",
     "requestAt": "2023-08-25 18:34:59.241"
   },
   {
+    "id": 18516,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "11. Klasse",
     "requestAt": "2023-08-25 23:17:45.543"
   },
   {
+    "id": 18008,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "9. Klasse",
     "requestAt": "2023-08-26 03:08:56.753"
   },
   {
+    "id": 17654,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Musik\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "9. Klasse",
     "requestAt": "2023-08-26 17:32:30.907"
   },
   {
+    "id": 14665,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":null},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "13. Klasse",
     "requestAt": "2023-08-26 17:42:01.492"
   },
   {
+    "id": 26289,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "7. Klasse",
     "requestAt": "2023-08-27 07:48:38.515"
   },
   {
+    "id": 28392,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
     "state": "be",
     "grade": "12. Klasse",
     "requestAt": "2023-08-27 14:13:29.399"
   },
   {
+    "id": 17225,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "6. Klasse",
     "requestAt": "2023-08-28 08:26:16.514"
   },
   {
+    "id": 28655,
     "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "12. Klasse",
     "requestAt": "2023-08-28 12:39:32.251"
   },
   {
+    "id": 24952,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "be",
     "grade": "5. Klasse",
     "requestAt": "2023-08-28 14:13:53.986"
   },
   {
+    "id": 28356,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "be",
     "grade": "3. Klasse",
     "requestAt": "2023-08-28 14:16:41.842"
   },
   {
+    "id": 29240,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "be",
     "grade": "6. Klasse",
     "requestAt": "2023-08-28 20:27:34.985"
   },
   {
+    "id": 29408,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "10. Klasse",
     "requestAt": "2023-08-29 18:41:09.487"
   },
   {
+    "id": 15901,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "sh",
     "grade": "9. Klasse",
     "requestAt": "2023-08-30 14:34:07.361"
   },
   {
+    "id": 29412,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "be",
     "grade": "9. Klasse",
     "requestAt": "2023-08-31 00:16:02.91"
   },
   {
+    "id": 29414,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "th",
     "grade": "2. Klasse",
     "requestAt": "2023-08-31 04:48:10.944"
   },
   {
+    "id": 26149,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "5. Klasse",
     "requestAt": "2023-08-31 12:38:38.071"
   },
   {
+    "id": 27618,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":null},{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":null},{\"name\":\"Spanisch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "12. Klasse",
     "requestAt": "2023-08-31 16:53:16.787"
   },
   {
+    "id": 25761,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "8. Klasse",
     "requestAt": "2023-08-31 18:25:21.093"
   },
   {
+    "id": 21103,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "8. Klasse",
     "requestAt": "2023-09-01 06:01:54.399"
   },
   {
+    "id": 29068,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Biologie\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "6. Klasse",
     "requestAt": "2023-09-01 06:43:27.503"
   },
   {
+    "id": 28868,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Philosophie\",\"mandatory\":false}]",
     "state": "hh",
     "grade": "13. Klasse",
     "requestAt": "2023-09-02 18:56:30.718"
   },
   {
+    "id": 28591,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":null},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Sachkunde\",\"mandatory\":false}]",
     "state": "sn",
     "grade": "5. Klasse",
     "requestAt": "2023-09-03 12:55:26.856"
   },
   {
+    "id": 4451,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "by",
     "grade": "11. Klasse",
     "requestAt": "2023-09-04 08:08:49.373"
   },
   {
+    "id": 29316,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "ni",
     "grade": "4. Klasse",
     "requestAt": "2023-09-04 22:57:04.642"
   },
   {
+    "id": 29432,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "5. Klasse",
     "requestAt": "2023-09-05 14:54:34.712"
   },
   {
+    "id": 14068,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "7. Klasse",
     "requestAt": "2023-09-05 19:57:17.988"
   },
   {
+    "id": 26640,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "6. Klasse",
     "requestAt": "2023-09-05 22:31:16.394"
   },
   {
+    "id": 27012,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "8. Klasse",
     "requestAt": "2023-09-06 14:43:29.107"
   },
   {
+    "id": 19623,
     "subjects": "[{\"name\":\"Informatik\",\"mandatory\":true}]",
     "state": "hb",
     "grade": "13. Klasse",
     "requestAt": "2023-09-08 09:49:22.146"
   },
   {
+    "id": 27692,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "4. Klasse",
     "requestAt": "2023-09-10 12:06:49.979"
   },
   {
+    "id": 29448,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "ni",
     "grade": "6. Klasse",
     "requestAt": "2023-09-10 12:24:54.726"
   },
   {
+    "id": 17114,
     "subjects": "[{\"name\":\"Latein\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Musik\",\"mandatory\":false}]",
     "state": "by",
     "grade": "10. Klasse",
     "requestAt": "2023-09-11 14:33:44.279"
   },
   {
+    "id": 15018,
     "subjects": "[{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "sn",
     "grade": "9. Klasse",
     "requestAt": "2023-09-11 16:29:49.495"
   },
   {
+    "id": 19623,
     "subjects": "[{\"name\":\"Informatik\",\"mandatory\":true}]",
     "state": "hb",
     "grade": "13. Klasse",
     "requestAt": "2023-09-11 21:06:49.862"
   },
   {
+    "id": 29454,
     "subjects": "[{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Politik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
     "state": "he",
     "grade": "9. Klasse",
     "requestAt": "2023-09-12 13:32:18.684"
   },
   {
+    "id": 19157,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":null}]",
     "state": "he",
     "grade": "8. Klasse",
     "requestAt": "2023-09-12 15:42:34.379"
   },
   {
+    "id": 29456,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Chinesisch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2023-09-12 16:55:56.104"
   },
   {
+    "id": 29457,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "9. Klasse",
     "requestAt": "2023-09-12 17:11:22.219"
   },
   {
+    "id": 29339,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2023-09-12 19:48:53.342"
   },
   {
+    "id": 29438,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "5. Klasse",
     "requestAt": "2023-09-12 19:57:18.575"
   },
   {
+    "id": 29459,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "ni",
     "grade": "6. Klasse",
     "requestAt": "2023-09-12 20:17:24.669"
   },
   {
+    "id": 20535,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Latein\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2023-09-13 08:59:33.775"
   },
   {
+    "id": 27287,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "5. Klasse",
     "requestAt": "2023-09-13 13:49:07.461"
   },
   {
+    "id": 28801,
     "subjects": "[{\"name\":\"Physik\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Latein\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Informatik\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false}]",
     "state": "sn",
     "grade": "10. Klasse",
     "requestAt": "2023-09-14 08:26:47.362"
   },
   {
+    "id": 24071,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":null},{\"name\":\"Informatik\",\"mandatory\":null}]",
     "state": "by",
     "grade": "11. Klasse",
     "requestAt": "2023-09-14 08:33:20.542"
   },
   {
+    "id": 29465,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "sn",
     "grade": "9. Klasse",
     "requestAt": "2023-09-15 11:54:35.614"
   },
   {
+    "id": 759,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":null},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "sn",
     "grade": "8. Klasse",
     "requestAt": "2023-09-15 12:01:26.807"
   },
   {
+    "id": 25977,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2023-09-16 11:38:07.131"
   },
   {
+    "id": 29468,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "be",
     "grade": "8. Klasse",
     "requestAt": "2023-09-16 16:34:32.636"
   },
   {
+    "id": 18341,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "8. Klasse",
     "requestAt": "2023-09-16 22:19:46.152"
   },
   {
+    "id": 4002,
     "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "13. Klasse",
     "requestAt": "2023-09-18 11:08:59.961"
   },
   {
+    "id": 13332,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
     "state": "be",
     "grade": "10. Klasse",
     "requestAt": "2023-09-18 15:32:40.951"
   },
   {
+    "id": 28977,
     "subjects": "[{\"name\":\"Pädagogik\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2023-09-18 16:35:18.32"
   },
   {
+    "id": 28955,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "6. Klasse",
     "requestAt": "2023-09-18 23:19:06.115"
   },
   {
+    "id": 18771,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "4. Klasse",
     "requestAt": "2023-09-19 17:00:15.205"
   },
   {
+    "id": 27852,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "4. Klasse",
     "requestAt": "2023-09-19 18:12:48.304"
   },
   {
+    "id": 27046,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2023-09-19 18:48:13.059"
   },
   {
+    "id": 27046,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2023-09-19 18:48:13.059"
   },
   {
+    "id": 25805,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "7. Klasse",
     "requestAt": "2023-09-20 14:06:36.753"
   },
   {
+    "id": 28370,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true}]",
     "state": "th",
     "grade": "10. Klasse",
     "requestAt": "2023-09-20 14:10:29.822"
   },
   {
+    "id": 1304,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2023-09-20 14:21:28.006"
   },
   {
+    "id": 14870,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "sh",
     "grade": "9. Klasse",
     "requestAt": "2023-09-20 14:21:39.104"
   },
   {
+    "id": 27160,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "9. Klasse",
     "requestAt": "2023-09-20 14:28:42.364"
   },
   {
+    "id": 26113,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Latein\",\"mandatory\":true}]",
     "state": "by",
     "grade": "6. Klasse",
     "requestAt": "2023-09-20 14:32:11.81"
   },
   {
+    "id": 26092,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "7. Klasse",
     "requestAt": "2023-09-20 14:32:55.808"
   },
   {
+    "id": 21324,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "10. Klasse",
     "requestAt": "2023-09-20 14:32:59.074"
   },
   {
+    "id": 28784,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "7. Klasse",
     "requestAt": "2023-09-20 14:35:22.306"
   },
   {
+    "id": 26730,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "he",
     "grade": "10. Klasse",
     "requestAt": "2023-09-20 14:43:42.654"
   },
   {
+    "id": 20025,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":null},{\"name\":\"Deutsch\",\"mandatory\":null}]",
     "state": "he",
     "grade": "11. Klasse",
     "requestAt": "2023-09-20 14:56:02.364"
   },
   {
+    "id": 29391,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "6. Klasse",
     "requestAt": "2023-09-20 15:05:42.222"
   },
   {
+    "id": 25921,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "6. Klasse",
     "requestAt": "2023-09-20 15:06:27.726"
   },
   {
+    "id": 18807,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "hh",
     "grade": "7. Klasse",
     "requestAt": "2023-09-20 15:12:53.572"
   },
   {
+    "id": 25919,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "7. Klasse",
     "requestAt": "2023-09-20 15:13:04.136"
   },
   {
+    "id": 28398,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "by",
     "grade": "9. Klasse",
     "requestAt": "2023-09-20 15:16:41.189"
   },
   {
+    "id": 18070,
     "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true},{\"name\":\"Geschichte\",\"mandatory\":false}]",
     "state": "hh",
     "grade": "9. Klasse",
     "requestAt": "2023-09-20 15:41:11.243"
   },
   {
+    "id": 27681,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "5. Klasse",
     "requestAt": "2023-09-20 16:36:57.018"
   },
   {
+    "id": 13520,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "11. Klasse",
     "requestAt": "2023-09-20 16:53:24.295"
   },
   {
+    "id": 29474,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2023-09-20 16:55:31.325"
   },
   {
+    "id": 28253,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "7. Klasse",
     "requestAt": "2023-09-20 17:08:12.584"
   },
   {
+    "id": 7593,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":null},{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "8. Klasse",
     "requestAt": "2023-09-20 17:40:48.221"
   },
   {
+    "id": 28632,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2023-09-20 19:15:12.074"
   },
   {
+    "id": 21560,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "he",
     "grade": "6. Klasse",
     "requestAt": "2023-09-20 20:11:54.316"
   },
   {
+    "id": 26851,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "sn",
     "grade": "9. Klasse",
     "requestAt": "2023-09-21 03:51:35.171"
   },
   {
+    "id": 2052,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "11. Klasse",
     "requestAt": "2023-09-21 04:35:25.246"
   },
   {
+    "id": 28831,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2023-09-21 11:12:52.819"
   },
   {
+    "id": 11091,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Spanisch\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
     "state": "be",
     "grade": "13. Klasse",
     "requestAt": "2023-09-21 12:09:49.713"
   },
   {
+    "id": 25061,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "5. Klasse",
     "requestAt": "2023-09-21 17:44:37.287"
   },
   {
+    "id": 21716,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2023-09-21 19:59:32.362"
   },
   {
+    "id": 28983,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2023-09-21 20:59:18.252"
   },
   {
+    "id": 804,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "9. Klasse",
     "requestAt": "2023-09-22 12:30:45.369"
   },
   {
+    "id": 29482,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "13. Klasse",
     "requestAt": "2023-09-22 20:06:17.185"
   },
   {
+    "id": 27107,
     "subjects": "[{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":true},{\"name\":\"Politik\",\"mandatory\":false},{\"name\":\"Philosophie\",\"mandatory\":false}]",
     "state": "ni",
     "grade": "12. Klasse",
     "requestAt": "2023-09-23 11:07:39.66"
   },
   {
+    "id": 1290,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "5. Klasse",
     "requestAt": "2023-09-25 07:43:24.23"
   },
   {
+    "id": 26113,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Latein\",\"mandatory\":true}]",
     "state": "by",
     "grade": "6. Klasse",
     "requestAt": "2023-09-25 10:37:10.034"
   },
   {
+    "id": 25978,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":null},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "8. Klasse",
     "requestAt": "2023-09-25 13:06:55.249"
   },
   {
+    "id": 25086,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "6. Klasse",
     "requestAt": "2023-09-25 13:23:33.631"
   },
   {
+    "id": 27915,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":null},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Wirtschaft\",\"mandatory\":true}]",
     "state": "be",
     "grade": "12. Klasse",
     "requestAt": "2023-09-25 13:57:09.893"
   },
   {
+    "id": 28925,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "he",
     "grade": "8. Klasse",
     "requestAt": "2023-09-25 14:08:37.976"
   },
   {
+    "id": 29466,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false}]",
     "state": "be",
     "grade": "13. Klasse",
     "requestAt": "2023-09-25 14:40:47.467"
   },
   {
+    "id": 26054,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "7. Klasse",
     "requestAt": "2023-09-25 17:50:38.674"
   },
   {
+    "id": 28216,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":null},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":null}]",
     "state": "by",
     "grade": "7. Klasse",
     "requestAt": "2023-09-25 18:36:08.041"
   },
   {
+    "id": 28655,
     "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "12. Klasse",
     "requestAt": "2023-09-26 06:56:32.735"
   },
   {
+    "id": 12553,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Geschichte\",\"mandatory\":false}]",
     "state": "hh",
     "grade": "10. Klasse",
     "requestAt": "2023-09-27 04:41:18.717"
   },
   {
+    "id": 20622,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "6. Klasse",
     "requestAt": "2023-09-27 06:25:26.394"
   },
   {
+    "id": 20623,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "by",
     "grade": "5. Klasse",
     "requestAt": "2023-09-27 06:28:40.127"
   },
   {
+    "id": 29494,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "hh",
     "grade": "8. Klasse",
     "requestAt": "2023-09-27 09:11:17.934"
   },
   {
+    "id": 20510,
     "subjects": "[{\"name\":\"Mathematik\"}]",
     "state": "he",
     "grade": "8. Klasse",
     "requestAt": "2023-09-28 11:46:44.716"
   },
   {
+    "id": 20510,
     "subjects": "[{\"name\":\"Mathematik\"}]",
     "state": "he",
     "grade": "8. Klasse",
     "requestAt": "2023-09-28 11:46:44.716"
   },
   {
+    "id": 17114,
     "subjects": "[{\"name\":\"Latein\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Musik\",\"mandatory\":false}]",
     "state": "by",
     "grade": "10. Klasse",
     "requestAt": "2023-09-28 11:57:18.061"
   },
   {
+    "id": 22728,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Wirtschaft\",\"mandatory\":true},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
     "state": "by",
     "grade": "9. Klasse",
     "requestAt": "2023-09-28 13:15:12.797"
   },
   {
+    "id": 755,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "by",
     "grade": "10. Klasse",
     "requestAt": "2023-09-28 14:46:12.22"
   },
   {
+    "id": 29497,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "5. Klasse",
     "requestAt": "2023-09-28 15:10:47.579"
   },
   {
+    "id": 11469,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "bb",
     "grade": "10. Klasse",
     "requestAt": "2023-09-28 17:13:20.191"
   },
   {
+    "id": 14292,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "6. Klasse",
     "requestAt": "2023-09-29 07:25:14.244"
   },
   {
+    "id": 4660,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
     "state": "sn",
     "grade": "8. Klasse",
     "requestAt": "2023-09-29 07:52:38.778"
   },
   {
+    "id": 28793,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true}]",
     "state": "be",
     "grade": "8. Klasse",
     "requestAt": "2023-09-30 09:48:39.252"
   },
   {
+    "id": 25329,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2023-10-01 12:43:20.116"
   },
   {
+    "id": 25938,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Wirtschaft\",\"mandatory\":false}]",
     "state": "hh",
     "grade": "13. Klasse",
     "requestAt": "2023-10-01 15:20:16.283"
   },
   {
+    "id": 28740,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":null},{\"name\":\"Mathematik\",\"mandatory\":null},{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "3. Klasse",
     "requestAt": "2023-10-03 20:19:28.842"
   },
   {
+    "id": 28973,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "5. Klasse",
     "requestAt": "2023-10-04 10:16:24.679"
   },
   {
+    "id": 29512,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "13. Klasse",
     "requestAt": "2023-10-04 11:46:52.732"
   },
   {
+    "id": 29516,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "6. Klasse",
     "requestAt": "2023-10-05 09:22:16.987"
   },
   {
+    "id": 28934,
     "subjects": "[{\"name\":\"Wirtschaft\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2023-10-05 16:31:41.934"
   },
   {
+    "id": 25061,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "5. Klasse",
     "requestAt": "2023-10-05 17:34:06.624"
   },
   {
+    "id": 15901,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "sh",
     "grade": "9. Klasse",
     "requestAt": "2023-10-06 12:51:31.004"
   },
   {
+    "id": 11903,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "8. Klasse",
     "requestAt": "2023-10-06 23:13:18.769"
   },
   {
+    "id": 26808,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Latein\",\"mandatory\":true}]",
     "state": "by",
     "grade": "6. Klasse",
     "requestAt": "2023-10-07 07:15:47.467"
   },
   {
+    "id": 11898,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "11. Klasse",
     "requestAt": "2023-10-09 05:47:27.76"
   },
   {
+    "id": 12513,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Philosophie\",\"mandatory\":false}]",
     "state": "sh",
     "grade": "13. Klasse",
     "requestAt": "2023-10-09 12:45:54.207"
   },
   {
+    "id": 29526,
     "subjects": "[{\"name\":\"Mathematik\"}]",
     "state": "by",
     "grade": "8. Klasse",
     "requestAt": "2023-10-09 15:58:43.874"
   },
   {
+    "id": 22425,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "he",
     "grade": "10. Klasse",
     "requestAt": "2023-10-11 06:07:28.548"
   },
   {
+    "id": 26471,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "13. Klasse",
     "requestAt": "2023-10-11 06:47:01.726"
   },
   {
+    "id": 29530,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "by",
     "grade": "6. Klasse",
     "requestAt": "2023-10-12 10:50:15.727"
   },
   {
+    "id": 14286,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "8. Klasse",
     "requestAt": "2023-10-12 12:13:34.951"
   },
   {
+    "id": 27618,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":null},{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":null},{\"name\":\"Spanisch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "12. Klasse",
     "requestAt": "2023-10-12 13:31:49.06"
   },
   {
+    "id": 25977,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2023-10-12 15:41:59.525"
   },
   {
+    "id": 29408,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "10. Klasse",
     "requestAt": "2023-10-12 15:48:53.052"
   },
   {
+    "id": 29210,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2023-10-12 16:52:29.621"
   },
   {
+    "id": 28876,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "6. Klasse",
     "requestAt": "2023-10-14 22:20:42.988"
   },
   {
+    "id": 29571,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "be",
     "grade": "10. Klasse",
     "requestAt": "2023-10-15 13:22:54.462"
   },
   {
+    "id": 19609,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "bb",
     "grade": "7. Klasse",
     "requestAt": "2023-10-15 19:07:49.43"
   },
   {
+    "id": 29574,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "he",
     "grade": "5. Klasse",
     "requestAt": "2023-10-16 10:03:46.939"
   },
   {
+    "id": 26850,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "sn",
     "grade": "12. Klasse",
     "requestAt": "2023-10-20 18:38:27.558"
   },
   {
+    "id": 29593,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "he",
     "grade": "3. Klasse",
     "requestAt": "2023-10-21 11:31:33.268"
   },
   {
+    "id": 17654,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Musik\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "9. Klasse",
     "requestAt": "2023-10-22 14:13:26.368"
   },
   {
+    "id": 29596,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2023-10-22 14:57:55.42"
   },
   {
+    "id": 29598,
     "subjects": "[{\"name\":\"Latein\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2023-10-23 12:30:41.862"
   },
   {
+    "id": 21997,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2023-10-23 13:57:10.394"
   },
   {
+    "id": 29602,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "8. Klasse",
     "requestAt": "2023-10-23 14:33:51.027"
   },
   {
+    "id": 26289,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "7. Klasse",
     "requestAt": "2023-10-23 17:07:08.978"
   },
   {
+    "id": 4002,
     "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "13. Klasse",
     "requestAt": "2023-10-23 20:07:02.868"
   },
   {
+    "id": 19992,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2023-10-23 20:11:28.777"
   },
   {
+    "id": 15170,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "9. Klasse",
     "requestAt": "2023-10-24 21:21:41.431"
   },
   {
+    "id": 29608,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Technik\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2023-10-25 06:25:21.268"
   },
   {
+    "id": 11949,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "sh",
     "grade": "9. Klasse",
     "requestAt": "2023-10-25 14:53:49.756"
   },
   {
+    "id": 4451,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "by",
     "grade": "11. Klasse",
     "requestAt": "2023-10-26 09:44:59.204"
   },
   {
+    "id": 17421,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "11. Klasse",
     "requestAt": "2023-10-26 10:25:04.49"
   },
   {
+    "id": 17792,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false}]",
     "state": "he",
     "grade": "8. Klasse",
     "requestAt": "2023-10-27 09:13:14.496"
   },
   {
+    "id": 29619,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2023-10-27 19:49:39.857"
   },
   {
+    "id": 24219,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "8. Klasse",
     "requestAt": "2023-10-29 10:24:23.41"
   },
   {
+    "id": 9563,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false}]",
     "state": "ni",
     "grade": "11. Klasse",
     "requestAt": "2023-10-29 11:54:37.63"
   },
   {
+    "id": 25921,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "6. Klasse",
     "requestAt": "2023-10-29 22:19:59.196"
   },
   {
+    "id": 10923,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":null},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "11. Klasse",
     "requestAt": "2023-10-30 15:06:19.826"
   },
   {
+    "id": 24656,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "11. Klasse",
     "requestAt": "2023-10-31 14:31:38.005"
   },
   {
+    "id": 29629,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2023-11-01 09:51:36.64"
   },
   {
+    "id": 29628,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "8. Klasse",
     "requestAt": "2023-11-01 10:31:26.134"
   },
   {
+    "id": 25597,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Musik\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "6. Klasse",
     "requestAt": "2023-11-01 12:02:04.786"
   },
   {
+    "id": 28370,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true}]",
     "state": "th",
     "grade": "10. Klasse",
     "requestAt": "2023-11-01 12:35:58.003"
   },
   {
+    "id": 28378,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "he",
     "grade": "9. Klasse",
     "requestAt": "2023-11-01 13:07:31.301"
   },
   {
+    "id": 29202,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "7. Klasse",
     "requestAt": "2023-11-02 14:11:35.146"
   },
   {
+    "id": 25904,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "7. Klasse",
     "requestAt": "2023-11-02 14:14:46.866"
   },
   {
+    "id": 3920,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":null},{\"name\":\"Englisch\",\"mandatory\":null}]",
     "state": "ni",
     "grade": "10. Klasse",
     "requestAt": "2023-11-02 14:20:50.133"
   },
   {
+    "id": 29229,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "9. Klasse",
     "requestAt": "2023-11-02 14:30:54.061"
   },
   {
+    "id": 29174,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "hh",
     "grade": "3. Klasse",
     "requestAt": "2023-11-02 15:10:36.891"
   },
   {
+    "id": 24276,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Religion\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Politik\",\"mandatory\":false},{\"name\":\"Wirtschaft\",\"mandatory\":false}]",
     "state": "he",
     "grade": "9. Klasse",
     "requestAt": "2023-11-02 15:48:14.87"
   },
   {
+    "id": 8440,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "be",
     "grade": "8. Klasse",
     "requestAt": "2023-11-02 16:37:11.336"
   },
   {
+    "id": 29637,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "hh",
     "grade": "6. Klasse",
     "requestAt": "2023-11-02 17:56:13.218"
   },
   {
+    "id": 26725,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "11. Klasse",
     "requestAt": "2023-11-02 18:06:18.191"
   },
   {
+    "id": 29161,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "other",
     "grade": "7. Klasse",
     "requestAt": "2023-11-02 19:06:22.038"
   },
   {
+    "id": 17730,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "9. Klasse",
     "requestAt": "2023-11-02 20:43:20.244"
   },
   {
+    "id": 10604,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "other",
     "grade": "6. Klasse",
     "requestAt": "2023-11-02 22:25:58.6"
   },
   {
+    "id": 29644,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "he",
     "grade": "7. Klasse",
     "requestAt": "2023-11-03 06:07:59.976"
   },
   {
+    "id": 29225,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2023-11-03 11:29:55.938"
   },
   {
+    "id": 29647,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "5. Klasse",
     "requestAt": "2023-11-03 15:20:00.47"
   },
   {
+    "id": 29653,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "10. Klasse",
     "requestAt": "2023-11-04 21:51:38.319"
   },
   {
+    "id": 29653,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "10. Klasse",
     "requestAt": "2023-11-04 21:51:38.319"
   },
   {
+    "id": 29050,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2023-11-05 07:36:23.975"
   },
   {
+    "id": 27455,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":null},{\"name\":\"Erdkunde\",\"mandatory\":null},{\"name\":\"Biologie\",\"mandatory\":null},{\"name\":\"Französisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "he",
     "grade": "8. Klasse",
     "requestAt": "2023-11-05 08:15:45.602"
   },
   {
+    "id": 28563,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "4. Klasse",
     "requestAt": "2023-11-05 09:41:44.937"
   },
   {
+    "id": 14171,
     "subjects": "[{\"name\":\"Physik\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "by",
     "grade": "13. Klasse",
     "requestAt": "2023-11-05 19:09:49.102"
   },
   {
+    "id": 28793,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true}]",
     "state": "be",
     "grade": "8. Klasse",
     "requestAt": "2023-11-05 19:54:40.344"
   },
   {
+    "id": 28356,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "be",
     "grade": "3. Klasse",
     "requestAt": "2023-11-06 12:41:21.579"
   },
   {
+    "id": 28411,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "6. Klasse",
     "requestAt": "2023-11-06 17:42:40.494"
   },
   {
+    "id": 28842,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "st",
     "grade": "4. Klasse",
     "requestAt": "2023-11-07 09:01:56.727"
   },
   {
+    "id": 29424,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Informatik\",\"mandatory\":false},{\"name\":\"Wirtschaft\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "13. Klasse",
     "requestAt": "2023-11-07 09:15:26.084"
   },
   {
+    "id": 26198,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "hh",
     "grade": "13. Klasse",
     "requestAt": "2023-11-07 15:40:56.962"
   },
   {
+    "id": 29516,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "6. Klasse",
     "requestAt": "2023-11-07 16:12:55.866"
   },
   {
+    "id": 26149,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "5. Klasse",
     "requestAt": "2023-11-08 09:34:45.516"
   },
   {
+    "id": 29667,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "ni",
     "grade": "11. Klasse",
     "requestAt": "2023-11-08 14:15:52.543"
   },
   {
+    "id": 27379,
     "subjects": "[{\"name\":\"Latein\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "11. Klasse",
     "requestAt": "2023-11-09 11:38:41.474"
   },
   {
+    "id": 29673,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "be",
     "grade": "6. Klasse",
     "requestAt": "2023-11-10 09:06:28.435"
   },
   {
+    "id": 29674,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "be",
     "grade": "8. Klasse",
     "requestAt": "2023-11-10 11:28:42.525"
   },
   {
+    "id": 24197,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2023-11-11 11:15:24.23"
   },
   {
+    "id": 28378,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "he",
     "grade": "9. Klasse",
     "requestAt": "2023-11-11 14:55:24.195"
   },
   {
+    "id": 28398,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "by",
     "grade": "9. Klasse",
     "requestAt": "2023-11-13 14:49:34.08"
   },
   {
+    "id": 28868,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Philosophie\",\"mandatory\":false}]",
     "state": "hh",
     "grade": "13. Klasse",
     "requestAt": "2023-11-13 19:00:10.909"
   },
   {
+    "id": 29693,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "be",
     "grade": "4. Klasse",
     "requestAt": "2023-11-14 18:57:47.82"
   },
   {
+    "id": 28628,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "6. Klasse",
     "requestAt": "2023-11-14 19:27:08.34"
   },
   {
+    "id": 15170,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "9. Klasse",
     "requestAt": "2023-11-14 21:48:58.952"
   },
   {
+    "id": 29698,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2023-11-15 15:31:50.78"
   },
   {
+    "id": 29223,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "he",
     "grade": "3. Klasse",
     "requestAt": "2023-11-15 20:30:29.26"
   },
   {
+    "id": 10855,
     "subjects": "[{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "sn",
     "grade": "11. Klasse",
     "requestAt": "2023-11-17 07:25:31.43"
   },
   {
+    "id": 29705,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "th",
     "grade": "5. Klasse",
     "requestAt": "2023-11-17 12:02:24.029"
   },
   {
+    "id": 28827,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "5. Klasse",
     "requestAt": "2023-11-17 19:20:39.952"
   },
   {
+    "id": 29688,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "be",
     "grade": "7. Klasse",
     "requestAt": "2023-11-17 21:54:33.382"
   },
   {
+    "id": 29687,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "be",
     "grade": "6. Klasse",
     "requestAt": "2023-11-17 21:57:12.512"
   },
   {
+    "id": 20029,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":null},{\"name\":\"Spanisch\",\"mandatory\":false}]",
     "state": "he",
     "grade": "8. Klasse",
     "requestAt": "2023-11-18 22:43:01.848"
   },
   {
+    "id": 16205,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true},{\"name\":\"Spanisch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "9. Klasse",
     "requestAt": "2023-11-19 16:16:46.72"
   },
   {
+    "id": 28371,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":null}]",
     "state": "th",
     "grade": "9. Klasse",
     "requestAt": "2023-11-19 18:23:08.267"
   },
   {
+    "id": 18314,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "7. Klasse",
     "requestAt": "2023-11-19 18:59:40.031"
   },
   {
+    "id": 29719,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "be",
     "grade": "4. Klasse",
     "requestAt": "2023-11-20 13:07:50.511"
   },
   {
+    "id": 29674,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "be",
     "grade": "8. Klasse",
     "requestAt": "2023-11-20 16:18:09.73"
   },
   {
+    "id": 29596,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2023-11-20 16:44:07.363"
   },
   {
+    "id": 23648,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "8. Klasse",
     "requestAt": "2023-11-20 18:37:21.49"
   },
   {
+    "id": 27198,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":null}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2023-11-21 14:04:41.21"
   },
   {
+    "id": 13108,
     "subjects": "[{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2023-11-21 17:48:28.613"
   },
   {
+    "id": 20622,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "6. Klasse",
     "requestAt": "2023-11-21 21:14:31.454"
   },
   {
+    "id": 29734,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Sachkunde\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "3. Klasse",
     "requestAt": "2023-11-21 21:30:05.946"
   },
   {
+    "id": 24875,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "5. Klasse",
     "requestAt": "2023-11-21 21:48:29.605"
   },
   {
+    "id": 23705,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "8. Klasse",
     "requestAt": "2023-11-22 08:08:12.615"
   },
   {
+    "id": 29682,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "be",
     "grade": "6. Klasse",
     "requestAt": "2023-11-22 12:48:17.549"
   },
   {
+    "id": 19225,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "9. Klasse",
     "requestAt": "2023-11-22 16:19:23.271"
   },
   {
+    "id": 29742,
     "subjects": "[{\"name\":\"Biologie\",\"mandatory\":true}]",
     "state": "sh",
     "grade": "10. Klasse",
     "requestAt": "2023-11-22 23:20:06.361"
   },
   {
+    "id": 29709,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "ni",
     "grade": "11. Klasse",
     "requestAt": "2023-11-23 12:47:17.085"
   },
   {
+    "id": 29226,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Latein\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "8. Klasse",
     "requestAt": "2023-11-24 06:17:49.097"
   },
   {
+    "id": 17381,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "sh",
     "grade": "9. Klasse",
     "requestAt": "2023-11-26 11:05:29.587"
   },
   {
+    "id": 28504,
     "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true},{\"name\":\"Spanisch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2023-11-26 12:57:04.023"
   },
   {
+    "id": 28522,
     "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2023-11-26 13:00:01.802"
   },
   {
+    "id": 29754,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "6. Klasse",
     "requestAt": "2023-11-27 06:26:18.573"
   },
   {
+    "id": 29756,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false}]",
     "state": "by",
     "grade": "9. Klasse",
     "requestAt": "2023-11-27 13:32:27.521"
   },
   {
+    "id": 23707,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"minGrade\":1,\"maxGrade\":13}]",
     "state": "bw",
     "grade": "9. Klasse",
     "requestAt": "2023-11-27 16:48:22.427"
   },
   {
+    "id": 29761,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "by",
     "grade": "4. Klasse",
     "requestAt": "2023-11-27 22:10:03.928"
   },
   {
+    "id": 29762,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "by",
     "grade": "6. Klasse",
     "requestAt": "2023-11-28 12:10:10.362"
   },
   {
+    "id": 1321,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "sn",
     "grade": "7. Klasse",
     "requestAt": "2023-11-28 18:30:32.557"
   },
   {
+    "id": 29764,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false}]",
     "state": "ni",
     "grade": "9. Klasse",
     "requestAt": "2023-11-29 12:02:51.191"
   },
   {
+    "id": 29768,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2023-11-29 18:48:23.606"
   },
   {
+    "id": 29690,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "3. Klasse",
     "requestAt": "2023-11-29 21:19:06.817"
   },
   {
+    "id": 14315,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "he",
     "grade": "13. Klasse",
     "requestAt": "2023-11-30 10:24:09.416"
   },
   {
+    "id": 29202,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "7. Klasse",
     "requestAt": "2023-12-01 08:06:23.824"
   },
   {
+    "id": 29772,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "4. Klasse",
     "requestAt": "2023-12-01 10:17:46.199"
   },
   {
+    "id": 26505,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "8. Klasse",
     "requestAt": "2023-12-03 04:13:53.111"
   },
   {
+    "id": 27279,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2023-12-04 16:36:21.297"
   },
   {
+    "id": 29778,
     "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2023-12-04 16:38:10.261"
   },
   {
+    "id": 29781,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "sn",
     "grade": "3. Klasse",
     "requestAt": "2023-12-05 08:20:02.128"
   },
   {
+    "id": 29226,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Latein\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "8. Klasse",
     "requestAt": "2023-12-05 12:25:09.468"
   },
   {
+    "id": 21330,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "7. Klasse",
     "requestAt": "2023-12-05 15:47:54.836"
   },
   {
+    "id": 18845,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
     "state": "he",
     "grade": "9. Klasse",
     "requestAt": "2023-12-07 07:12:50.1"
   },
   {
+    "id": 29736,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "by",
     "grade": "5. Klasse",
     "requestAt": "2023-12-07 16:00:30.178"
   },
   {
+    "id": 23704,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "3. Klasse",
     "requestAt": "2023-12-07 17:23:15.957"
   },
   {
+    "id": 25261,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2023-12-08 14:54:57.044"
   },
   {
+    "id": 29784,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "6. Klasse",
     "requestAt": "2023-12-08 19:32:43.152"
   },
   {
+    "id": 26357,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "9. Klasse",
     "requestAt": "2023-12-10 16:26:55.731"
   },
   {
+    "id": 26808,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Latein\",\"mandatory\":true}]",
     "state": "by",
     "grade": "6. Klasse",
     "requestAt": "2023-12-12 06:05:05.758"
   },
   {
+    "id": 29688,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "be",
     "grade": "7. Klasse",
     "requestAt": "2023-12-12 17:56:18.537"
   },
   {
+    "id": 24875,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "5. Klasse",
     "requestAt": "2023-12-12 18:50:04.951"
   },
   {
+    "id": 26054,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "7. Klasse",
     "requestAt": "2023-12-13 09:32:49.885"
   },
   {
+    "id": 26149,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "5. Klasse",
     "requestAt": "2023-12-13 20:20:56.679"
   },
   {
+    "id": 29795,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "10. Klasse",
     "requestAt": "2023-12-14 09:07:32.141"
   },
   {
+    "id": 29801,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "10. Klasse",
     "requestAt": "2023-12-18 17:14:52.71"
   },
   {
+    "id": 5313,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2023-12-18 18:35:33.456"
   },
   {
+    "id": 14347,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2023-12-18 21:31:09.182"
   },
   {
+    "id": 8983,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Latein\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2023-12-19 19:30:47.053"
   },
   {
+    "id": 29809,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "be",
     "grade": "13. Klasse",
     "requestAt": "2023-12-20 11:11:37.572"
   },
   {
+    "id": 25940,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "6. Klasse",
     "requestAt": "2023-12-20 15:24:17.316"
   },
   {
+    "id": 26149,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "5. Klasse",
     "requestAt": "2023-12-20 20:27:41.043"
   },
   {
+    "id": 29754,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "6. Klasse",
     "requestAt": "2023-12-20 20:35:43.829"
   },
   {
+    "id": 29811,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Spanisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "3. Klasse",
     "requestAt": "2023-12-21 18:32:45.476"
   },
   {
+    "id": 14837,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "9. Klasse",
     "requestAt": "2023-12-22 00:15:38.412"
   },
   {
+    "id": 12094,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":null},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false}]",
     "state": "th",
     "grade": "12. Klasse",
     "requestAt": "2023-12-22 17:27:44.935"
   },
   {
+    "id": 16267,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
     "state": "by",
     "grade": "10. Klasse",
     "requestAt": "2023-12-23 07:47:57.328"
   },
   {
+    "id": 6684,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "8. Klasse",
     "requestAt": "2023-12-23 07:56:03.147"
   },
   {
+    "id": 27589,
     "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "mv",
     "grade": "13. Klasse",
     "requestAt": "2023-12-23 10:48:22.421"
   },
   {
+    "id": 20451,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "bb",
     "grade": "12. Klasse",
     "requestAt": "2023-12-23 10:59:54.36"
   },
   {
+    "id": 7205,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "be",
     "grade": "7. Klasse",
     "requestAt": "2023-12-23 11:25:02.132"
   },
   {
+    "id": 29812,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2023-12-23 21:31:28.01"
   },
   {
+    "id": 8994,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "11. Klasse",
     "requestAt": "2023-12-24 07:39:20.181"
   },
   {
+    "id": 29221,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2023-12-24 13:13:22.206"
   },
   {
+    "id": 29222,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "6. Klasse",
     "requestAt": "2023-12-24 13:23:49.786"
   },
   {
+    "id": 25174,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2023-12-25 01:56:43.992"
   },
   {
+    "id": 21522,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "7. Klasse",
     "requestAt": "2023-12-25 06:01:37.583"
   },
   {
+    "id": 9519,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":true}]",
     "state": "be",
     "grade": "7. Klasse",
     "requestAt": "2023-12-25 09:08:33.738"
   },
   {
+    "id": 29817,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "7. Klasse",
     "requestAt": "2023-12-25 10:08:03.041"
   },
   {
+    "id": 20176,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "he",
     "grade": "13. Klasse",
     "requestAt": "2023-12-25 14:02:45.871"
   },
   {
+    "id": 7694,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":null},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "by",
     "grade": "9. Klasse",
     "requestAt": "2023-12-25 19:47:07.925"
   },
   {
+    "id": 25634,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "4. Klasse",
     "requestAt": "2023-12-25 20:26:42.281"
   },
   {
+    "id": 29242,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "4. Klasse",
     "requestAt": "2023-12-26 19:46:01.836"
   },
   {
+    "id": 19291,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "8. Klasse",
     "requestAt": "2023-12-26 20:36:38.706"
   },
   {
+    "id": 11679,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Informatik\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Kunst\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "13. Klasse",
     "requestAt": "2023-12-27 12:36:21.051"
   },
   {
+    "id": 6316,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":null},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "be",
     "grade": "7. Klasse",
     "requestAt": "2023-12-27 16:44:53.967"
   },
   {
+    "id": 18055,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "11. Klasse",
     "requestAt": "2023-12-27 22:28:10.237"
   },
   {
+    "id": 20469,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2023-12-28 01:31:22.101"
   },
   {
+    "id": 29823,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "be",
     "grade": "7. Klasse",
     "requestAt": "2023-12-28 15:05:14.113"
   },
   {
+    "id": 29858,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "be",
     "grade": "8. Klasse",
     "requestAt": "2023-12-29 13:03:19.98"
   },
   {
+    "id": 12889,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2024-01-01 19:41:39.721"
   },
   {
+    "id": 28801,
     "subjects": "[{\"name\":\"Physik\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Latein\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Informatik\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false}]",
     "state": "sn",
     "grade": "10. Klasse",
     "requestAt": "2024-01-01 20:00:01.977"
   },
   {
+    "id": 29861,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "hb",
     "grade": "13. Klasse",
     "requestAt": "2024-01-02 09:56:39.582"
   },
   {
+    "id": 19694,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "5. Klasse",
     "requestAt": "2024-01-02 15:46:23.06"
   },
   {
+    "id": 29862,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "be",
     "grade": "8. Klasse",
     "requestAt": "2024-01-02 16:47:15.156"
   },
   {
+    "id": 11399,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":null},{\"name\":\"Sachkunde\",\"mandatory\":true}]",
     "state": "other",
     "grade": "3. Klasse",
     "requestAt": "2024-01-05 11:21:57.905"
   },
   {
+    "id": 13588,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":false}]",
     "state": "sn",
     "grade": "7. Klasse",
     "requestAt": "2024-01-07 12:42:20.376"
   },
   {
+    "id": 29866,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "be",
     "grade": "13. Klasse",
     "requestAt": "2024-01-07 13:53:32.326"
   },
   {
+    "id": 29869,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false}]",
     "state": "hh",
     "grade": "8. Klasse",
     "requestAt": "2024-01-07 23:19:02.36"
   },
   {
+    "id": 27592,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2024-01-08 09:20:03.478"
   },
   {
+    "id": 29786,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "4. Klasse",
     "requestAt": "2024-01-08 12:26:11.784"
   },
   {
+    "id": 29447,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false}]",
     "state": "sn",
     "grade": "12. Klasse",
     "requestAt": "2024-01-08 14:13:50.584"
   },
   {
+    "id": 3075,
     "subjects": "[{\"name\":\"Biologie\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "12. Klasse",
     "requestAt": "2024-01-08 20:50:45.274"
   },
   {
+    "id": 29873,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "5. Klasse",
     "requestAt": "2024-01-09 10:31:49.226"
   },
   {
+    "id": 20912,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "7. Klasse",
     "requestAt": "2024-01-09 16:08:41.501"
   },
   {
+    "id": 9563,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false}]",
     "state": "ni",
     "grade": "11. Klasse",
     "requestAt": "2024-01-10 10:43:07.117"
   },
   {
+    "id": 29503,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "11. Klasse",
     "requestAt": "2024-01-10 13:37:44.593"
   },
   {
+    "id": 29420,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false}]",
     "state": "he",
     "grade": "12. Klasse",
     "requestAt": "2024-01-10 15:39:01.814"
   },
   {
+    "id": 29867,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "at",
     "grade": "6. Klasse",
     "requestAt": "2024-01-10 17:07:19.218"
   },
   {
+    "id": 1290,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "5. Klasse",
     "requestAt": "2024-01-10 18:55:16.909"
   },
   {
+    "id": 29608,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Technik\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2024-01-11 20:09:56.923"
   },
   {
+    "id": 17504,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "he",
     "grade": "6. Klasse",
     "requestAt": "2024-01-12 16:51:33.802"
   },
   {
+    "id": 28522,
     "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2024-01-12 20:17:40.378"
   },
   {
+    "id": 29885,
     "subjects": "[{\"name\":\"Erdkunde\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "13. Klasse",
     "requestAt": "2024-01-13 20:20:37.15"
   },
   {
+    "id": 29698,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2024-01-13 23:08:38.449"
   },
   {
+    "id": 29886,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "th",
     "grade": "6. Klasse",
     "requestAt": "2024-01-14 12:11:07.372"
   },
   {
+    "id": 7471,
     "subjects": "[{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":true}]",
     "state": "hh",
     "grade": "10. Klasse",
     "requestAt": "2024-01-14 13:20:04.67"
   },
   {
+    "id": 29764,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false}]",
     "state": "ni",
     "grade": "9. Klasse",
     "requestAt": "2024-01-15 14:36:29.673"
   },
   {
+    "id": 29892,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "he",
     "grade": "4. Klasse",
     "requestAt": "2024-01-15 19:55:04.217"
   },
   {
+    "id": 28842,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "st",
     "grade": "4. Klasse",
     "requestAt": "2024-01-15 20:34:33.103"
   },
   {
+    "id": 26692,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Spanisch\",\"mandatory\":false}]",
     "state": "sn",
     "grade": "9. Klasse",
     "requestAt": "2024-01-15 20:34:54.706"
   },
   {
+    "id": 28955,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "6. Klasse",
     "requestAt": "2024-01-16 18:37:58.853"
   },
   {
+    "id": 26070,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "10. Klasse",
     "requestAt": "2024-01-16 18:55:31.488"
   },
   {
+    "id": 29762,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "by",
     "grade": "6. Klasse",
     "requestAt": "2024-01-17 15:56:46.027"
   },
   {
+    "id": 13108,
     "subjects": "[{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2024-01-17 16:17:21.001"
   },
   {
+    "id": 24292,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "5. Klasse",
     "requestAt": "2024-01-17 16:21:52.388"
   },
   {
+    "id": 29432,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "5. Klasse",
     "requestAt": "2024-01-17 16:26:35.173"
   },
   {
+    "id": 29895,
     "subjects": "[{\"name\":\"Geschichte\",\"mandatory\":true}]",
     "state": "hh",
     "grade": "11. Klasse",
     "requestAt": "2024-01-17 17:28:53.586"
   },
   {
+    "id": 11892,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":null},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2024-01-17 17:33:08.37"
   },
   {
+    "id": 12150,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "8. Klasse",
     "requestAt": "2024-01-17 19:57:45.352"
   },
   {
+    "id": 29637,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "hh",
     "grade": "6. Klasse",
     "requestAt": "2024-01-17 20:01:16.636"
   },
   {
+    "id": 28831,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2024-01-18 14:43:27.257"
   },
   {
+    "id": 29823,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "be",
     "grade": "7. Klasse",
     "requestAt": "2024-01-18 16:10:04.093"
   },
   {
+    "id": 28411,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "6. Klasse",
     "requestAt": "2024-01-18 18:15:40.161"
   },
   {
+    "id": 5313,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2024-01-21 19:48:43.842"
   },
   {
+    "id": 28537,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "4. Klasse",
     "requestAt": "2024-01-21 21:14:08.366"
   },
   {
+    "id": 28536,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "4. Klasse",
     "requestAt": "2024-01-21 21:27:27.931"
   },
   {
+    "id": 29482,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "13. Klasse",
     "requestAt": "2024-01-22 10:55:46.187"
   },
   {
+    "id": 29862,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "be",
     "grade": "8. Klasse",
     "requestAt": "2024-01-22 14:52:54.862"
   },
   {
+    "id": 12781,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "7. Klasse",
     "requestAt": "2024-01-22 18:57:25.005"
   },
   {
+    "id": 4002,
     "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "13. Klasse",
     "requestAt": "2024-01-22 21:14:33.87"
   },
   {
+    "id": 29916,
     "subjects": "[{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false}]",
     "state": "by",
     "grade": "9. Klasse",
     "requestAt": "2024-01-23 08:24:37.318"
   },
   {
+    "id": 17421,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "11. Klasse",
     "requestAt": "2024-01-23 17:10:09.418"
   },
   {
+    "id": 12889,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2024-01-23 18:01:38.202"
   },
   {
+    "id": 29653,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "10. Klasse",
     "requestAt": "2024-01-23 19:46:51.164"
   },
   {
+    "id": 29922,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "5. Klasse",
     "requestAt": "2024-01-24 15:56:37.546"
   },
   {
+    "id": 26948,
     "subjects": "[{\"name\":\"Mathematik\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Physik\",\"minGrade\":1,\"maxGrade\":13}]",
     "state": "sn",
     "grade": "8. Klasse",
     "requestAt": "2024-01-24 16:46:22.231"
   },
   {
+    "id": 26505,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "8. Klasse",
     "requestAt": "2024-01-25 07:59:06.225"
   },
   {
+    "id": 29812,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2024-01-25 11:45:38.424"
   },
   {
+    "id": 8440,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "be",
     "grade": "8. Klasse",
     "requestAt": "2024-01-26 10:22:59.458"
   },
   {
+    "id": 29674,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "be",
     "grade": "8. Klasse",
     "requestAt": "2024-01-26 10:24:56.395"
   },
   {
+    "id": 27113,
     "subjects": "[{\"name\":\"Wirtschaft\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "11. Klasse",
     "requestAt": "2024-01-27 09:42:00.289"
   },
   {
+    "id": 29927,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":true}]",
     "state": "sn",
     "grade": "7. Klasse",
     "requestAt": "2024-01-27 20:14:50.906"
   },
   {
+    "id": 12972,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2024-01-28 14:24:36.461"
   },
   {
+    "id": 27320,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2024-01-28 15:35:39.22"
   },
   {
+    "id": 11170,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2024-01-29 09:10:23.929"
   },
   {
+    "id": 29778,
     "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2024-01-30 10:11:13.768"
   },
   {
+    "id": 29942,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "be",
     "grade": "7. Klasse",
     "requestAt": "2024-01-30 12:29:19.016"
   },
   {
+    "id": 25940,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "6. Klasse",
     "requestAt": "2024-01-30 17:29:11.787"
   },
   {
+    "id": 14823,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "9. Klasse",
     "requestAt": "2024-01-30 19:43:23.572"
   },
   {
+    "id": 25580,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "ni",
     "grade": "11. Klasse",
     "requestAt": "2024-01-30 21:00:14.056"
   },
   {
+    "id": 13108,
     "subjects": "[{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2024-01-31 11:38:47.292"
   },
   {
+    "id": 29047,
     "subjects": "[{\"name\":\"Latein\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2024-01-31 12:39:20.947"
   },
   {
+    "id": 26109,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "5. Klasse",
     "requestAt": "2024-02-01 09:15:20.733"
   },
   {
+    "id": 29858,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "be",
     "grade": "8. Klasse",
     "requestAt": "2024-02-01 09:39:50.713"
   },
   {
+    "id": 6596,
     "subjects": "[{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "12. Klasse",
     "requestAt": "2024-02-01 09:42:05.898"
   },
   {
+    "id": 29673,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "be",
     "grade": "6. Klasse",
     "requestAt": "2024-02-01 09:59:09.872"
   },
   {
+    "id": 29768,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2024-02-01 16:55:28.73"
   },
   {
+    "id": 29958,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2024-02-02 17:56:54.577"
   },
   {
+    "id": 29482,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "13. Klasse",
     "requestAt": "2024-02-02 19:26:32.035"
   },
   {
+    "id": 6098,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "hb",
     "grade": "11. Klasse",
     "requestAt": "2024-02-03 09:15:45.924"
   },
   {
+    "id": 25692,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "bb",
     "grade": "12. Klasse",
     "requestAt": "2024-02-03 20:50:49.359"
   },
   {
+    "id": 25761,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "8. Klasse",
     "requestAt": "2024-02-04 17:11:52.738"
   },
   {
+    "id": 28522,
     "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2024-02-05 16:18:06.833"
   },
   {
+    "id": 25597,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Musik\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "6. Klasse",
     "requestAt": "2024-02-05 18:54:08.146"
   },
   {
+    "id": 13519,
     "subjects": "[{\"name\":\"Latein\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2024-02-06 07:09:24.351"
   },
   {
+    "id": 29972,
     "subjects": "[{\"name\":\"Lernen lernen\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "sh",
     "grade": "6. Klasse",
     "requestAt": "2024-02-06 09:12:28.57"
   },
   {
+    "id": 29938,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "5. Klasse",
     "requestAt": "2024-02-06 10:38:23.538"
   },
   {
+    "id": 27364,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2024-02-07 08:19:01.052"
   },
   {
+    "id": 29976,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "by",
     "grade": "3. Klasse",
     "requestAt": "2024-02-07 19:31:13.396"
   },
   {
+    "id": 20811,
     "subjects": "[{\"name\":\"Latein\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "9. Klasse",
     "requestAt": "2024-02-08 17:16:22.802"
   },
   {
+    "id": 29980,
     "subjects": "[{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2024-02-08 20:12:38.081"
   },
   {
+    "id": 29984,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "8. Klasse",
     "requestAt": "2024-02-09 18:26:29.601"
   },
   {
+    "id": 29987,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "he",
     "grade": "3. Klasse",
     "requestAt": "2024-02-10 20:16:15.572"
   },
   {
+    "id": 22285,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2024-02-11 14:16:06.488"
   },
   {
+    "id": 28793,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true}]",
     "state": "be",
     "grade": "8. Klasse",
     "requestAt": "2024-02-11 21:13:43.365"
   },
   {
+    "id": 29991,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "by",
     "grade": "4. Klasse",
     "requestAt": "2024-02-12 12:23:45.815"
   },
   {
+    "id": 29447,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false}]",
     "state": "sn",
     "grade": "12. Klasse",
     "requestAt": "2024-02-13 14:07:06.213"
   },
   {
+    "id": 29997,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "by",
     "grade": "2. Klasse",
     "requestAt": "2024-02-13 16:53:11.409"
   },
   {
+    "id": 29998,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "by",
     "grade": "2. Klasse",
     "requestAt": "2024-02-13 18:44:52.104"
   },
   {
+    "id": 19623,
     "subjects": "[{\"name\":\"Informatik\",\"mandatory\":true}]",
     "state": "hb",
     "grade": "13. Klasse",
     "requestAt": "2024-02-13 20:35:53.405"
   },
   {
+    "id": 20169,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "ni",
     "grade": "8. Klasse",
     "requestAt": "2024-02-13 20:43:33.537"
   },
   {
+    "id": 29619,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2024-02-14 09:57:46.441"
   },
   {
+    "id": 24875,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "5. Klasse",
     "requestAt": "2024-02-14 13:22:12.024"
   },
   {
+    "id": 29858,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "be",
     "grade": "8. Klasse",
     "requestAt": "2024-02-15 16:26:32.873"
   },
   {
+    "id": 17114,
     "subjects": "[{\"name\":\"Latein\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Musik\",\"mandatory\":false}]",
     "state": "by",
     "grade": "10. Klasse",
     "requestAt": "2024-02-16 15:02:55.913"
   },
   {
+    "id": 25174,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2024-02-16 16:11:54.701"
   },
   {
+    "id": 21522,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "7. Klasse",
     "requestAt": "2024-02-16 16:23:19.678"
   },
   {
+    "id": 29516,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "6. Klasse",
     "requestAt": "2024-02-16 16:49:02.791"
   },
   {
+    "id": 29072,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "3. Klasse",
     "requestAt": "2024-02-16 18:34:59.924"
   },
   {
+    "id": 29369,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "4. Klasse",
     "requestAt": "2024-02-16 18:43:33.262"
   },
   {
+    "id": 29223,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "he",
     "grade": "3. Klasse",
     "requestAt": "2024-02-16 19:39:19.505"
   },
   {
+    "id": 29181,
     "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2024-02-16 20:26:48.172"
   },
   {
+    "id": 29371,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "4. Klasse",
     "requestAt": "2024-02-16 20:38:30.88"
   },
   {
+    "id": 29225,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2024-02-16 22:08:16.329"
   },
   {
+    "id": 12074,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "he",
     "grade": "9. Klasse",
     "requestAt": "2024-02-17 00:27:22.238"
   },
   {
+    "id": 16780,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "8. Klasse",
     "requestAt": "2024-02-17 02:15:45.733"
   },
   {
+    "id": 21331,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "he",
     "grade": "6. Klasse",
     "requestAt": "2024-02-17 04:00:46.739"
   },
   {
+    "id": 29414,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "th",
     "grade": "2. Klasse",
     "requestAt": "2024-02-17 04:44:21.641"
   },
   {
+    "id": 9490,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "8. Klasse",
     "requestAt": "2024-02-17 04:45:56.834"
   },
   {
+    "id": 14286,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "8. Klasse",
     "requestAt": "2024-02-17 06:26:01.526"
   },
   {
+    "id": 25574,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "7. Klasse",
     "requestAt": "2024-02-17 06:47:40.095"
   },
   {
+    "id": 11903,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "8. Klasse",
     "requestAt": "2024-02-17 06:54:58.317"
   },
   {
+    "id": 27160,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "9. Klasse",
     "requestAt": "2024-02-17 07:10:59.432"
   },
   {
+    "id": 26626,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "6. Klasse",
     "requestAt": "2024-02-17 07:18:13.397"
   },
   {
+    "id": 10561,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "be",
     "grade": "7. Klasse",
     "requestAt": "2024-02-17 07:20:56.222"
   },
   {
+    "id": 26379,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2024-02-17 07:27:46.483"
   },
   {
+    "id": 26578,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "be",
     "grade": "6. Klasse",
     "requestAt": "2024-02-17 07:30:51.788"
   },
   {
+    "id": 28088,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "ni",
     "grade": "10. Klasse",
     "requestAt": "2024-02-17 07:32:44.446"
   },
   {
+    "id": 9551,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true}]",
     "state": "by",
     "grade": "9. Klasse",
     "requestAt": "2024-02-17 07:36:03.37"
   },
   {
+    "id": 24061,
     "subjects": "[{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "he",
     "grade": "11. Klasse",
     "requestAt": "2024-02-17 08:01:16.404"
   },
   {
+    "id": 29202,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "7. Klasse",
     "requestAt": "2024-02-17 08:03:17.385"
   },
   {
+    "id": 25261,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2024-02-17 08:04:51.31"
   },
   {
+    "id": 27860,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "7. Klasse",
     "requestAt": "2024-02-17 08:08:06.508"
   },
   {
+    "id": 28955,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "6. Klasse",
     "requestAt": "2024-02-17 09:15:05.216"
   },
   {
+    "id": 28550,
     "subjects": "[{\"name\":\"Biologie\",\"mandatory\":true},{\"name\":\"Erdkunde\",\"mandatory\":false}]",
     "state": "hh",
     "grade": "12. Klasse",
     "requestAt": "2024-02-17 09:26:04.998"
   },
   {
+    "id": 25452,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "6. Klasse",
     "requestAt": "2024-02-17 09:26:18.801"
   },
   {
+    "id": 5675,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "10. Klasse",
     "requestAt": "2024-02-17 09:53:22.003"
   },
   {
+    "id": 15790,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "5. Klasse",
     "requestAt": "2024-02-17 09:56:52.199"
   },
   {
+    "id": 19749,
     "subjects": "[{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "by",
     "grade": "11. Klasse",
     "requestAt": "2024-02-17 10:36:12.712"
   },
   {
+    "id": 21011,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Religion\",\"mandatory\":true}]",
     "state": "hb",
     "grade": "13. Klasse",
     "requestAt": "2024-02-17 10:42:57.212"
   },
   {
+    "id": 28595,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "th",
     "grade": "8. Klasse",
     "requestAt": "2024-02-17 11:05:57.272"
   },
   {
+    "id": 13639,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2024-02-17 12:44:03.724"
   },
   {
+    "id": 13332,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
     "state": "be",
     "grade": "10. Klasse",
     "requestAt": "2024-02-17 13:16:41.993"
   },
   {
+    "id": 28378,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "he",
     "grade": "9. Klasse",
     "requestAt": "2024-02-17 14:44:11.787"
   },
   {
+    "id": 28851,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "11. Klasse",
     "requestAt": "2024-02-17 16:01:43.392"
   },
   {
+    "id": 26851,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "sn",
     "grade": "9. Klasse",
     "requestAt": "2024-02-17 16:03:00.662"
   },
   {
+    "id": 29526,
     "subjects": "[{\"name\":\"Mathematik\"}]",
     "state": "by",
     "grade": "8. Klasse",
     "requestAt": "2024-02-17 16:20:20.476"
   },
   {
+    "id": 11108,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false}]",
     "state": "by",
     "grade": "11. Klasse",
     "requestAt": "2024-02-17 16:59:31.984"
   },
   {
+    "id": 6684,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "8. Klasse",
     "requestAt": "2024-02-17 17:37:17.516"
   },
   {
+    "id": 30012,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "by",
     "grade": "2. Klasse",
     "requestAt": "2024-02-17 20:27:15.848"
   },
   {
+    "id": 13598,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Biologie\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "6. Klasse",
     "requestAt": "2024-02-17 20:39:23.402"
   },
   {
+    "id": 28676,
     "subjects": "[{\"name\":\"Physik\",\"mandatory\":true},{\"name\":\"Lernen lernen\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
     "state": "ni",
     "grade": "9. Klasse",
     "requestAt": "2024-02-17 21:38:38.397"
   },
   {
+    "id": 29752,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2024-02-17 22:30:49.724"
   },
   {
+    "id": 12889,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2024-02-18 07:59:40.933"
   },
   {
+    "id": 29050,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2024-02-18 08:42:20.259"
   },
   {
+    "id": 29873,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "5. Klasse",
     "requestAt": "2024-02-18 12:13:45.553"
   },
   {
+    "id": 30015,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "5. Klasse",
     "requestAt": "2024-02-18 12:39:29.374"
   },
   {
+    "id": 26058,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2024-02-18 14:04:49.083"
   },
   {
+    "id": 30016,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "by",
     "grade": "3. Klasse",
     "requestAt": "2024-02-18 14:09:38.334"
   },
   {
+    "id": 28627,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "4. Klasse",
     "requestAt": "2024-02-18 15:13:22.838"
   },
   {
+    "id": 27131,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "9. Klasse",
     "requestAt": "2024-02-18 17:12:45.596"
   },
   {
+    "id": 15901,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "sh",
     "grade": "9. Klasse",
     "requestAt": "2024-02-18 20:48:20.449"
   },
   {
+    "id": 17504,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "he",
     "grade": "6. Klasse",
     "requestAt": "2024-02-18 22:27:09.238"
   },
   {
+    "id": 25575,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "8. Klasse",
     "requestAt": "2024-02-19 13:05:21.222"
   },
   {
+    "id": 29304,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "by",
     "grade": "6. Klasse",
     "requestAt": "2024-02-19 14:49:02.508"
   },
   {
+    "id": 20622,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "6. Klasse",
     "requestAt": "2024-02-19 15:15:14.737"
   },
   {
+    "id": 12879,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "11. Klasse",
     "requestAt": "2024-02-19 15:52:11.75"
   },
   {
+    "id": 26165,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "by",
     "grade": "11. Klasse",
     "requestAt": "2024-02-19 16:44:46.63"
   },
   {
+    "id": 17654,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Musik\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "9. Klasse",
     "requestAt": "2024-02-19 19:04:17.636"
   },
   {
+    "id": 28977,
     "subjects": "[{\"name\":\"Pädagogik\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2024-02-19 19:21:02.68"
   },
   {
+    "id": 30020,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
     "state": "be",
     "grade": "9. Klasse",
     "requestAt": "2024-02-19 19:24:36.02"
   },
   {
+    "id": 29671,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false}]",
     "state": "be",
     "grade": "9. Klasse",
     "requestAt": "2024-02-19 19:30:59.242"
   },
   {
+    "id": 24371,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "be",
     "grade": "7. Klasse",
     "requestAt": "2024-02-19 19:33:24.391"
   },
   {
+    "id": 29742,
     "subjects": "[{\"name\":\"Biologie\",\"mandatory\":true}]",
     "state": "sh",
     "grade": "10. Klasse",
     "requestAt": "2024-02-19 19:46:40.556"
   },
   {
+    "id": 16205,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true},{\"name\":\"Spanisch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "9. Klasse",
     "requestAt": "2024-02-20 17:28:58.631"
   },
   {
+    "id": 28732,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "7. Klasse",
     "requestAt": "2024-02-20 20:52:56.984"
   },
   {
+    "id": 28969,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "he",
     "grade": "6. Klasse",
     "requestAt": "2024-02-20 21:14:09.625"
   },
   {
+    "id": 20510,
     "subjects": "[{\"name\":\"Mathematik\"}]",
     "state": "he",
     "grade": "8. Klasse",
     "requestAt": "2024-02-21 06:16:14.669"
   },
   {
+    "id": 30029,
     "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2024-02-21 08:28:39.326"
   },
   {
+    "id": 29477,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2024-02-21 08:36:16.846"
   },
   {
+    "id": 29011,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
     "state": "ni",
     "grade": "5. Klasse",
     "requestAt": "2024-02-21 19:02:05.429"
   },
   {
+    "id": 21330,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "7. Klasse",
     "requestAt": "2024-02-21 21:46:09.08"
   },
   {
+    "id": 28496,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "10. Klasse",
     "requestAt": "2024-02-22 09:22:02.535"
   },
   {
+    "id": 29009,
     "subjects": "[{\"name\":\"Latein\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":false}]",
     "state": "sh",
     "grade": "9. Klasse",
     "requestAt": "2024-02-22 12:41:26.485"
   },
   {
+    "id": 5648,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Politik\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
     "state": "ni",
     "grade": "10. Klasse",
     "requestAt": "2024-02-22 14:41:59.201"
   },
   {
+    "id": 30027,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "6. Klasse",
     "requestAt": "2024-02-22 14:54:39.263"
   },
   {
+    "id": 19623,
     "subjects": "[{\"name\":\"Informatik\",\"mandatory\":true}]",
     "state": "hb",
     "grade": "13. Klasse",
     "requestAt": "2024-02-22 15:10:50.984"
   },
   {
+    "id": 27379,
     "subjects": "[{\"name\":\"Latein\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "11. Klasse",
     "requestAt": "2024-02-22 15:23:36.805"
   },
   {
+    "id": 30035,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
     "state": "by",
     "grade": "7. Klasse",
     "requestAt": "2024-02-22 20:57:10.573"
   },
   {
+    "id": 29328,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "ni",
     "grade": "12. Klasse",
     "requestAt": "2024-02-23 08:53:07.187"
   },
   {
+    "id": 27137,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "5. Klasse",
     "requestAt": "2024-02-23 14:00:49.021"
   },
   {
+    "id": 28158,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "he",
     "grade": "6. Klasse",
     "requestAt": "2024-02-23 18:36:30.127"
   },
   {
+    "id": 29503,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "11. Klasse",
     "requestAt": "2024-02-24 18:29:05.114"
   },
   {
+    "id": 30043,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Lernen lernen\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
     "state": "by",
     "grade": "8. Klasse",
     "requestAt": "2024-02-25 08:56:04.6"
   },
   {
+    "id": 29801,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "10. Klasse",
     "requestAt": "2024-02-25 10:34:00.528"
   },
   {
+    "id": 21522,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "7. Klasse",
     "requestAt": "2024-02-25 10:43:26.224"
   },
   {
+    "id": 29673,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "be",
     "grade": "6. Klasse",
     "requestAt": "2024-02-25 17:00:25.379"
   },
   {
+    "id": 9457,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
     "state": "be",
     "grade": "9. Klasse",
     "requestAt": "2024-02-25 17:14:22.937"
   },
   {
+    "id": 18536,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "th",
     "grade": "8. Klasse",
     "requestAt": "2024-02-26 14:37:05.32"
   },
   {
+    "id": 12606,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false}]",
     "state": "other",
     "grade": "10. Klasse",
     "requestAt": "2024-02-26 17:31:54.351"
   },
   {
+    "id": 28655,
     "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "12. Klasse",
     "requestAt": "2024-02-26 17:33:49.984"
   },
   {
+    "id": 29817,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "7. Klasse",
     "requestAt": "2024-02-26 17:56:54.815"
   },
   {
+    "id": 29316,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "ni",
     "grade": "4. Klasse",
     "requestAt": "2024-02-28 07:42:00.258"
   },
   {
+    "id": 14347,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2024-02-28 10:06:28.49"
   },
   {
+    "id": 30040,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "be",
     "grade": "3. Klasse",
     "requestAt": "2024-02-29 13:06:08.887"
   },
   {
+    "id": 5078,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":false}]",
     "state": "other",
     "grade": "13. Klasse",
     "requestAt": "2024-02-29 14:27:03.101"
   },
   {
+    "id": 28934,
     "subjects": "[{\"name\":\"Wirtschaft\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2024-02-29 17:02:46.703"
   },
   {
+    "id": 28632,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2024-02-29 18:59:22.892"
   },
   {
+    "id": 30066,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
     "state": "sn",
     "grade": "10. Klasse",
     "requestAt": "2024-02-29 21:00:40.459"
   },
   {
+    "id": 30067,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "6. Klasse",
     "requestAt": "2024-02-29 22:16:47.893"
   },
   {
+    "id": 13639,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2024-03-01 07:44:30.814"
   },
   {
+    "id": 30074,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2024-03-03 19:15:54.777"
   },
   {
+    "id": 30018,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "5. Klasse",
     "requestAt": "2024-03-03 20:10:00.869"
   },
   {
+    "id": 29927,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":true}]",
     "state": "sn",
     "grade": "7. Klasse",
     "requestAt": "2024-03-03 20:33:52.591"
   },
   {
+    "id": 27596,
     "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2024-03-04 15:16:44.016"
   },
   {
+    "id": 2439,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "hh",
     "grade": "5. Klasse",
     "requestAt": "2024-03-05 07:28:04.081"
   },
   {
+    "id": 5585,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true}]",
     "state": "be",
     "grade": "12. Klasse",
     "requestAt": "2024-03-05 14:20:28.395"
   },
   {
+    "id": 29629,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2024-03-05 18:16:16.427"
   },
   {
+    "id": 804,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "9. Klasse",
     "requestAt": "2024-03-05 19:24:00.629"
   },
   {
+    "id": 17730,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "9. Klasse",
     "requestAt": "2024-03-06 11:00:08.711"
   },
   {
+    "id": 1321,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "sn",
     "grade": "7. Klasse",
     "requestAt": "2024-03-06 18:34:59.004"
   },
   {
+    "id": 29958,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2024-03-09 15:41:43.141"
   },
   {
+    "id": 28934,
     "subjects": "[{\"name\":\"Wirtschaft\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2024-03-09 15:46:33.586"
   },
   {
+    "id": 29024,
     "subjects": "[{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "12. Klasse",
     "requestAt": "2024-03-09 16:56:56.807"
   },
   {
+    "id": 28632,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2024-03-09 20:28:18.616"
   },
   {
+    "id": 28784,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "7. Klasse",
     "requestAt": "2024-03-10 08:07:04.793"
   },
   {
+    "id": 22124,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "10. Klasse",
     "requestAt": "2024-03-10 19:16:55.117"
   },
   {
+    "id": 1838,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "th",
     "grade": "7. Klasse",
     "requestAt": "2024-03-11 11:46:34.144"
   },
   {
+    "id": 29690,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "3. Klasse",
     "requestAt": "2024-03-11 17:51:47.582"
   },
   {
+    "id": 25444,
     "subjects": "[{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "ni",
     "grade": "6. Klasse",
     "requestAt": "2024-03-11 23:41:28.463"
   },
   {
+    "id": 12496,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2024-03-13 10:24:51.696"
   },
   {
+    "id": 5543,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "8. Klasse",
     "requestAt": "2024-03-13 14:04:12.158"
   },
   {
+    "id": 30089,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "8. Klasse",
     "requestAt": "2024-03-14 14:55:09.003"
   },
   {
+    "id": 7471,
     "subjects": "[{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":true}]",
     "state": "hh",
     "grade": "10. Klasse",
     "requestAt": "2024-03-14 20:03:52.38"
   },
   {
+    "id": 27438,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Latein\",\"mandatory\":true}]",
     "state": "ni",
     "grade": "8. Klasse",
     "requestAt": "2024-03-15 06:54:52.267"
   },
   {
+    "id": 29477,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2024-03-15 12:15:59.715"
   },
   {
+    "id": 22728,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Wirtschaft\",\"mandatory\":true},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
     "state": "by",
     "grade": "9. Klasse",
     "requestAt": "2024-03-17 11:52:52.57"
   },
   {
+    "id": 19320,
     "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true}]",
     "state": "hh",
     "grade": "13. Klasse",
     "requestAt": "2024-03-19 09:21:28.287"
   },
   {
+    "id": 29316,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "ni",
     "grade": "4. Klasse",
     "requestAt": "2024-03-19 15:03:07.591"
   },
   {
+    "id": 30094,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "be",
     "grade": "10. Klasse",
     "requestAt": "2024-03-19 15:20:14.288"
   },
   {
+    "id": 30091,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "4. Klasse",
     "requestAt": "2024-03-19 16:01:46.771"
   },
   {
+    "id": 28504,
     "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true},{\"name\":\"Spanisch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2024-03-19 17:19:31.846"
   },
   {
+    "id": 29360,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "he",
     "grade": "4. Klasse",
     "requestAt": "2024-03-20 09:12:45.646"
   },
   {
+    "id": 26725,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "11. Klasse",
     "requestAt": "2024-03-20 10:59:13.124"
   },
   {
+    "id": 30137,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "11. Klasse",
     "requestAt": "2024-03-20 12:13:33.449"
   },
   {
+    "id": 29754,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "6. Klasse",
     "requestAt": "2024-03-20 15:02:47.443"
   },
   {
+    "id": 30150,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "9. Klasse",
     "requestAt": "2024-03-21 14:46:00.899"
   },
   {
+    "id": 30163,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "11. Klasse",
     "requestAt": "2024-03-21 15:32:27.368"
   },
   {
+    "id": 26313,
     "subjects": "[{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "hh",
     "grade": "13. Klasse",
     "requestAt": "2024-03-22 00:03:00.113"
   },
   {
+    "id": 30084,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
     "state": "by",
     "grade": "3. Klasse",
     "requestAt": "2024-03-22 13:40:57.105"
   },
   {
+    "id": 30087,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "10. Klasse",
     "requestAt": "2024-03-22 13:48:36.079"
   },
   {
+    "id": 25761,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "8. Klasse",
     "requestAt": "2024-03-23 23:25:16.706"
   },
   {
+    "id": 30152,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":false}]",
     "state": "he",
     "grade": "5. Klasse",
     "requestAt": "2024-03-25 17:37:18.699"
   },
   {
+    "id": 28370,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true}]",
     "state": "th",
     "grade": "10. Klasse",
     "requestAt": "2024-03-26 16:06:33.401"
   },
   {
+    "id": 3075,
     "subjects": "[{\"name\":\"Biologie\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "12. Klasse",
     "requestAt": "2024-03-27 14:04:45.063"
   },
   {
+    "id": 18055,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "11. Klasse",
     "requestAt": "2024-03-27 17:25:59.215"
   },
   {
+    "id": 27012,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "8. Klasse",
     "requestAt": "2024-03-27 19:22:00.485"
   },
   {
+    "id": 29225,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2024-03-27 23:24:09.235"
   },
   {
+    "id": 27131,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "9. Klasse",
     "requestAt": "2024-03-28 20:33:20.886"
   },
   {
+    "id": 28827,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "5. Klasse",
     "requestAt": "2024-03-31 18:36:43.508"
   },
   {
+    "id": 4002,
     "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "13. Klasse",
     "requestAt": "2024-04-01 11:11:06.091"
   },
   {
+    "id": 29223,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "he",
     "grade": "3. Klasse",
     "requestAt": "2024-04-01 13:53:25.519"
   },
   {
+    "id": 29972,
     "subjects": "[{\"name\":\"Lernen lernen\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "sh",
     "grade": "6. Klasse",
     "requestAt": "2024-04-01 17:15:17.148"
   },
   {
+    "id": 29886,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "th",
     "grade": "6. Klasse",
     "requestAt": "2024-04-03 07:45:31.86"
   },
   {
+    "id": 30184,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "2. Klasse",
     "requestAt": "2024-04-03 13:29:21.537"
   },
   {
+    "id": 24727,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "9. Klasse",
     "requestAt": "2024-04-04 08:27:43.028"
   },
   {
+    "id": 22285,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2024-04-04 14:12:24.875"
   },
   {
+    "id": 30168,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "by",
     "grade": "6. Klasse",
     "requestAt": "2024-04-05 08:20:13.088"
   },
   {
+    "id": 30183,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "2. Klasse",
     "requestAt": "2024-04-08 12:13:17.589"
   },
   {
+    "id": 30186,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "8. Klasse",
     "requestAt": "2024-04-08 12:44:22.86"
   },
   {
+    "id": 27596,
     "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2024-04-08 15:11:42.801"
   },
   {
+    "id": 25141,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "6. Klasse",
     "requestAt": "2024-04-09 10:35:43.999"
   },
   {
+    "id": 17730,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "9. Klasse",
     "requestAt": "2024-04-10 07:07:14.519"
   },
   {
+    "id": 30165,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "7. Klasse",
     "requestAt": "2024-04-10 09:56:54.313"
   },
   {
+    "id": 12972,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2024-04-10 16:04:17.341"
   },
   {
+    "id": 10617,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "sn",
     "grade": "10. Klasse",
     "requestAt": "2024-04-11 14:49:47.71"
   },
   {
+    "id": 12496,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2024-04-12 08:33:33.371"
   },
   {
+    "id": 9519,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":true}]",
     "state": "be",
     "grade": "7. Klasse",
     "requestAt": "2024-04-12 10:07:33.217"
   },
   {
+    "id": 25256,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":true}]",
     "state": "ni",
     "grade": "10. Klasse",
     "requestAt": "2024-04-12 12:17:34.821"
   },
   {
+    "id": 21751,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
     "state": "he",
     "grade": "11. Klasse",
     "requestAt": "2024-04-12 14:28:38.568"
   },
   {
+    "id": 12318,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2024-04-12 19:45:53.443"
   },
   {
+    "id": 11662,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "6. Klasse",
     "requestAt": "2024-04-13 04:23:43.633"
   },
   {
+    "id": 11918,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "by",
     "grade": "6. Klasse",
     "requestAt": "2024-04-14 19:03:36.935"
   },
   {
+    "id": 29752,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2024-04-14 19:48:22.17"
   },
   {
+    "id": 28611,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "by",
     "grade": "7. Klasse",
     "requestAt": "2024-04-15 12:10:28.151"
   },
   {
+    "id": 30207,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "he",
     "grade": "6. Klasse",
     "requestAt": "2024-04-16 12:40:34.116"
   },
   {
+    "id": 13460,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "10. Klasse",
     "requestAt": "2024-04-16 14:37:11.016"
   },
   {
+    "id": 24402,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "6. Klasse",
     "requestAt": "2024-04-16 17:29:21.288"
   },
   {
+    "id": 24061,
     "subjects": "[{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "he",
     "grade": "11. Klasse",
     "requestAt": "2024-04-16 18:18:38.051"
   },
   {
+    "id": 17486,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":false}]",
     "state": "hh",
     "grade": "12. Klasse",
     "requestAt": "2024-04-17 09:13:50.558"
   },
   {
+    "id": 30220,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "he",
     "grade": "2. Klasse",
     "requestAt": "2024-04-18 13:14:04.763"
   },
   {
+    "id": 30206,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "2. Klasse",
     "requestAt": "2024-04-18 14:04:13.805"
   },
   {
+    "id": 28983,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2024-04-18 14:10:30.6"
   },
   {
+    "id": 10430,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "9. Klasse",
     "requestAt": "2024-04-18 18:23:34.539"
   },
   {
+    "id": 30210,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "th",
     "grade": "3. Klasse",
     "requestAt": "2024-04-18 19:18:37.566"
   },
   {
+    "id": 24875,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "5. Klasse",
     "requestAt": "2024-04-19 13:50:09.994"
   },
   {
+    "id": 28356,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "be",
     "grade": "3. Klasse",
     "requestAt": "2024-04-22 14:18:26.413"
   },
   {
+    "id": 22728,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Wirtschaft\",\"mandatory\":true},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
     "state": "by",
     "grade": "9. Klasse",
     "requestAt": "2024-04-23 11:01:50.207"
   },
   {
+    "id": 30223,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "sn",
     "grade": "6. Klasse",
     "requestAt": "2024-04-23 13:17:27.892"
   },
   {
+    "id": 30221,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":false}]",
     "state": "other",
     "grade": "6. Klasse",
     "requestAt": "2024-04-23 13:20:10.854"
   },
   {
+    "id": 30094,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "be",
     "grade": "10. Klasse",
     "requestAt": "2024-04-24 20:51:03.424"
   },
   {
+    "id": 28955,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "6. Klasse",
     "requestAt": "2024-04-25 12:14:09.008"
   },
   {
+    "id": 29305,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "he",
     "grade": "6. Klasse",
     "requestAt": "2024-04-25 14:07:31.542"
   },
   {
+    "id": 20510,
     "subjects": "[{\"name\":\"Mathematik\"}]",
     "state": "he",
     "grade": "8. Klasse",
     "requestAt": "2024-04-25 14:17:22.809"
   },
   {
+    "id": 29474,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2024-04-25 16:03:14.767"
   },
   {
+    "id": 29946,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "by",
     "grade": "6. Klasse",
     "requestAt": "2024-04-25 16:21:33.787"
   },
   {
+    "id": 30145,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "2. Klasse",
     "requestAt": "2024-04-25 17:12:19.294"
   },
   {
+    "id": 24271,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2024-04-25 18:22:27.473"
   },
   {
+    "id": 7471,
     "subjects": "[{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":true}]",
     "state": "hh",
     "grade": "10. Klasse",
     "requestAt": "2024-04-26 09:21:01.78"
   },
   {
+    "id": 25444,
     "subjects": "[{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "ni",
     "grade": "6. Klasse",
     "requestAt": "2024-04-27 06:58:43.683"
   },
   {
+    "id": 17730,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "9. Klasse",
     "requestAt": "2024-04-28 14:46:03.851"
   },
   {
+    "id": 24292,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "5. Klasse",
     "requestAt": "2024-04-28 17:46:56.337"
   },
   {
+    "id": 29772,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "4. Klasse",
     "requestAt": "2024-04-29 11:55:56.546"
   },
   {
+    "id": 30230,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "sn",
     "grade": "8. Klasse",
     "requestAt": "2024-04-29 12:22:54.284"
   },
   {
+    "id": 30172,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "10. Klasse",
     "requestAt": "2024-04-29 18:17:56.025"
   },
   {
+    "id": 30185,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "5. Klasse",
     "requestAt": "2024-04-29 18:25:44.651"
   },
   {
+    "id": 11638,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Latein\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "10. Klasse",
     "requestAt": "2024-04-30 19:08:06.284"
   },
   {
+    "id": 17504,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "he",
     "grade": "6. Klasse",
     "requestAt": "2024-05-02 08:24:37.828"
   },
   {
+    "id": 12150,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "8. Klasse",
     "requestAt": "2024-05-02 11:39:44.913"
   },
   {
+    "id": 30190,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
     "state": "hh",
     "grade": "6. Klasse",
     "requestAt": "2024-05-02 14:21:08.59"
   },
   {
+    "id": 3075,
     "subjects": "[{\"name\":\"Biologie\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "12. Klasse",
     "requestAt": "2024-05-02 16:32:17.981"
   },
   {
+    "id": 29628,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "8. Klasse",
     "requestAt": "2024-05-02 17:44:47.898"
   },
   {
+    "id": 14854,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2024-05-03 09:45:25.685"
   },
   {
+    "id": 28563,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "4. Klasse",
     "requestAt": "2024-05-03 10:46:15.457"
   },
   {
+    "id": 29976,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "by",
     "grade": "3. Klasse",
     "requestAt": "2024-05-03 14:19:50.776"
   },
   {
+    "id": 29466,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false}]",
     "state": "be",
     "grade": "13. Klasse",
     "requestAt": "2024-05-05 11:23:48.051"
   },
   {
+    "id": 30263,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "sn",
     "grade": "3. Klasse",
     "requestAt": "2024-05-06 12:06:39.039"
   },
   {
+    "id": 22425,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "he",
     "grade": "10. Klasse",
     "requestAt": "2024-05-06 15:23:43.849"
   },
   {
+    "id": 30220,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "he",
     "grade": "2. Klasse",
     "requestAt": "2024-05-06 16:04:47.89"
   },
   {
+    "id": 30058,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "5. Klasse",
     "requestAt": "2024-05-06 17:46:34.365"
   },
   {
+    "id": 30260,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "be",
     "grade": "11. Klasse",
     "requestAt": "2024-05-07 08:58:34.446"
   },
   {
+    "id": 30258,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "be",
     "grade": "4. Klasse",
     "requestAt": "2024-05-07 15:12:10.176"
   },
   {
+    "id": 30257,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false}]",
     "state": "be",
     "grade": "6. Klasse",
     "requestAt": "2024-05-07 15:13:02.277"
   },
   {
+    "id": 29072,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "3. Klasse",
     "requestAt": "2024-05-07 16:06:16.697"
   },
   {
+    "id": 22531,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "10. Klasse",
     "requestAt": "2024-05-07 16:57:57.781"
   },
   {
+    "id": 29181,
     "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2024-05-09 14:27:42.26"
   },
   {
+    "id": 16205,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true},{\"name\":\"Spanisch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "9. Klasse",
     "requestAt": "2024-05-10 13:03:54.047"
   },
   {
+    "id": 28378,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "he",
     "grade": "9. Klasse",
     "requestAt": "2024-05-13 09:01:48.827"
   },
   {
+    "id": 30282,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "by",
     "grade": "14. Klasse",
     "requestAt": "2024-05-13 14:15:00.216"
   },
   {
+    "id": 30287,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "2. Klasse",
     "requestAt": "2024-05-13 15:55:02.207"
   },
   {
+    "id": 20219,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "11. Klasse",
     "requestAt": "2024-05-14 12:00:16.501"
   },
   {
+    "id": 30268,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "by",
     "grade": "12. Klasse",
     "requestAt": "2024-05-14 15:56:25.539"
   },
   {
+    "id": 30271,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "he",
     "grade": "4. Klasse",
     "requestAt": "2024-05-14 17:12:05.726"
   },
   {
+    "id": 26851,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "sn",
     "grade": "9. Klasse",
     "requestAt": "2024-05-16 03:56:35.825"
   },
   {
+    "id": 18926,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "6. Klasse",
     "requestAt": "2024-05-16 08:15:34.446"
   },
   {
+    "id": 24197,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2024-05-16 13:49:20.577"
   },
   {
+    "id": 30279,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Pädagogik\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "14. Klasse",
     "requestAt": "2024-05-16 16:32:11.215"
   },
   {
+    "id": 30210,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "th",
     "grade": "3. Klasse",
     "requestAt": "2024-05-16 19:14:17.24"
   },
   {
+    "id": 17730,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "9. Klasse",
     "requestAt": "2024-05-17 12:11:00.495"
   },
   {
+    "id": 28955,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "6. Klasse",
     "requestAt": "2024-05-17 12:23:29.828"
   },
   {
+    "id": 28158,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "he",
     "grade": "6. Klasse",
     "requestAt": "2024-05-17 22:20:48.23"
   },
   {
+    "id": 29629,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2024-05-18 13:28:04.688"
   },
   {
+    "id": 13815,
     "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true},{\"name\":\"Politik\",\"mandatory\":false}]",
     "state": "he",
     "grade": "12. Klasse",
     "requestAt": "2024-05-18 22:56:36.484"
   },
   {
+    "id": 10660,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "11. Klasse",
     "requestAt": "2024-05-19 07:47:40.741"
   },
   {
+    "id": 30273,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "9. Klasse",
     "requestAt": "2024-05-19 10:44:16.729"
   },
   {
+    "id": 29516,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "6. Klasse",
     "requestAt": "2024-05-19 15:55:01.33"
   },
   {
+    "id": 30200,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2024-05-19 18:58:10.551"
   },
   {
+    "id": 30292,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "by",
     "grade": "8. Klasse",
     "requestAt": "2024-05-20 16:20:32.736"
   },
   {
+    "id": 30296,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "9. Klasse",
     "requestAt": "2024-05-20 21:25:12.568"
   },
   {
+    "id": 30280,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "14. Klasse",
     "requestAt": "2024-05-21 13:20:47.694"
   },
   {
+    "id": 30301,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "by",
     "grade": "3. Klasse",
     "requestAt": "2024-05-21 16:33:59.634"
   },
   {
+    "id": 26692,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Spanisch\",\"mandatory\":false}]",
     "state": "sn",
     "grade": "9. Klasse",
     "requestAt": "2024-05-22 13:16:18.841"
   },
   {
+    "id": 17486,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":false}]",
     "state": "hh",
     "grade": "12. Klasse",
     "requestAt": "2024-05-22 22:18:38.734"
   },
   {
+    "id": 28496,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "10. Klasse",
     "requestAt": "2024-05-23 08:13:44.319"
   },
   {
+    "id": 28496,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "10. Klasse",
     "requestAt": "2024-05-23 08:13:44.319"
   },
   {
+    "id": 28793,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true}]",
     "state": "be",
     "grade": "8. Klasse",
     "requestAt": "2024-05-23 13:57:10.221"
   },
   {
+    "id": 30285,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2024-05-23 15:59:13.234"
   },
   {
+    "id": 30217,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "he",
     "grade": "2. Klasse",
     "requestAt": "2024-05-23 16:24:51.753"
   },
   {
+    "id": 30292,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "by",
     "grade": "8. Klasse",
     "requestAt": "2024-05-24 13:20:54.389"
   },
   {
+    "id": 30201,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "he",
     "grade": "6. Klasse",
     "requestAt": "2024-05-25 12:31:47.612"
   },
   {
+    "id": 15901,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "sh",
     "grade": "9. Klasse",
     "requestAt": "2024-05-25 17:28:03.062"
   },
   {
+    "id": 28356,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "be",
     "grade": "3. Klasse",
     "requestAt": "2024-05-26 11:44:40.407"
   },
   {
+    "id": 29942,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "be",
     "grade": "7. Klasse",
     "requestAt": "2024-05-26 15:40:16.084"
   },
   {
+    "id": 30291,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "2. Klasse",
     "requestAt": "2024-05-27 12:46:20.754"
   },
   {
+    "id": 30307,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "8. Klasse",
     "requestAt": "2024-05-27 14:14:01.119"
   },
   {
+    "id": 30313,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "he",
     "grade": "14. Klasse",
     "requestAt": "2024-05-27 15:55:03.889"
   },
   {
+    "id": 30144,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
     "state": "he",
     "grade": "6. Klasse",
     "requestAt": "2024-05-28 11:51:21.787"
   },
   {
+    "id": 30293,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "14. Klasse",
     "requestAt": "2024-05-28 13:48:29.868"
   },
   {
+    "id": 29328,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "ni",
     "grade": "12. Klasse",
     "requestAt": "2024-05-28 14:38:36.054"
   },
   {
+    "id": 30317,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "be",
     "grade": "6. Klasse",
     "requestAt": "2024-05-28 16:27:12.307"
   },
   {
+    "id": 30309,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "sn",
     "grade": "5. Klasse",
     "requestAt": "2024-05-28 17:19:18.471"
   },
   {
+    "id": 13108,
     "subjects": "[{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2024-05-29 12:30:39.373"
   },
   {
+    "id": 30044,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "10. Klasse",
     "requestAt": "2024-05-29 14:28:27.366"
   },
   {
+    "id": 30252,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "be",
     "grade": "5. Klasse",
     "requestAt": "2024-05-29 16:41:29.035"
   },
   {
+    "id": 30308,
     "subjects": "[{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "14. Klasse",
     "requestAt": "2024-05-29 17:07:08.651"
   },
   {
+    "id": 29892,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "he",
     "grade": "4. Klasse",
     "requestAt": "2024-05-30 11:33:20.531"
   },
   {
+    "id": 19320,
     "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true}]",
     "state": "hh",
     "grade": "13. Klasse",
     "requestAt": "2024-05-30 21:09:35.272"
   },
   {
+    "id": 21196,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "6. Klasse",
     "requestAt": "2024-05-31 07:01:06.281"
   },
   {
+    "id": 19490,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Erdkunde\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2024-05-31 08:08:15.167"
   },
   {
+    "id": 29671,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false}]",
     "state": "be",
     "grade": "9. Klasse",
     "requestAt": "2024-05-31 20:54:18.743"
   },
   {
+    "id": 30292,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "by",
     "grade": "8. Klasse",
     "requestAt": "2024-06-02 22:45:39.795"
   },
   {
+    "id": 30305,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "14. Klasse",
     "requestAt": "2024-06-03 12:35:12.299"
   },
   {
+    "id": 21464,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2024-06-04 05:27:04.723"
   },
   {
+    "id": 30137,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "11. Klasse",
     "requestAt": "2024-06-04 08:14:22.957"
   },
   {
+    "id": 30315,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2024-06-04 17:55:20.071"
   },
   {
+    "id": 14854,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2024-06-05 05:12:25.796"
   },
   {
+    "id": 30302,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Biologie\",\"mandatory\":false}]",
     "state": "sh",
     "grade": "13. Klasse",
     "requestAt": "2024-06-05 15:34:00.951"
   },
   {
+    "id": 30373,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "th",
     "grade": "7. Klasse",
     "requestAt": "2024-06-05 16:08:14.734"
   },
   {
+    "id": 30351,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Informatik\",\"mandatory\":false}]",
     "state": "he",
     "grade": "14. Klasse",
     "requestAt": "2024-06-06 17:08:42.31"
   },
   {
+    "id": 28969,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "he",
     "grade": "6. Klasse",
     "requestAt": "2024-06-07 08:05:49.37"
   },
   {
+    "id": 30154,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Erdkunde\",\"mandatory\":false}]",
     "state": "hh",
     "grade": "13. Klasse",
     "requestAt": "2024-06-07 12:38:34.733"
   },
   {
+    "id": 29754,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "6. Klasse",
     "requestAt": "2024-06-07 13:14:01.065"
   },
   {
+    "id": 15101,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
     "state": "sn",
     "grade": "7. Klasse",
     "requestAt": "2024-06-07 14:18:33.346"
   },
   {
+    "id": 30285,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2024-06-09 15:19:33.004"
   },
   {
+    "id": 30371,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2024-06-10 13:28:59.394"
   },
   {
+    "id": 28955,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "6. Klasse",
     "requestAt": "2024-06-11 07:27:59.047"
   },
   {
+    "id": 30220,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "he",
     "grade": "2. Klasse",
     "requestAt": "2024-06-11 07:29:32.9"
   },
   {
+    "id": 22425,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "he",
     "grade": "10. Klasse",
     "requestAt": "2024-06-11 13:57:53.074"
   },
   {
+    "id": 28088,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "ni",
     "grade": "10. Klasse",
     "requestAt": "2024-06-11 15:42:17.351"
   },
   {
+    "id": 30306,
     "subjects": "[{\"name\":\"Informatik\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "14. Klasse",
     "requestAt": "2024-06-11 16:43:46.933"
   },
   {
+    "id": 30359,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "ni",
     "grade": "3. Klasse",
     "requestAt": "2024-06-11 16:44:38.293"
   },
   {
+    "id": 30380,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2024-06-11 16:45:23.033"
   },
   {
+    "id": 30382,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":false}]",
     "state": "he",
     "grade": "2. Klasse",
     "requestAt": "2024-06-11 17:41:24.208"
   },
   {
+    "id": 21939,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "he",
     "grade": "6. Klasse",
     "requestAt": "2024-06-12 11:13:55.535"
   },
   {
+    "id": 29628,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "8. Klasse",
     "requestAt": "2024-06-12 18:27:41.742"
   },
   {
+    "id": 7471,
     "subjects": "[{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":true}]",
     "state": "hh",
     "grade": "10. Klasse",
     "requestAt": "2024-06-12 18:49:47.979"
   },
   {
+    "id": 9066,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Informatik\",\"mandatory\":true}]",
     "state": "other",
     "grade": "10. Klasse",
     "requestAt": "2024-06-12 19:24:11.209"
   },
   {
+    "id": 18845,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
     "state": "he",
     "grade": "9. Klasse",
     "requestAt": "2024-06-13 09:01:37.424"
   },
   {
+    "id": 30400,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "hb",
     "grade": "14. Klasse",
     "requestAt": "2024-06-13 12:47:29.957"
   },
   {
+    "id": 30315,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2024-06-13 15:27:48.614"
   },
   {
+    "id": 30371,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2024-06-13 19:42:40.106"
   },
   {
+    "id": 17504,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "he",
     "grade": "6. Klasse",
     "requestAt": "2024-06-14 11:27:17.929"
   },
   {
+    "id": 30394,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "ni",
     "grade": "7. Klasse",
     "requestAt": "2024-06-14 11:48:37.33"
   },
   {
+    "id": 30396,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "4. Klasse",
     "requestAt": "2024-06-14 12:39:47.707"
   },
   {
+    "id": 19023,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "be",
     "grade": "10. Klasse",
     "requestAt": "2024-06-14 12:52:19.656"
   },
   {
+    "id": 19320,
     "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true}]",
     "state": "hh",
     "grade": "13. Klasse",
     "requestAt": "2024-06-14 22:03:19.034"
   },
   {
+    "id": 29223,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "he",
     "grade": "3. Klasse",
     "requestAt": "2024-06-17 13:25:13.633"
   },
   {
+    "id": 30184,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "2. Klasse",
     "requestAt": "2024-06-17 13:51:51.57"
   },
   {
+    "id": 28878,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "ni",
     "grade": "13. Klasse",
     "requestAt": "2024-06-17 17:10:11.907"
   },
   {
+    "id": 29705,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "th",
     "grade": "5. Klasse",
     "requestAt": "2024-06-18 05:36:58.806"
   },
   {
+    "id": 29892,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "he",
     "grade": "4. Klasse",
     "requestAt": "2024-06-18 11:50:53.084"
   },
   {
+    "id": 19023,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "be",
     "grade": "10. Klasse",
     "requestAt": "2024-06-18 12:19:25.665"
   },
   {
+    "id": 30401,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Spanisch\",\"mandatory\":false}]",
     "state": "he",
     "grade": "7. Klasse",
     "requestAt": "2024-06-18 14:23:10.129"
   },
   {
+    "id": 30398,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "8. Klasse",
     "requestAt": "2024-06-18 15:14:36.636"
   },
   {
+    "id": 30217,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "he",
     "grade": "2. Klasse",
     "requestAt": "2024-06-19 07:07:50.836"
   },
   {
+    "id": 30404,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "sn",
     "grade": "6. Klasse",
     "requestAt": "2024-06-19 14:18:04.015"
   },
   {
+    "id": 30405,
     "subjects": "[{\"name\":\"Sachkunde\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "sn",
     "grade": "4. Klasse",
     "requestAt": "2024-06-19 14:40:05.602"
   },
   {
+    "id": 25805,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "7. Klasse",
     "requestAt": "2024-06-19 16:04:44.279"
   },
   {
+    "id": 30384,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "be",
     "grade": "8. Klasse",
     "requestAt": "2024-06-19 16:37:31.68"
   },
   {
+    "id": 18536,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "th",
     "grade": "8. Klasse",
     "requestAt": "2024-06-19 20:46:22.208"
   },
   {
+    "id": 29976,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "by",
     "grade": "3. Klasse",
     "requestAt": "2024-06-21 03:26:51.934"
   },
   {
+    "id": 19379,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "7. Klasse",
     "requestAt": "2024-06-21 19:49:53.233"
   },
   {
+    "id": 30058,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "5. Klasse",
     "requestAt": "2024-06-22 20:49:52.049"
   },
   {
+    "id": 30405,
     "subjects": "[{\"name\":\"Sachkunde\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "sn",
     "grade": "4. Klasse",
     "requestAt": "2024-06-23 14:08:34.469"
   },
   {
+    "id": 28356,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "be",
     "grade": "3. Klasse",
     "requestAt": "2024-06-24 07:34:12.643"
   },
   {
+    "id": 29705,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "th",
     "grade": "5. Klasse",
     "requestAt": "2024-06-24 14:19:09.335"
   },
   {
+    "id": 30407,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "3. Klasse",
     "requestAt": "2024-06-24 14:52:30.262"
   },
   {
+    "id": 30350,
     "subjects": "[{\"name\":\"Wirtschaft\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "be",
     "grade": "14. Klasse",
     "requestAt": "2024-06-24 16:44:00.571"
   },
   {
+    "id": 30403,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "3. Klasse",
     "requestAt": "2024-06-24 17:32:02.74"
   },
   {
+    "id": 19640,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "10. Klasse",
     "requestAt": "2024-06-24 20:02:49.177"
   },
   {
+    "id": 30409,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "13. Klasse",
     "requestAt": "2024-06-25 04:57:09.927"
   },
   {
+    "id": 29360,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "he",
     "grade": "4. Klasse",
     "requestAt": "2024-06-25 09:44:02.536"
   },
   {
+    "id": 30018,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "5. Klasse",
     "requestAt": "2024-06-26 13:26:05.129"
   },
   {
+    "id": 30402,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "by",
     "grade": "8. Klasse",
     "requestAt": "2024-06-26 14:35:02.638"
   },
   {
+    "id": 27279,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2024-06-26 18:38:31.956"
   },
   {
+    "id": 30164,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false}]",
     "state": "sn",
     "grade": "10. Klasse",
     "requestAt": "2024-06-27 10:21:28.938"
   },
   {
+    "id": 30027,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "6. Klasse",
     "requestAt": "2024-06-27 12:12:18.688"
   },
   {
+    "id": 30426,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":false}]",
     "state": "other",
     "grade": "14. Klasse",
     "requestAt": "2024-06-27 15:55:58.427"
   },
   {
+    "id": 30432,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true}]",
     "state": "he",
     "grade": "14. Klasse",
     "requestAt": "2024-06-28 11:54:44.33"
   },
   {
+    "id": 29608,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Technik\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2024-07-01 12:15:09.867"
   },
   {
+    "id": 29629,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2024-07-01 12:28:23.244"
   },
   {
+    "id": 30428,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "2. Klasse",
     "requestAt": "2024-07-01 14:13:52.394"
   },
   {
+    "id": 29339,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2024-07-02 16:57:20.462"
   },
   {
+    "id": 9551,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true}]",
     "state": "by",
     "grade": "9. Klasse",
     "requestAt": "2024-07-02 18:18:19.031"
   },
   {
+    "id": 17730,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "9. Klasse",
     "requestAt": "2024-07-03 09:12:26.006"
   },
   {
+    "id": 29892,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "he",
     "grade": "4. Klasse",
     "requestAt": "2024-07-03 10:11:13.972"
   },
   {
+    "id": 21522,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "7. Klasse",
     "requestAt": "2024-07-04 13:30:23.786"
   },
   {
+    "id": 23301,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "7. Klasse",
     "requestAt": "2024-07-04 17:30:55.972"
   },
   {
+    "id": 29305,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "he",
     "grade": "6. Klasse",
     "requestAt": "2024-07-04 19:47:53.798"
   },
   {
+    "id": 15901,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "sh",
     "grade": "9. Klasse",
     "requestAt": "2024-07-05 17:48:37.445"
   },
   {
+    "id": 30223,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "sn",
     "grade": "6. Klasse",
     "requestAt": "2024-07-06 19:53:37.357"
   },
   {
+    "id": 30454,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "by",
     "grade": "6. Klasse",
     "requestAt": "2024-07-07 15:35:06.482"
   },
   {
+    "id": 30355,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "he",
     "grade": "14. Klasse",
     "requestAt": "2024-07-08 08:23:38.277"
   },
   {
+    "id": 30420,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2024-07-09 14:33:01.755"
   },
   {
+    "id": 30144,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
     "state": "he",
     "grade": "6. Klasse",
     "requestAt": "2024-07-09 15:23:42.879"
   },
   {
+    "id": 30044,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "10. Klasse",
     "requestAt": "2024-07-10 14:38:55.904"
   },
   {
+    "id": 30058,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "5. Klasse",
     "requestAt": "2024-07-10 15:35:12.92"
   },
   {
+    "id": 27279,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2024-07-10 18:38:50.708"
   },
   {
+    "id": 28370,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true}]",
     "state": "th",
     "grade": "10. Klasse",
     "requestAt": "2024-07-11 08:01:30.445"
   },
   {
+    "id": 21716,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2024-07-11 18:15:56.825"
   },
   {
+    "id": 29339,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2024-07-13 15:10:16.36"
   },
   {
+    "id": 30418,
     "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
     "state": "he",
     "grade": "7. Klasse",
     "requestAt": "2024-07-13 17:08:45.857"
   },
   {
+    "id": 30462,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "be",
     "grade": "14. Klasse",
     "requestAt": "2024-07-15 10:17:11.686"
   },
   {
+    "id": 30468,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":false}]",
     "state": "ni",
     "grade": "11. Klasse",
     "requestAt": "2024-07-15 12:37:42.847"
   },
   {
+    "id": 30315,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2024-07-16 19:28:24.164"
   },
   {
+    "id": 30463,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "be",
     "grade": "14. Klasse",
     "requestAt": "2024-07-17 10:35:34.393"
   },
   {
+    "id": 30150,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "9. Klasse",
     "requestAt": "2024-07-18 11:26:38.788"
   },
   {
+    "id": 27119,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false}]",
     "state": "be",
     "grade": "10. Klasse",
     "requestAt": "2024-07-18 16:13:23.047"
   },
   {
+    "id": 30434,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "8. Klasse",
     "requestAt": "2024-07-19 19:15:52.285"
   },
   {
+    "id": 17730,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "rp",
     "grade": "9. Klasse",
     "requestAt": "2024-07-21 05:18:50.122"
   },
   {
+    "id": 30479,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "hh",
     "grade": "7. Klasse",
     "requestAt": "2024-07-22 10:23:16.716"
   },
   {
+    "id": 30201,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "he",
     "grade": "6. Klasse",
     "requestAt": "2024-07-22 15:55:35.267"
   },
   {
+    "id": 30464,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "be",
     "grade": "14. Klasse",
     "requestAt": "2024-07-24 10:09:21.899"
   },
   {
+    "id": 30478,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "4. Klasse",
     "requestAt": "2024-07-24 12:40:14.597"
   },
   {
+    "id": 30492,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "hb",
     "grade": "3. Klasse",
     "requestAt": "2024-07-24 16:21:21.847"
   },
   {
+    "id": 19388,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "hb",
     "grade": "9. Klasse",
     "requestAt": "2024-07-25 11:46:07.287"
   },
   {
+    "id": 30263,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "sn",
     "grade": "3. Klasse",
     "requestAt": "2024-07-25 20:41:59.412"
   },
   {
+    "id": 30494,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Sachkunde\",\"mandatory\":true}]",
     "state": "sn",
     "grade": "5. Klasse",
     "requestAt": "2024-07-26 15:09:59.087"
   },
   {
+    "id": 24488,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Latein\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "8. Klasse",
     "requestAt": "2024-07-26 16:14:46.716"
   },
   {
+    "id": 30210,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "th",
     "grade": "3. Klasse",
     "requestAt": "2024-07-28 14:39:53.322"
   },
   {
+    "id": 30315,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2024-07-28 18:07:36.273"
   },
   {
+    "id": 30507,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "at",
     "grade": "6. Klasse",
     "requestAt": "2024-08-01 15:37:30.178"
   },
   {
+    "id": 30317,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "be",
     "grade": "6. Klasse",
     "requestAt": "2024-08-02 10:45:56.248"
   },
   {
+    "id": 30359,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "ni",
     "grade": "3. Klasse",
     "requestAt": "2024-08-02 19:58:54.911"
   },
   {
+    "id": 30507,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "at",
     "grade": "6. Klasse",
     "requestAt": "2024-08-05 16:07:25.376"
   },
   {
+    "id": 20169,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "ni",
     "grade": "8. Klasse",
     "requestAt": "2024-08-06 15:07:53.696"
   },
   {
+    "id": 30528,
     "subjects": "[{\"name\":\"Wirtschaft\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "14. Klasse",
     "requestAt": "2024-08-06 16:31:34.144"
   },
   {
+    "id": 30407,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "3. Klasse",
     "requestAt": "2024-08-06 16:40:31.185"
   },
   {
+    "id": 30509,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "5. Klasse",
     "requestAt": "2024-08-06 20:37:56.32"
   },
   {
+    "id": 30514,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "5. Klasse",
     "requestAt": "2024-08-08 16:19:49.019"
   },
   {
+    "id": 29011,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
     "state": "ni",
     "grade": "5. Klasse",
     "requestAt": "2024-08-10 12:34:48.003"
   },
   {
+    "id": 30540,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "7. Klasse",
     "requestAt": "2024-08-12 13:58:24.625"
   },
   {
+    "id": 28851,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "11. Klasse",
     "requestAt": "2024-08-12 15:10:02.944"
   },
   {
+    "id": 30541,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":false}]",
     "state": "he",
     "grade": "3. Klasse",
     "requestAt": "2024-08-12 15:39:32.497"
   },
   {
+    "id": 30574,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":false}]",
     "state": "bw",
     "grade": "10. Klasse",
     "requestAt": "2024-08-13 05:19:45.884"
   },
   {
+    "id": 30549,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "5. Klasse",
     "requestAt": "2024-08-13 07:11:30.572"
   },
   {
+    "id": 28370,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true}]",
     "state": "th",
     "grade": "10. Klasse",
     "requestAt": "2024-08-13 12:24:02.861"
   },
   {
+    "id": 3075,
     "subjects": "[{\"name\":\"Biologie\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "12. Klasse",
     "requestAt": "2024-08-13 14:03:11.918"
   },
   {
+    "id": 30565,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "by",
     "grade": "7. Klasse",
     "requestAt": "2024-08-13 14:27:27.087"
   },
   {
+    "id": 30567,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2024-08-13 16:21:32.936"
   },
   {
+    "id": 23301,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "7. Klasse",
     "requestAt": "2024-08-14 11:49:04.744"
   },
   {
+    "id": 16205,
     "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true},{\"name\":\"Spanisch\",\"mandatory\":false}]",
     "state": "by",
     "grade": "9. Klasse",
     "requestAt": "2024-08-14 18:07:19.993"
   },
   {
+    "id": 29778,
     "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2024-08-15 09:30:11.178"
   },
   {
+    "id": 27113,
     "subjects": "[{\"name\":\"Wirtschaft\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "11. Klasse",
     "requestAt": "2024-08-15 11:07:37.168"
   },
   {
+    "id": 30519,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Gesundheit\",\"mandatory\":false},{\"name\":\"Pädagogik\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "14. Klasse",
     "requestAt": "2024-08-15 11:22:51.978"
   },
   {
+    "id": 30551,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "14. Klasse",
     "requestAt": "2024-08-15 16:27:37.599"
   },
   {
+    "id": 4451,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "by",
     "grade": "11. Klasse",
     "requestAt": "2024-08-16 09:42:49.732"
   },
   {
+    "id": 30530,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "by",
     "grade": "5. Klasse",
     "requestAt": "2024-08-20 09:27:27.413"
   },
   {
+    "id": 28784,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "7. Klasse",
     "requestAt": "2024-08-20 16:55:25.369"
   },
   {
+    "id": 28496,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "10. Klasse",
     "requestAt": "2024-08-22 14:02:06.231"
   },
   {
+    "id": 30433,
     "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Biologie\",\"mandatory\":false}]",
     "state": "he",
     "grade": "5. Klasse",
     "requestAt": "2024-08-22 16:45:55.241"
   },
   {
+    "id": 29608,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Technik\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "9. Klasse",
     "requestAt": "2024-08-23 14:48:46.84"
   },
   {
+    "id": 29980,
     "subjects": "[{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "12. Klasse",
     "requestAt": "2024-08-23 16:20:46.836"
   },
   {
+    "id": 29451,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "bw",
     "grade": "4. Klasse",
     "requestAt": "2024-08-23 17:43:50.042"
   },
   {
+    "id": 30509,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "nw",
     "grade": "5. Klasse",
     "requestAt": "2024-08-24 16:47:30.011"
   },
   {
+    "id": 30573,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
     "state": "rp",
     "grade": "5. Klasse",
     "requestAt": "2024-08-24 22:56:23.546"
   },
   {
+    "id": 30616,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Religion\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false}]",
     "state": "hb",
     "grade": "12. Klasse",
     "requestAt": "2024-08-26 15:21:54.515"
   },
   {
+    "id": 30614,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Geschichte\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "10. Klasse",
     "requestAt": "2024-08-26 16:12:27.535"
   },
   {
+    "id": 30589,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "sn",
     "grade": "5. Klasse",
     "requestAt": "2024-08-26 17:25:25.517"
   },
   {
+    "id": 30481,
     "subjects": "[{\"name\":\"Informatik\",\"mandatory\":true}]",
     "state": "by",
     "grade": "14. Klasse",
     "requestAt": "2024-08-28 15:52:30.365"
   },
   {
+    "id": 30408,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Technik\",\"mandatory\":false}]",
     "state": "by",
     "grade": "11. Klasse",
     "requestAt": "2024-08-29 12:49:19.821"
   },
   {
+    "id": 30508,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "by",
     "grade": "11. Klasse",
     "requestAt": "2024-08-30 10:21:11.257"
   },
   {
+    "id": 30026,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
     "state": "nw",
     "grade": "7. Klasse",
     "requestAt": "2024-08-31 14:31:35.867"
   },
   {
+    "id": 30438,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "hb",
     "grade": "14. Klasse",
     "requestAt": "2024-09-03 05:34:41.869"
   },
   {
+    "id": 30602,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
     "state": "bb",
     "grade": "5. Klasse",
     "requestAt": "2024-09-03 14:32:05.864"
   },
   {
+    "id": 29946,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "by",
     "grade": "6. Klasse",
     "requestAt": "2024-09-04 21:01:12.883"
   },
   {
+    "id": 17504,
     "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
     "state": "he",
     "grade": "6. Klasse",
     "requestAt": "2024-09-08 13:39:57.606"
   },
   {
+    "id": 28848,
     "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
     "state": "sn",
     "grade": "12. Klasse",

--- a/common/match/matching.perf.pupil.json
+++ b/common/match/matching.perf.pupil.json
@@ -1,0 +1,6272 @@
+[
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "13. Klasse",
+    "requestAt": "2022-08-25 17:51:28.769"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\"},{\"name\":\"Chemie\"}]",
+    "state": "bw",
+    "grade": "13. Klasse",
+    "requestAt": "2022-09-22 08:39:47.383"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Mathematik\",\"minGrade\":1,\"maxGrade\":13}]",
+    "state": "nw",
+    "grade": "7. Klasse",
+    "requestAt": "2022-10-21 20:40:39.821"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Mathematik\",\"minGrade\":1,\"maxGrade\":13}]",
+    "state": "th",
+    "grade": "12. Klasse",
+    "requestAt": "2022-10-26 16:13:28.125"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "7. Klasse",
+    "requestAt": "2022-11-04 09:15:00.443"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "7. Klasse",
+    "requestAt": "2022-11-04 09:15:00.443"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "bb",
+    "grade": "12. Klasse",
+    "requestAt": "2022-11-11 11:01:12.448"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "5. Klasse",
+    "requestAt": "2022-11-11 11:04:39.991"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\"},{\"name\":\"Englisch\"},{\"name\":\"Deutsch\"},{\"name\":\"Mathematik\"}]",
+    "state": "bw",
+    "grade": "8. Klasse",
+    "requestAt": "2022-11-15 08:32:17.028"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\"},{\"name\":\"Mathematik\"},{\"name\":\"Spanisch\"},{\"name\":\"Musik\"},{\"name\":\"Chemie\"},{\"name\":\"Politik\"},{\"name\":\"Geschichte\"}]",
+    "state": "mv",
+    "grade": "12. Klasse",
+    "requestAt": "2022-11-15 08:41:06.569"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\"}]",
+    "state": "sn",
+    "grade": "11. Klasse",
+    "requestAt": "2022-11-16 22:12:09.291"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\"}]",
+    "state": "sn",
+    "grade": "11. Klasse",
+    "requestAt": "2022-11-16 22:12:09.291"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\"},{\"name\":\"Englisch\"}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2022-11-18 08:38:44.62"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\"},{\"name\":\"Englisch\"}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2022-11-18 08:38:44.62"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Französisch\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Mathematik\",\"minGrade\":1,\"maxGrade\":13}]",
+    "state": "be",
+    "grade": "7. Klasse",
+    "requestAt": "2022-11-22 09:27:28.797"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Französisch\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Mathematik\",\"minGrade\":1,\"maxGrade\":13}]",
+    "state": "be",
+    "grade": "7. Klasse",
+    "requestAt": "2022-11-22 09:27:28.797"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "6. Klasse",
+    "requestAt": "2022-11-23 21:19:06.215"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "5. Klasse",
+    "requestAt": "2022-11-23 21:25:48.876"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "5. Klasse",
+    "requestAt": "2022-11-23 21:25:48.876"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "13. Klasse",
+    "requestAt": "2022-11-25 08:21:01.309"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "8. Klasse",
+    "requestAt": "2022-11-25 08:46:04.468"
+  },
+  {
+    "subjects": "[{\"name\":\"Spanisch\"},{\"name\":\"Deutsch\"},{\"name\":\"Mathematik\"}]",
+    "state": "he",
+    "grade": "9. Klasse",
+    "requestAt": "2022-12-02 09:14:00.496"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "10. Klasse",
+    "requestAt": "2022-12-28 14:28:05.649"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2023-01-06 10:33:08.376"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\"},{\"name\":\"Deutsch\"},{\"name\":\"Englisch\"}]",
+    "state": "he",
+    "grade": "9. Klasse",
+    "requestAt": "2023-01-10 11:00:52.529"
+  },
+  {
+    "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2023-01-18 08:03:17.14"
+  },
+  {
+    "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2023-01-18 08:03:17.14"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":null},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Informatik\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "6. Klasse",
+    "requestAt": "2023-01-27 08:55:21.84"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2023-01-27 08:58:56.654"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2023-01-27 08:58:56.654"
+  },
+  {
+    "subjects": "[{\"name\":\"Spanisch\"}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2023-02-01 10:03:49.042"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Mathematik\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Englisch\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Physik\",\"minGrade\":1,\"maxGrade\":13}]",
+    "state": "nw",
+    "grade": "6. Klasse",
+    "requestAt": "2023-02-01 19:48:12.471"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\"},{\"name\":\"Deutsch\"}]",
+    "state": "he",
+    "grade": "6. Klasse",
+    "requestAt": "2023-02-15 18:03:24.829"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\"},{\"name\":\"Mathematik\"}]",
+    "state": "sl",
+    "grade": "7. Klasse",
+    "requestAt": "2023-02-21 09:09:56.146"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\"}]",
+    "state": "nw",
+    "grade": "2. Klasse",
+    "requestAt": "2023-02-25 18:23:13.4"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "11. Klasse",
+    "requestAt": "2023-02-27 08:49:58.433"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":null},{\"name\":\"Spanisch\",\"mandatory\":true},{\"name\":\"Erdkunde\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "13. Klasse",
+    "requestAt": "2023-02-27 10:17:19.676"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "9. Klasse",
+    "requestAt": "2023-02-27 21:04:14.284"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "8. Klasse",
+    "requestAt": "2023-02-27 21:07:36.518"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "3. Klasse",
+    "requestAt": "2023-02-27 21:53:04.704"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "5. Klasse",
+    "requestAt": "2023-02-28 03:04:44.218"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":null}]",
+    "state": "bw",
+    "grade": "10. Klasse",
+    "requestAt": "2023-02-28 05:17:16.361"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "5. Klasse",
+    "requestAt": "2023-02-28 07:07:48.659"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "6. Klasse",
+    "requestAt": "2023-02-28 08:46:14.703"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":null},{\"name\":\"Englisch\",\"mandatory\":null},{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "7. Klasse",
+    "requestAt": "2023-02-28 11:10:30.77"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "6. Klasse",
+    "requestAt": "2023-02-28 16:27:25.675"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false}]",
+    "state": "other",
+    "grade": "10. Klasse",
+    "requestAt": "2023-02-28 16:46:59.211"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":null},{\"name\":\"Deutsch\",\"mandatory\":null},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2023-02-28 19:10:06.539"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "7. Klasse",
+    "requestAt": "2023-02-28 20:40:59.631"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "6. Klasse",
+    "requestAt": "2023-02-28 20:48:07.644"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "5. Klasse",
+    "requestAt": "2023-02-28 20:52:24.875"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "ni",
+    "grade": "13. Klasse",
+    "requestAt": "2023-03-01 10:32:43.534"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2023-03-01 21:28:12.264"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":null}]",
+    "state": "bw",
+    "grade": "12. Klasse",
+    "requestAt": "2023-03-02 16:48:26.477"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Mathematik\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Musik\",\"minGrade\":1,\"maxGrade\":13}]",
+    "state": "rp",
+    "grade": "4. Klasse",
+    "requestAt": "2023-03-02 20:15:01.751"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "4. Klasse",
+    "requestAt": "2023-03-03 13:34:38.399"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "7. Klasse",
+    "requestAt": "2023-03-03 20:54:07.542"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "8. Klasse",
+    "requestAt": "2023-03-05 11:59:53.975"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "3. Klasse",
+    "requestAt": "2023-03-06 07:01:44.071"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Sachkunde\",\"mandatory\":null},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "3. Klasse",
+    "requestAt": "2023-03-07 00:48:15.224"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2023-03-07 14:56:32.487"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "6. Klasse",
+    "requestAt": "2023-03-09 14:35:07.244"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2023-03-10 05:56:22.014"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "sn",
+    "grade": "9. Klasse",
+    "requestAt": "2023-03-10 08:07:28.48"
+  },
+  {
+    "subjects": "[{\"name\":\"Wirtschaft\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2023-03-10 14:53:08.082"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "9. Klasse",
+    "requestAt": "2023-03-10 15:39:05.209"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "9. Klasse",
+    "requestAt": "2023-03-10 15:51:58.837"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "12. Klasse",
+    "requestAt": "2023-03-12 19:16:20.093"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "10. Klasse",
+    "requestAt": "2023-03-13 09:17:29.385"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2023-03-15 15:41:26.667"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "6. Klasse",
+    "requestAt": "2023-03-17 20:52:26.525"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "7. Klasse",
+    "requestAt": "2023-03-18 12:05:22.636"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "6. Klasse",
+    "requestAt": "2023-03-19 21:57:41.744"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2023-03-21 15:10:30.89"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "ni",
+    "grade": "11. Klasse",
+    "requestAt": "2023-03-21 17:15:42.878"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "6. Klasse",
+    "requestAt": "2023-03-21 22:16:43.212"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "4. Klasse",
+    "requestAt": "2023-03-22 06:34:03.322"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "9. Klasse",
+    "requestAt": "2023-03-25 12:35:54.169"
+  },
+  {
+    "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2023-03-25 20:00:43.034"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "9. Klasse",
+    "requestAt": "2023-03-26 13:58:25.263"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "ni",
+    "grade": "12. Klasse",
+    "requestAt": "2023-03-27 10:34:48.426"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "5. Klasse",
+    "requestAt": "2023-03-27 10:34:49.12"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "bb",
+    "grade": "6. Klasse",
+    "requestAt": "2023-03-27 17:18:33.875"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "3. Klasse",
+    "requestAt": "2023-03-27 19:38:58.598"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "4. Klasse",
+    "requestAt": "2023-03-29 07:23:04.292"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "other",
+    "grade": "10. Klasse",
+    "requestAt": "2023-03-29 08:30:02.098"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "6. Klasse",
+    "requestAt": "2023-03-29 09:02:32.853"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "6. Klasse",
+    "requestAt": "2023-04-01 07:34:33.978"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "3. Klasse",
+    "requestAt": "2023-04-01 16:31:30.751"
+  },
+  {
+    "subjects": "[{\"name\":\"Wirtschaft\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2023-04-02 08:47:35.345"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "11. Klasse",
+    "requestAt": "2023-04-03 04:53:25.117"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "7. Klasse",
+    "requestAt": "2023-04-03 06:19:57.448"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "11. Klasse",
+    "requestAt": "2023-04-03 06:21:47.12"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2023-04-03 08:19:00.749"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\"}]",
+    "state": "bw",
+    "grade": "4. Klasse",
+    "requestAt": "2023-04-03 13:04:25.388"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "6. Klasse",
+    "requestAt": "2023-04-03 17:23:26.534"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "7. Klasse",
+    "requestAt": "2023-04-05 16:30:20.471"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\"},{\"name\":\"Englisch\"}]",
+    "state": "sh",
+    "grade": "13. Klasse",
+    "requestAt": "2023-04-07 08:25:22.699"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "4. Klasse",
+    "requestAt": "2023-04-07 11:04:19.992"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":false}]",
+    "state": "sh",
+    "grade": "9. Klasse",
+    "requestAt": "2023-04-07 17:23:47.915"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Italienisch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Politik\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2023-04-08 13:50:54.17"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
+    "state": "ni",
+    "grade": "5. Klasse",
+    "requestAt": "2023-04-09 21:07:11.894"
+  },
+  {
+    "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2023-04-12 15:01:02.806"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Mathematik\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Musik\",\"minGrade\":1,\"maxGrade\":13}]",
+    "state": "rp",
+    "grade": "4. Klasse",
+    "requestAt": "2023-04-12 15:11:10.761"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"minGrade\":1,\"maxGrade\":13}]",
+    "state": "sn",
+    "grade": "6. Klasse",
+    "requestAt": "2023-04-24 16:53:42.247"
+  },
+  {
+    "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2023-04-24 17:32:52.476"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":null},{\"name\":\"Sachkunde\",\"mandatory\":null},{\"name\":\"Musik\",\"mandatory\":null},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "ni",
+    "grade": "3. Klasse",
+    "requestAt": "2023-04-27 12:03:47.647"
+  },
+  {
+    "subjects": "[{ \"name\": \"Mathematik\" },{ \"name\": \"Deutsch\" },{ \"name\": \"Englisch\" }]",
+    "state": "by",
+    "grade": "7. Klasse",
+    "requestAt": "2023-05-09 16:26:03.605"
+  },
+  {
+    "subjects": "[{ \"name\": \"Mathematik\" },{ \"name\": \"Deutsch\" },{ \"name\": \"Englisch\" }]",
+    "state": "by",
+    "grade": "7. Klasse",
+    "requestAt": "2023-05-09 16:26:03.605"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\"}]",
+    "state": "bw",
+    "grade": "10. Klasse",
+    "requestAt": "2023-05-10 15:38:54.198"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "9. Klasse",
+    "requestAt": "2023-05-15 12:56:03.398"
+  },
+  {
+    "subjects": "[{\"name\":\"Wirtschaft\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2023-05-15 16:31:41.456"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2023-05-16 15:29:17.127"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "6. Klasse",
+    "requestAt": "2023-05-16 16:46:03.22"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Englisch\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Latein\",\"minGrade\":1,\"maxGrade\":13}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2023-05-16 16:47:51.24"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Englisch\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Deutsch\",\"minGrade\":1,\"maxGrade\":13}]",
+    "state": "he",
+    "grade": "10. Klasse",
+    "requestAt": "2023-05-17 14:33:14.591"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\"}]",
+    "state": "nw",
+    "grade": "11. Klasse",
+    "requestAt": "2023-05-18 13:05:50.833"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "sn",
+    "grade": "12. Klasse",
+    "requestAt": "2023-05-19 18:21:58.937"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"mandatory\":true},{\"name\":\"Erdkunde\",\"mandatory\":false}]",
+    "state": "hh",
+    "grade": "12. Klasse",
+    "requestAt": "2023-05-25 08:05:01.939"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "8. Klasse",
+    "requestAt": "2023-05-26 08:21:22.623"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":null}]",
+    "state": "bw",
+    "grade": "10. Klasse",
+    "requestAt": "2023-06-12 17:30:17.481"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Spanisch\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "13. Klasse",
+    "requestAt": "2023-06-17 12:49:28.536"
+  },
+  {
+    "subjects": "[{\"name\":\"Informatik\",\"mandatory\":true}]",
+    "state": "hb",
+    "grade": "13. Klasse",
+    "requestAt": "2023-06-18 12:28:13.9"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "4. Klasse",
+    "requestAt": "2023-06-20 18:20:24.726"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\"}]",
+    "state": "bw",
+    "grade": "10. Klasse",
+    "requestAt": "2023-06-23 09:34:16.544"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":null},{\"name\":\"Latein\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "7. Klasse",
+    "requestAt": "2023-06-28 11:29:18.397"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":null},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "6. Klasse",
+    "requestAt": "2023-06-28 11:37:44.187"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":null},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "13. Klasse",
+    "requestAt": "2023-06-28 11:42:08.514"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "9. Klasse",
+    "requestAt": "2023-06-28 12:04:32.057"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "9. Klasse",
+    "requestAt": "2023-06-28 12:10:46.35"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "bb",
+    "grade": "9. Klasse",
+    "requestAt": "2023-06-28 13:46:08.298"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\"}]",
+    "state": "nw",
+    "grade": "2. Klasse",
+    "requestAt": "2023-06-28 20:20:30.554"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Politik\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
+    "state": "ni",
+    "grade": "10. Klasse",
+    "requestAt": "2023-07-10 18:45:37.641"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Biologie\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "6. Klasse",
+    "requestAt": "2023-07-11 09:07:16.118"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"minGrade\":1,\"maxGrade\":13}]",
+    "state": "nw",
+    "grade": "4. Klasse",
+    "requestAt": "2023-07-11 19:13:30.586"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"minGrade\":1,\"maxGrade\":13}]",
+    "state": "nw",
+    "grade": "4. Klasse",
+    "requestAt": "2023-07-11 19:13:30.586"
+  },
+  {
+    "subjects": "[{\"name\":\"Wirtschaft\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2023-07-13 15:32:38.5"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "11. Klasse",
+    "requestAt": "2023-07-17 15:30:02.401"
+  },
+  {
+    "subjects": "[{\"name\":\"Erdkunde\"},{\"name\":\"Mathematik\"},{\"name\":\"Englisch\"},{\"name\":\"Biologie\"},{\"name\":\"Deutsch\"}]",
+    "state": "rp",
+    "grade": "9. Klasse",
+    "requestAt": "2023-07-24 08:09:19.222"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "6. Klasse",
+    "requestAt": "2023-07-31 10:41:09.494"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "11. Klasse",
+    "requestAt": "2023-08-01 12:04:31.98"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "6. Klasse",
+    "requestAt": "2023-08-01 19:49:41.058"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "9. Klasse",
+    "requestAt": "2023-08-03 14:22:14.915"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\"}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2023-08-03 14:51:59.492"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "10. Klasse",
+    "requestAt": "2023-08-04 13:04:17.194"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "ni",
+    "grade": "5. Klasse",
+    "requestAt": "2023-08-05 21:49:49.113"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "3. Klasse",
+    "requestAt": "2023-08-06 09:21:27.505"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "6. Klasse",
+    "requestAt": "2023-08-06 20:33:22.771"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "4. Klasse",
+    "requestAt": "2023-08-07 18:15:21.508"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "11. Klasse",
+    "requestAt": "2023-08-08 00:17:21.887"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Musik\",\"mandatory\":false},{\"name\":\"Kunst\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "5. Klasse",
+    "requestAt": "2023-08-08 09:04:35.377"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2023-08-08 15:28:06.932"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "6. Klasse",
+    "requestAt": "2023-08-09 17:41:57.161"
+  },
+  {
+    "subjects": "[{\"name\":\"Wirtschaft\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2023-08-10 14:33:37.579"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2023-08-10 18:23:32.921"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2023-08-11 12:27:34.987"
+  },
+  {
+    "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2023-08-11 12:32:28.866"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "7. Klasse",
+    "requestAt": "2023-08-12 02:13:22.915"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2023-08-13 09:58:45.124"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "sn",
+    "grade": "12. Klasse",
+    "requestAt": "2023-08-13 18:16:52.163"
+  },
+  {
+    "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2023-08-14 15:18:42.711"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "ni",
+    "grade": "13. Klasse",
+    "requestAt": "2023-08-14 15:22:52.827"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false}]",
+    "state": "ni",
+    "grade": "11. Klasse",
+    "requestAt": "2023-08-14 17:57:44.1"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false}]",
+    "state": "th",
+    "grade": "9. Klasse",
+    "requestAt": "2023-08-14 19:44:26.803"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2023-08-15 05:59:40.563"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "ni",
+    "grade": "3. Klasse",
+    "requestAt": "2023-08-15 12:47:58.4"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2023-08-16 15:23:34.597"
+  },
+  {
+    "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2023-08-16 15:41:08.601"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "4. Klasse",
+    "requestAt": "2023-08-16 16:40:13.916"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "4. Klasse",
+    "requestAt": "2023-08-17 09:27:20.782"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "3. Klasse",
+    "requestAt": "2023-08-17 09:33:10.991"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2023-08-18 11:02:07.918"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "ni",
+    "grade": "12. Klasse",
+    "requestAt": "2023-08-19 13:28:39.864"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "7. Klasse",
+    "requestAt": "2023-08-19 16:50:51.728"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "ni",
+    "grade": "8. Klasse",
+    "requestAt": "2023-08-20 14:36:02.342"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true},{\"name\":\"Informatik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "13. Klasse",
+    "requestAt": "2023-08-20 17:32:16.858"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "12. Klasse",
+    "requestAt": "2023-08-21 07:21:33.97"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "9. Klasse",
+    "requestAt": "2023-08-21 14:23:03.606"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "10. Klasse",
+    "requestAt": "2023-08-22 17:20:49.489"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "12. Klasse",
+    "requestAt": "2023-08-22 18:00:24.329"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Latein\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "6. Klasse",
+    "requestAt": "2023-08-23 09:50:32.68"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "13. Klasse",
+    "requestAt": "2023-08-23 16:42:18.087"
+  },
+  {
+    "subjects": "[{\"name\":\"Physik\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Latein\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Informatik\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false}]",
+    "state": "sn",
+    "grade": "10. Klasse",
+    "requestAt": "2023-08-23 20:33:50.639"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2023-08-24 11:58:08.356"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "6. Klasse",
+    "requestAt": "2023-08-24 15:06:56.805"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2023-08-24 17:12:57.661"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":null},{\"name\":\"Russisch\",\"mandatory\":null},{\"name\":\"Informatik\",\"mandatory\":null}]",
+    "state": "bw",
+    "grade": "9. Klasse",
+    "requestAt": "2023-08-25 08:20:45.827"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2023-08-25 09:46:23.359"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":null},{\"name\":\"Biologie\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2023-08-25 09:51:02.788"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true}]",
+    "state": "hh",
+    "grade": "13. Klasse",
+    "requestAt": "2023-08-25 10:14:10.9"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2023-08-25 10:43:34.318"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "4. Klasse",
+    "requestAt": "2023-08-25 11:29:21.642"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "9. Klasse",
+    "requestAt": "2023-08-25 18:34:59.241"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "11. Klasse",
+    "requestAt": "2023-08-25 23:17:45.543"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "9. Klasse",
+    "requestAt": "2023-08-26 03:08:56.753"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Musik\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "9. Klasse",
+    "requestAt": "2023-08-26 17:32:30.907"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":null},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "13. Klasse",
+    "requestAt": "2023-08-26 17:42:01.492"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "7. Klasse",
+    "requestAt": "2023-08-27 07:48:38.515"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "12. Klasse",
+    "requestAt": "2023-08-27 14:13:29.399"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "6. Klasse",
+    "requestAt": "2023-08-28 08:26:16.514"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "12. Klasse",
+    "requestAt": "2023-08-28 12:39:32.251"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "5. Klasse",
+    "requestAt": "2023-08-28 14:13:53.986"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "3. Klasse",
+    "requestAt": "2023-08-28 14:16:41.842"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "6. Klasse",
+    "requestAt": "2023-08-28 20:27:34.985"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "10. Klasse",
+    "requestAt": "2023-08-29 18:41:09.487"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "sh",
+    "grade": "9. Klasse",
+    "requestAt": "2023-08-30 14:34:07.361"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "9. Klasse",
+    "requestAt": "2023-08-31 00:16:02.91"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "th",
+    "grade": "2. Klasse",
+    "requestAt": "2023-08-31 04:48:10.944"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "5. Klasse",
+    "requestAt": "2023-08-31 12:38:38.071"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":null},{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":null},{\"name\":\"Spanisch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "12. Klasse",
+    "requestAt": "2023-08-31 16:53:16.787"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "8. Klasse",
+    "requestAt": "2023-08-31 18:25:21.093"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "8. Klasse",
+    "requestAt": "2023-09-01 06:01:54.399"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Biologie\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "6. Klasse",
+    "requestAt": "2023-09-01 06:43:27.503"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Philosophie\",\"mandatory\":false}]",
+    "state": "hh",
+    "grade": "13. Klasse",
+    "requestAt": "2023-09-02 18:56:30.718"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":null},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Sachkunde\",\"mandatory\":false}]",
+    "state": "sn",
+    "grade": "5. Klasse",
+    "requestAt": "2023-09-03 12:55:26.856"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "11. Klasse",
+    "requestAt": "2023-09-04 08:08:49.373"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "ni",
+    "grade": "4. Klasse",
+    "requestAt": "2023-09-04 22:57:04.642"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "5. Klasse",
+    "requestAt": "2023-09-05 14:54:34.712"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "7. Klasse",
+    "requestAt": "2023-09-05 19:57:17.988"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "6. Klasse",
+    "requestAt": "2023-09-05 22:31:16.394"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "8. Klasse",
+    "requestAt": "2023-09-06 14:43:29.107"
+  },
+  {
+    "subjects": "[{\"name\":\"Informatik\",\"mandatory\":true}]",
+    "state": "hb",
+    "grade": "13. Klasse",
+    "requestAt": "2023-09-08 09:49:22.146"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "4. Klasse",
+    "requestAt": "2023-09-10 12:06:49.979"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "ni",
+    "grade": "6. Klasse",
+    "requestAt": "2023-09-10 12:24:54.726"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Musik\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "10. Klasse",
+    "requestAt": "2023-09-11 14:33:44.279"
+  },
+  {
+    "subjects": "[{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "sn",
+    "grade": "9. Klasse",
+    "requestAt": "2023-09-11 16:29:49.495"
+  },
+  {
+    "subjects": "[{\"name\":\"Informatik\",\"mandatory\":true}]",
+    "state": "hb",
+    "grade": "13. Klasse",
+    "requestAt": "2023-09-11 21:06:49.862"
+  },
+  {
+    "subjects": "[{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Politik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "9. Klasse",
+    "requestAt": "2023-09-12 13:32:18.684"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":null}]",
+    "state": "he",
+    "grade": "8. Klasse",
+    "requestAt": "2023-09-12 15:42:34.379"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Chinesisch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2023-09-12 16:55:56.104"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "9. Klasse",
+    "requestAt": "2023-09-12 17:11:22.219"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2023-09-12 19:48:53.342"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "5. Klasse",
+    "requestAt": "2023-09-12 19:57:18.575"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "ni",
+    "grade": "6. Klasse",
+    "requestAt": "2023-09-12 20:17:24.669"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Latein\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2023-09-13 08:59:33.775"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "5. Klasse",
+    "requestAt": "2023-09-13 13:49:07.461"
+  },
+  {
+    "subjects": "[{\"name\":\"Physik\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Latein\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Informatik\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false}]",
+    "state": "sn",
+    "grade": "10. Klasse",
+    "requestAt": "2023-09-14 08:26:47.362"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":null},{\"name\":\"Informatik\",\"mandatory\":null}]",
+    "state": "by",
+    "grade": "11. Klasse",
+    "requestAt": "2023-09-14 08:33:20.542"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "sn",
+    "grade": "9. Klasse",
+    "requestAt": "2023-09-15 11:54:35.614"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":null},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "sn",
+    "grade": "8. Klasse",
+    "requestAt": "2023-09-15 12:01:26.807"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2023-09-16 11:38:07.131"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "8. Klasse",
+    "requestAt": "2023-09-16 16:34:32.636"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "8. Klasse",
+    "requestAt": "2023-09-16 22:19:46.152"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "13. Klasse",
+    "requestAt": "2023-09-18 11:08:59.961"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "10. Klasse",
+    "requestAt": "2023-09-18 15:32:40.951"
+  },
+  {
+    "subjects": "[{\"name\":\"Pädagogik\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2023-09-18 16:35:18.32"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "6. Klasse",
+    "requestAt": "2023-09-18 23:19:06.115"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "4. Klasse",
+    "requestAt": "2023-09-19 17:00:15.205"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "4. Klasse",
+    "requestAt": "2023-09-19 18:12:48.304"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2023-09-19 18:48:13.059"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2023-09-19 18:48:13.059"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "7. Klasse",
+    "requestAt": "2023-09-20 14:06:36.753"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true}]",
+    "state": "th",
+    "grade": "10. Klasse",
+    "requestAt": "2023-09-20 14:10:29.822"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2023-09-20 14:21:28.006"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "sh",
+    "grade": "9. Klasse",
+    "requestAt": "2023-09-20 14:21:39.104"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "9. Klasse",
+    "requestAt": "2023-09-20 14:28:42.364"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Latein\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "6. Klasse",
+    "requestAt": "2023-09-20 14:32:11.81"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "7. Klasse",
+    "requestAt": "2023-09-20 14:32:55.808"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "10. Klasse",
+    "requestAt": "2023-09-20 14:32:59.074"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "7. Klasse",
+    "requestAt": "2023-09-20 14:35:22.306"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "10. Klasse",
+    "requestAt": "2023-09-20 14:43:42.654"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":null},{\"name\":\"Deutsch\",\"mandatory\":null}]",
+    "state": "he",
+    "grade": "11. Klasse",
+    "requestAt": "2023-09-20 14:56:02.364"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "6. Klasse",
+    "requestAt": "2023-09-20 15:05:42.222"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "6. Klasse",
+    "requestAt": "2023-09-20 15:06:27.726"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "hh",
+    "grade": "7. Klasse",
+    "requestAt": "2023-09-20 15:12:53.572"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "7. Klasse",
+    "requestAt": "2023-09-20 15:13:04.136"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "9. Klasse",
+    "requestAt": "2023-09-20 15:16:41.189"
+  },
+  {
+    "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true},{\"name\":\"Geschichte\",\"mandatory\":false}]",
+    "state": "hh",
+    "grade": "9. Klasse",
+    "requestAt": "2023-09-20 15:41:11.243"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "5. Klasse",
+    "requestAt": "2023-09-20 16:36:57.018"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "11. Klasse",
+    "requestAt": "2023-09-20 16:53:24.295"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2023-09-20 16:55:31.325"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "7. Klasse",
+    "requestAt": "2023-09-20 17:08:12.584"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":null},{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "8. Klasse",
+    "requestAt": "2023-09-20 17:40:48.221"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2023-09-20 19:15:12.074"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "6. Klasse",
+    "requestAt": "2023-09-20 20:11:54.316"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "sn",
+    "grade": "9. Klasse",
+    "requestAt": "2023-09-21 03:51:35.171"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "11. Klasse",
+    "requestAt": "2023-09-21 04:35:25.246"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2023-09-21 11:12:52.819"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Spanisch\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "13. Klasse",
+    "requestAt": "2023-09-21 12:09:49.713"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "5. Klasse",
+    "requestAt": "2023-09-21 17:44:37.287"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2023-09-21 19:59:32.362"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2023-09-21 20:59:18.252"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "9. Klasse",
+    "requestAt": "2023-09-22 12:30:45.369"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "13. Klasse",
+    "requestAt": "2023-09-22 20:06:17.185"
+  },
+  {
+    "subjects": "[{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":true},{\"name\":\"Politik\",\"mandatory\":false},{\"name\":\"Philosophie\",\"mandatory\":false}]",
+    "state": "ni",
+    "grade": "12. Klasse",
+    "requestAt": "2023-09-23 11:07:39.66"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "5. Klasse",
+    "requestAt": "2023-09-25 07:43:24.23"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Latein\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "6. Klasse",
+    "requestAt": "2023-09-25 10:37:10.034"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":null},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "8. Klasse",
+    "requestAt": "2023-09-25 13:06:55.249"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "6. Klasse",
+    "requestAt": "2023-09-25 13:23:33.631"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":null},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Wirtschaft\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "12. Klasse",
+    "requestAt": "2023-09-25 13:57:09.893"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "8. Klasse",
+    "requestAt": "2023-09-25 14:08:37.976"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "13. Klasse",
+    "requestAt": "2023-09-25 14:40:47.467"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "7. Klasse",
+    "requestAt": "2023-09-25 17:50:38.674"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":null},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":null}]",
+    "state": "by",
+    "grade": "7. Klasse",
+    "requestAt": "2023-09-25 18:36:08.041"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "12. Klasse",
+    "requestAt": "2023-09-26 06:56:32.735"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Geschichte\",\"mandatory\":false}]",
+    "state": "hh",
+    "grade": "10. Klasse",
+    "requestAt": "2023-09-27 04:41:18.717"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "6. Klasse",
+    "requestAt": "2023-09-27 06:25:26.394"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "5. Klasse",
+    "requestAt": "2023-09-27 06:28:40.127"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "hh",
+    "grade": "8. Klasse",
+    "requestAt": "2023-09-27 09:11:17.934"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\"}]",
+    "state": "he",
+    "grade": "8. Klasse",
+    "requestAt": "2023-09-28 11:46:44.716"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\"}]",
+    "state": "he",
+    "grade": "8. Klasse",
+    "requestAt": "2023-09-28 11:46:44.716"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Musik\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "10. Klasse",
+    "requestAt": "2023-09-28 11:57:18.061"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Wirtschaft\",\"mandatory\":true},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "9. Klasse",
+    "requestAt": "2023-09-28 13:15:12.797"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "10. Klasse",
+    "requestAt": "2023-09-28 14:46:12.22"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "5. Klasse",
+    "requestAt": "2023-09-28 15:10:47.579"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "bb",
+    "grade": "10. Klasse",
+    "requestAt": "2023-09-28 17:13:20.191"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "6. Klasse",
+    "requestAt": "2023-09-29 07:25:14.244"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
+    "state": "sn",
+    "grade": "8. Klasse",
+    "requestAt": "2023-09-29 07:52:38.778"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "8. Klasse",
+    "requestAt": "2023-09-30 09:48:39.252"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2023-10-01 12:43:20.116"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Wirtschaft\",\"mandatory\":false}]",
+    "state": "hh",
+    "grade": "13. Klasse",
+    "requestAt": "2023-10-01 15:20:16.283"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":null},{\"name\":\"Mathematik\",\"mandatory\":null},{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "3. Klasse",
+    "requestAt": "2023-10-03 20:19:28.842"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "5. Klasse",
+    "requestAt": "2023-10-04 10:16:24.679"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "13. Klasse",
+    "requestAt": "2023-10-04 11:46:52.732"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "6. Klasse",
+    "requestAt": "2023-10-05 09:22:16.987"
+  },
+  {
+    "subjects": "[{\"name\":\"Wirtschaft\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2023-10-05 16:31:41.934"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "5. Klasse",
+    "requestAt": "2023-10-05 17:34:06.624"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "sh",
+    "grade": "9. Klasse",
+    "requestAt": "2023-10-06 12:51:31.004"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "8. Klasse",
+    "requestAt": "2023-10-06 23:13:18.769"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Latein\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "6. Klasse",
+    "requestAt": "2023-10-07 07:15:47.467"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "11. Klasse",
+    "requestAt": "2023-10-09 05:47:27.76"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Philosophie\",\"mandatory\":false}]",
+    "state": "sh",
+    "grade": "13. Klasse",
+    "requestAt": "2023-10-09 12:45:54.207"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\"}]",
+    "state": "by",
+    "grade": "8. Klasse",
+    "requestAt": "2023-10-09 15:58:43.874"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "10. Klasse",
+    "requestAt": "2023-10-11 06:07:28.548"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "13. Klasse",
+    "requestAt": "2023-10-11 06:47:01.726"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "6. Klasse",
+    "requestAt": "2023-10-12 10:50:15.727"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "8. Klasse",
+    "requestAt": "2023-10-12 12:13:34.951"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":null},{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":null},{\"name\":\"Spanisch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "12. Klasse",
+    "requestAt": "2023-10-12 13:31:49.06"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2023-10-12 15:41:59.525"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "10. Klasse",
+    "requestAt": "2023-10-12 15:48:53.052"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2023-10-12 16:52:29.621"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "6. Klasse",
+    "requestAt": "2023-10-14 22:20:42.988"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "10. Klasse",
+    "requestAt": "2023-10-15 13:22:54.462"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "bb",
+    "grade": "7. Klasse",
+    "requestAt": "2023-10-15 19:07:49.43"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "5. Klasse",
+    "requestAt": "2023-10-16 10:03:46.939"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "sn",
+    "grade": "12. Klasse",
+    "requestAt": "2023-10-20 18:38:27.558"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "3. Klasse",
+    "requestAt": "2023-10-21 11:31:33.268"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Musik\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "9. Klasse",
+    "requestAt": "2023-10-22 14:13:26.368"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2023-10-22 14:57:55.42"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2023-10-23 12:30:41.862"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2023-10-23 13:57:10.394"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "8. Klasse",
+    "requestAt": "2023-10-23 14:33:51.027"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "7. Klasse",
+    "requestAt": "2023-10-23 17:07:08.978"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "13. Klasse",
+    "requestAt": "2023-10-23 20:07:02.868"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2023-10-23 20:11:28.777"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "9. Klasse",
+    "requestAt": "2023-10-24 21:21:41.431"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Technik\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2023-10-25 06:25:21.268"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "sh",
+    "grade": "9. Klasse",
+    "requestAt": "2023-10-25 14:53:49.756"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "11. Klasse",
+    "requestAt": "2023-10-26 09:44:59.204"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "11. Klasse",
+    "requestAt": "2023-10-26 10:25:04.49"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "8. Klasse",
+    "requestAt": "2023-10-27 09:13:14.496"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2023-10-27 19:49:39.857"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "8. Klasse",
+    "requestAt": "2023-10-29 10:24:23.41"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false}]",
+    "state": "ni",
+    "grade": "11. Klasse",
+    "requestAt": "2023-10-29 11:54:37.63"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "6. Klasse",
+    "requestAt": "2023-10-29 22:19:59.196"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":null},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "11. Klasse",
+    "requestAt": "2023-10-30 15:06:19.826"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "11. Klasse",
+    "requestAt": "2023-10-31 14:31:38.005"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2023-11-01 09:51:36.64"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "8. Klasse",
+    "requestAt": "2023-11-01 10:31:26.134"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Musik\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "6. Klasse",
+    "requestAt": "2023-11-01 12:02:04.786"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true}]",
+    "state": "th",
+    "grade": "10. Klasse",
+    "requestAt": "2023-11-01 12:35:58.003"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "9. Klasse",
+    "requestAt": "2023-11-01 13:07:31.301"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "7. Klasse",
+    "requestAt": "2023-11-02 14:11:35.146"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "7. Klasse",
+    "requestAt": "2023-11-02 14:14:46.866"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":null},{\"name\":\"Englisch\",\"mandatory\":null}]",
+    "state": "ni",
+    "grade": "10. Klasse",
+    "requestAt": "2023-11-02 14:20:50.133"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "9. Klasse",
+    "requestAt": "2023-11-02 14:30:54.061"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "hh",
+    "grade": "3. Klasse",
+    "requestAt": "2023-11-02 15:10:36.891"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Religion\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Politik\",\"mandatory\":false},{\"name\":\"Wirtschaft\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "9. Klasse",
+    "requestAt": "2023-11-02 15:48:14.87"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "8. Klasse",
+    "requestAt": "2023-11-02 16:37:11.336"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "hh",
+    "grade": "6. Klasse",
+    "requestAt": "2023-11-02 17:56:13.218"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "11. Klasse",
+    "requestAt": "2023-11-02 18:06:18.191"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "other",
+    "grade": "7. Klasse",
+    "requestAt": "2023-11-02 19:06:22.038"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "9. Klasse",
+    "requestAt": "2023-11-02 20:43:20.244"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "other",
+    "grade": "6. Klasse",
+    "requestAt": "2023-11-02 22:25:58.6"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "7. Klasse",
+    "requestAt": "2023-11-03 06:07:59.976"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2023-11-03 11:29:55.938"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "5. Klasse",
+    "requestAt": "2023-11-03 15:20:00.47"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "10. Klasse",
+    "requestAt": "2023-11-04 21:51:38.319"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "10. Klasse",
+    "requestAt": "2023-11-04 21:51:38.319"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2023-11-05 07:36:23.975"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":null},{\"name\":\"Erdkunde\",\"mandatory\":null},{\"name\":\"Biologie\",\"mandatory\":null},{\"name\":\"Französisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "8. Klasse",
+    "requestAt": "2023-11-05 08:15:45.602"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "4. Klasse",
+    "requestAt": "2023-11-05 09:41:44.937"
+  },
+  {
+    "subjects": "[{\"name\":\"Physik\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "13. Klasse",
+    "requestAt": "2023-11-05 19:09:49.102"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "8. Klasse",
+    "requestAt": "2023-11-05 19:54:40.344"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "3. Klasse",
+    "requestAt": "2023-11-06 12:41:21.579"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "6. Klasse",
+    "requestAt": "2023-11-06 17:42:40.494"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "st",
+    "grade": "4. Klasse",
+    "requestAt": "2023-11-07 09:01:56.727"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Informatik\",\"mandatory\":false},{\"name\":\"Wirtschaft\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "13. Klasse",
+    "requestAt": "2023-11-07 09:15:26.084"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "hh",
+    "grade": "13. Klasse",
+    "requestAt": "2023-11-07 15:40:56.962"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "6. Klasse",
+    "requestAt": "2023-11-07 16:12:55.866"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "5. Klasse",
+    "requestAt": "2023-11-08 09:34:45.516"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "ni",
+    "grade": "11. Klasse",
+    "requestAt": "2023-11-08 14:15:52.543"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "11. Klasse",
+    "requestAt": "2023-11-09 11:38:41.474"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "6. Klasse",
+    "requestAt": "2023-11-10 09:06:28.435"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "8. Klasse",
+    "requestAt": "2023-11-10 11:28:42.525"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2023-11-11 11:15:24.23"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "9. Klasse",
+    "requestAt": "2023-11-11 14:55:24.195"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "9. Klasse",
+    "requestAt": "2023-11-13 14:49:34.08"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Philosophie\",\"mandatory\":false}]",
+    "state": "hh",
+    "grade": "13. Klasse",
+    "requestAt": "2023-11-13 19:00:10.909"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "4. Klasse",
+    "requestAt": "2023-11-14 18:57:47.82"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "6. Klasse",
+    "requestAt": "2023-11-14 19:27:08.34"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "9. Klasse",
+    "requestAt": "2023-11-14 21:48:58.952"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2023-11-15 15:31:50.78"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "3. Klasse",
+    "requestAt": "2023-11-15 20:30:29.26"
+  },
+  {
+    "subjects": "[{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "sn",
+    "grade": "11. Klasse",
+    "requestAt": "2023-11-17 07:25:31.43"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "th",
+    "grade": "5. Klasse",
+    "requestAt": "2023-11-17 12:02:24.029"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "5. Klasse",
+    "requestAt": "2023-11-17 19:20:39.952"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "7. Klasse",
+    "requestAt": "2023-11-17 21:54:33.382"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "6. Klasse",
+    "requestAt": "2023-11-17 21:57:12.512"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":null},{\"name\":\"Spanisch\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "8. Klasse",
+    "requestAt": "2023-11-18 22:43:01.848"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true},{\"name\":\"Spanisch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "9. Klasse",
+    "requestAt": "2023-11-19 16:16:46.72"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":null}]",
+    "state": "th",
+    "grade": "9. Klasse",
+    "requestAt": "2023-11-19 18:23:08.267"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "7. Klasse",
+    "requestAt": "2023-11-19 18:59:40.031"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "4. Klasse",
+    "requestAt": "2023-11-20 13:07:50.511"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "8. Klasse",
+    "requestAt": "2023-11-20 16:18:09.73"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2023-11-20 16:44:07.363"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "8. Klasse",
+    "requestAt": "2023-11-20 18:37:21.49"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":null}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2023-11-21 14:04:41.21"
+  },
+  {
+    "subjects": "[{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2023-11-21 17:48:28.613"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "6. Klasse",
+    "requestAt": "2023-11-21 21:14:31.454"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Sachkunde\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "3. Klasse",
+    "requestAt": "2023-11-21 21:30:05.946"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "5. Klasse",
+    "requestAt": "2023-11-21 21:48:29.605"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "8. Klasse",
+    "requestAt": "2023-11-22 08:08:12.615"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "6. Klasse",
+    "requestAt": "2023-11-22 12:48:17.549"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "9. Klasse",
+    "requestAt": "2023-11-22 16:19:23.271"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"mandatory\":true}]",
+    "state": "sh",
+    "grade": "10. Klasse",
+    "requestAt": "2023-11-22 23:20:06.361"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "ni",
+    "grade": "11. Klasse",
+    "requestAt": "2023-11-23 12:47:17.085"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Latein\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "8. Klasse",
+    "requestAt": "2023-11-24 06:17:49.097"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "sh",
+    "grade": "9. Klasse",
+    "requestAt": "2023-11-26 11:05:29.587"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true},{\"name\":\"Spanisch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2023-11-26 12:57:04.023"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2023-11-26 13:00:01.802"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "6. Klasse",
+    "requestAt": "2023-11-27 06:26:18.573"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "9. Klasse",
+    "requestAt": "2023-11-27 13:32:27.521"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"minGrade\":1,\"maxGrade\":13}]",
+    "state": "bw",
+    "grade": "9. Klasse",
+    "requestAt": "2023-11-27 16:48:22.427"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "4. Klasse",
+    "requestAt": "2023-11-27 22:10:03.928"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "6. Klasse",
+    "requestAt": "2023-11-28 12:10:10.362"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "sn",
+    "grade": "7. Klasse",
+    "requestAt": "2023-11-28 18:30:32.557"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false}]",
+    "state": "ni",
+    "grade": "9. Klasse",
+    "requestAt": "2023-11-29 12:02:51.191"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2023-11-29 18:48:23.606"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "3. Klasse",
+    "requestAt": "2023-11-29 21:19:06.817"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "13. Klasse",
+    "requestAt": "2023-11-30 10:24:09.416"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "7. Klasse",
+    "requestAt": "2023-12-01 08:06:23.824"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "4. Klasse",
+    "requestAt": "2023-12-01 10:17:46.199"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "8. Klasse",
+    "requestAt": "2023-12-03 04:13:53.111"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2023-12-04 16:36:21.297"
+  },
+  {
+    "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2023-12-04 16:38:10.261"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "sn",
+    "grade": "3. Klasse",
+    "requestAt": "2023-12-05 08:20:02.128"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Latein\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "8. Klasse",
+    "requestAt": "2023-12-05 12:25:09.468"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "7. Klasse",
+    "requestAt": "2023-12-05 15:47:54.836"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "9. Klasse",
+    "requestAt": "2023-12-07 07:12:50.1"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "5. Klasse",
+    "requestAt": "2023-12-07 16:00:30.178"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "3. Klasse",
+    "requestAt": "2023-12-07 17:23:15.957"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2023-12-08 14:54:57.044"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "6. Klasse",
+    "requestAt": "2023-12-08 19:32:43.152"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "9. Klasse",
+    "requestAt": "2023-12-10 16:26:55.731"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Latein\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "6. Klasse",
+    "requestAt": "2023-12-12 06:05:05.758"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "7. Klasse",
+    "requestAt": "2023-12-12 17:56:18.537"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "5. Klasse",
+    "requestAt": "2023-12-12 18:50:04.951"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "7. Klasse",
+    "requestAt": "2023-12-13 09:32:49.885"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "5. Klasse",
+    "requestAt": "2023-12-13 20:20:56.679"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "10. Klasse",
+    "requestAt": "2023-12-14 09:07:32.141"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "10. Klasse",
+    "requestAt": "2023-12-18 17:14:52.71"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2023-12-18 18:35:33.456"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2023-12-18 21:31:09.182"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Latein\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2023-12-19 19:30:47.053"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "13. Klasse",
+    "requestAt": "2023-12-20 11:11:37.572"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "6. Klasse",
+    "requestAt": "2023-12-20 15:24:17.316"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "5. Klasse",
+    "requestAt": "2023-12-20 20:27:41.043"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "6. Klasse",
+    "requestAt": "2023-12-20 20:35:43.829"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Spanisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "3. Klasse",
+    "requestAt": "2023-12-21 18:32:45.476"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "9. Klasse",
+    "requestAt": "2023-12-22 00:15:38.412"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":null},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false}]",
+    "state": "th",
+    "grade": "12. Klasse",
+    "requestAt": "2023-12-22 17:27:44.935"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "10. Klasse",
+    "requestAt": "2023-12-23 07:47:57.328"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "8. Klasse",
+    "requestAt": "2023-12-23 07:56:03.147"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "mv",
+    "grade": "13. Klasse",
+    "requestAt": "2023-12-23 10:48:22.421"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "bb",
+    "grade": "12. Klasse",
+    "requestAt": "2023-12-23 10:59:54.36"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "7. Klasse",
+    "requestAt": "2023-12-23 11:25:02.132"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2023-12-23 21:31:28.01"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "11. Klasse",
+    "requestAt": "2023-12-24 07:39:20.181"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2023-12-24 13:13:22.206"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "6. Klasse",
+    "requestAt": "2023-12-24 13:23:49.786"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2023-12-25 01:56:43.992"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "7. Klasse",
+    "requestAt": "2023-12-25 06:01:37.583"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "7. Klasse",
+    "requestAt": "2023-12-25 09:08:33.738"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "7. Klasse",
+    "requestAt": "2023-12-25 10:08:03.041"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "13. Klasse",
+    "requestAt": "2023-12-25 14:02:45.871"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":null},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "9. Klasse",
+    "requestAt": "2023-12-25 19:47:07.925"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "4. Klasse",
+    "requestAt": "2023-12-25 20:26:42.281"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "4. Klasse",
+    "requestAt": "2023-12-26 19:46:01.836"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "8. Klasse",
+    "requestAt": "2023-12-26 20:36:38.706"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Informatik\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Kunst\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "13. Klasse",
+    "requestAt": "2023-12-27 12:36:21.051"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":null},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "7. Klasse",
+    "requestAt": "2023-12-27 16:44:53.967"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "11. Klasse",
+    "requestAt": "2023-12-27 22:28:10.237"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2023-12-28 01:31:22.101"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "7. Klasse",
+    "requestAt": "2023-12-28 15:05:14.113"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "8. Klasse",
+    "requestAt": "2023-12-29 13:03:19.98"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-01-01 19:41:39.721"
+  },
+  {
+    "subjects": "[{\"name\":\"Physik\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Latein\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Informatik\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false}]",
+    "state": "sn",
+    "grade": "10. Klasse",
+    "requestAt": "2024-01-01 20:00:01.977"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "hb",
+    "grade": "13. Klasse",
+    "requestAt": "2024-01-02 09:56:39.582"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "5. Klasse",
+    "requestAt": "2024-01-02 15:46:23.06"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "8. Klasse",
+    "requestAt": "2024-01-02 16:47:15.156"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":null},{\"name\":\"Sachkunde\",\"mandatory\":true}]",
+    "state": "other",
+    "grade": "3. Klasse",
+    "requestAt": "2024-01-05 11:21:57.905"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":false}]",
+    "state": "sn",
+    "grade": "7. Klasse",
+    "requestAt": "2024-01-07 12:42:20.376"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "13. Klasse",
+    "requestAt": "2024-01-07 13:53:32.326"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false}]",
+    "state": "hh",
+    "grade": "8. Klasse",
+    "requestAt": "2024-01-07 23:19:02.36"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2024-01-08 09:20:03.478"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "4. Klasse",
+    "requestAt": "2024-01-08 12:26:11.784"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false}]",
+    "state": "sn",
+    "grade": "12. Klasse",
+    "requestAt": "2024-01-08 14:13:50.584"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "12. Klasse",
+    "requestAt": "2024-01-08 20:50:45.274"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "5. Klasse",
+    "requestAt": "2024-01-09 10:31:49.226"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "7. Klasse",
+    "requestAt": "2024-01-09 16:08:41.501"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false}]",
+    "state": "ni",
+    "grade": "11. Klasse",
+    "requestAt": "2024-01-10 10:43:07.117"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "11. Klasse",
+    "requestAt": "2024-01-10 13:37:44.593"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "12. Klasse",
+    "requestAt": "2024-01-10 15:39:01.814"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "at",
+    "grade": "6. Klasse",
+    "requestAt": "2024-01-10 17:07:19.218"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "5. Klasse",
+    "requestAt": "2024-01-10 18:55:16.909"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Technik\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2024-01-11 20:09:56.923"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "6. Klasse",
+    "requestAt": "2024-01-12 16:51:33.802"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-01-12 20:17:40.378"
+  },
+  {
+    "subjects": "[{\"name\":\"Erdkunde\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "13. Klasse",
+    "requestAt": "2024-01-13 20:20:37.15"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2024-01-13 23:08:38.449"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "th",
+    "grade": "6. Klasse",
+    "requestAt": "2024-01-14 12:11:07.372"
+  },
+  {
+    "subjects": "[{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":true}]",
+    "state": "hh",
+    "grade": "10. Klasse",
+    "requestAt": "2024-01-14 13:20:04.67"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false}]",
+    "state": "ni",
+    "grade": "9. Klasse",
+    "requestAt": "2024-01-15 14:36:29.673"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "4. Klasse",
+    "requestAt": "2024-01-15 19:55:04.217"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "st",
+    "grade": "4. Klasse",
+    "requestAt": "2024-01-15 20:34:33.103"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Spanisch\",\"mandatory\":false}]",
+    "state": "sn",
+    "grade": "9. Klasse",
+    "requestAt": "2024-01-15 20:34:54.706"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "6. Klasse",
+    "requestAt": "2024-01-16 18:37:58.853"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "10. Klasse",
+    "requestAt": "2024-01-16 18:55:31.488"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "6. Klasse",
+    "requestAt": "2024-01-17 15:56:46.027"
+  },
+  {
+    "subjects": "[{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2024-01-17 16:17:21.001"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "5. Klasse",
+    "requestAt": "2024-01-17 16:21:52.388"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "5. Klasse",
+    "requestAt": "2024-01-17 16:26:35.173"
+  },
+  {
+    "subjects": "[{\"name\":\"Geschichte\",\"mandatory\":true}]",
+    "state": "hh",
+    "grade": "11. Klasse",
+    "requestAt": "2024-01-17 17:28:53.586"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":null},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2024-01-17 17:33:08.37"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "8. Klasse",
+    "requestAt": "2024-01-17 19:57:45.352"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "hh",
+    "grade": "6. Klasse",
+    "requestAt": "2024-01-17 20:01:16.636"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2024-01-18 14:43:27.257"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "7. Klasse",
+    "requestAt": "2024-01-18 16:10:04.093"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "6. Klasse",
+    "requestAt": "2024-01-18 18:15:40.161"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2024-01-21 19:48:43.842"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "4. Klasse",
+    "requestAt": "2024-01-21 21:14:08.366"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "4. Klasse",
+    "requestAt": "2024-01-21 21:27:27.931"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "13. Klasse",
+    "requestAt": "2024-01-22 10:55:46.187"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "8. Klasse",
+    "requestAt": "2024-01-22 14:52:54.862"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "7. Klasse",
+    "requestAt": "2024-01-22 18:57:25.005"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "13. Klasse",
+    "requestAt": "2024-01-22 21:14:33.87"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "9. Klasse",
+    "requestAt": "2024-01-23 08:24:37.318"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "11. Klasse",
+    "requestAt": "2024-01-23 17:10:09.418"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-01-23 18:01:38.202"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "10. Klasse",
+    "requestAt": "2024-01-23 19:46:51.164"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "5. Klasse",
+    "requestAt": "2024-01-24 15:56:37.546"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Physik\",\"minGrade\":1,\"maxGrade\":13}]",
+    "state": "sn",
+    "grade": "8. Klasse",
+    "requestAt": "2024-01-24 16:46:22.231"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "8. Klasse",
+    "requestAt": "2024-01-25 07:59:06.225"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2024-01-25 11:45:38.424"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "8. Klasse",
+    "requestAt": "2024-01-26 10:22:59.458"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "8. Klasse",
+    "requestAt": "2024-01-26 10:24:56.395"
+  },
+  {
+    "subjects": "[{\"name\":\"Wirtschaft\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "11. Klasse",
+    "requestAt": "2024-01-27 09:42:00.289"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":true}]",
+    "state": "sn",
+    "grade": "7. Klasse",
+    "requestAt": "2024-01-27 20:14:50.906"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2024-01-28 14:24:36.461"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-01-28 15:35:39.22"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-01-29 09:10:23.929"
+  },
+  {
+    "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2024-01-30 10:11:13.768"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "7. Klasse",
+    "requestAt": "2024-01-30 12:29:19.016"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "6. Klasse",
+    "requestAt": "2024-01-30 17:29:11.787"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "9. Klasse",
+    "requestAt": "2024-01-30 19:43:23.572"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "ni",
+    "grade": "11. Klasse",
+    "requestAt": "2024-01-30 21:00:14.056"
+  },
+  {
+    "subjects": "[{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2024-01-31 11:38:47.292"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-01-31 12:39:20.947"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "5. Klasse",
+    "requestAt": "2024-02-01 09:15:20.733"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "8. Klasse",
+    "requestAt": "2024-02-01 09:39:50.713"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "12. Klasse",
+    "requestAt": "2024-02-01 09:42:05.898"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "6. Klasse",
+    "requestAt": "2024-02-01 09:59:09.872"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2024-02-01 16:55:28.73"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-02-02 17:56:54.577"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "13. Klasse",
+    "requestAt": "2024-02-02 19:26:32.035"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "hb",
+    "grade": "11. Klasse",
+    "requestAt": "2024-02-03 09:15:45.924"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "bb",
+    "grade": "12. Klasse",
+    "requestAt": "2024-02-03 20:50:49.359"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "8. Klasse",
+    "requestAt": "2024-02-04 17:11:52.738"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-02-05 16:18:06.833"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Musik\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "6. Klasse",
+    "requestAt": "2024-02-05 18:54:08.146"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2024-02-06 07:09:24.351"
+  },
+  {
+    "subjects": "[{\"name\":\"Lernen lernen\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "sh",
+    "grade": "6. Klasse",
+    "requestAt": "2024-02-06 09:12:28.57"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "5. Klasse",
+    "requestAt": "2024-02-06 10:38:23.538"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-02-07 08:19:01.052"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "3. Klasse",
+    "requestAt": "2024-02-07 19:31:13.396"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "9. Klasse",
+    "requestAt": "2024-02-08 17:16:22.802"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2024-02-08 20:12:38.081"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "8. Klasse",
+    "requestAt": "2024-02-09 18:26:29.601"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "3. Klasse",
+    "requestAt": "2024-02-10 20:16:15.572"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2024-02-11 14:16:06.488"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "8. Klasse",
+    "requestAt": "2024-02-11 21:13:43.365"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "4. Klasse",
+    "requestAt": "2024-02-12 12:23:45.815"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false}]",
+    "state": "sn",
+    "grade": "12. Klasse",
+    "requestAt": "2024-02-13 14:07:06.213"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "2. Klasse",
+    "requestAt": "2024-02-13 16:53:11.409"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "2. Klasse",
+    "requestAt": "2024-02-13 18:44:52.104"
+  },
+  {
+    "subjects": "[{\"name\":\"Informatik\",\"mandatory\":true}]",
+    "state": "hb",
+    "grade": "13. Klasse",
+    "requestAt": "2024-02-13 20:35:53.405"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "ni",
+    "grade": "8. Klasse",
+    "requestAt": "2024-02-13 20:43:33.537"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2024-02-14 09:57:46.441"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "5. Klasse",
+    "requestAt": "2024-02-14 13:22:12.024"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "8. Klasse",
+    "requestAt": "2024-02-15 16:26:32.873"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Musik\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "10. Klasse",
+    "requestAt": "2024-02-16 15:02:55.913"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2024-02-16 16:11:54.701"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "7. Klasse",
+    "requestAt": "2024-02-16 16:23:19.678"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "6. Klasse",
+    "requestAt": "2024-02-16 16:49:02.791"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "3. Klasse",
+    "requestAt": "2024-02-16 18:34:59.924"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "4. Klasse",
+    "requestAt": "2024-02-16 18:43:33.262"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "3. Klasse",
+    "requestAt": "2024-02-16 19:39:19.505"
+  },
+  {
+    "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-02-16 20:26:48.172"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "4. Klasse",
+    "requestAt": "2024-02-16 20:38:30.88"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2024-02-16 22:08:16.329"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "9. Klasse",
+    "requestAt": "2024-02-17 00:27:22.238"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "8. Klasse",
+    "requestAt": "2024-02-17 02:15:45.733"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "6. Klasse",
+    "requestAt": "2024-02-17 04:00:46.739"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "th",
+    "grade": "2. Klasse",
+    "requestAt": "2024-02-17 04:44:21.641"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "8. Klasse",
+    "requestAt": "2024-02-17 04:45:56.834"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "8. Klasse",
+    "requestAt": "2024-02-17 06:26:01.526"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "7. Klasse",
+    "requestAt": "2024-02-17 06:47:40.095"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "8. Klasse",
+    "requestAt": "2024-02-17 06:54:58.317"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "9. Klasse",
+    "requestAt": "2024-02-17 07:10:59.432"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "6. Klasse",
+    "requestAt": "2024-02-17 07:18:13.397"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "7. Klasse",
+    "requestAt": "2024-02-17 07:20:56.222"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-02-17 07:27:46.483"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "6. Klasse",
+    "requestAt": "2024-02-17 07:30:51.788"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "ni",
+    "grade": "10. Klasse",
+    "requestAt": "2024-02-17 07:32:44.446"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "9. Klasse",
+    "requestAt": "2024-02-17 07:36:03.37"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "11. Klasse",
+    "requestAt": "2024-02-17 08:01:16.404"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "7. Klasse",
+    "requestAt": "2024-02-17 08:03:17.385"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2024-02-17 08:04:51.31"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "7. Klasse",
+    "requestAt": "2024-02-17 08:08:06.508"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "6. Klasse",
+    "requestAt": "2024-02-17 09:15:05.216"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"mandatory\":true},{\"name\":\"Erdkunde\",\"mandatory\":false}]",
+    "state": "hh",
+    "grade": "12. Klasse",
+    "requestAt": "2024-02-17 09:26:04.998"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "6. Klasse",
+    "requestAt": "2024-02-17 09:26:18.801"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-02-17 09:53:22.003"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "5. Klasse",
+    "requestAt": "2024-02-17 09:56:52.199"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "11. Klasse",
+    "requestAt": "2024-02-17 10:36:12.712"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Religion\",\"mandatory\":true}]",
+    "state": "hb",
+    "grade": "13. Klasse",
+    "requestAt": "2024-02-17 10:42:57.212"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "th",
+    "grade": "8. Klasse",
+    "requestAt": "2024-02-17 11:05:57.272"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-02-17 12:44:03.724"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "10. Klasse",
+    "requestAt": "2024-02-17 13:16:41.993"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "9. Klasse",
+    "requestAt": "2024-02-17 14:44:11.787"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "11. Klasse",
+    "requestAt": "2024-02-17 16:01:43.392"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "sn",
+    "grade": "9. Klasse",
+    "requestAt": "2024-02-17 16:03:00.662"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\"}]",
+    "state": "by",
+    "grade": "8. Klasse",
+    "requestAt": "2024-02-17 16:20:20.476"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "11. Klasse",
+    "requestAt": "2024-02-17 16:59:31.984"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "8. Klasse",
+    "requestAt": "2024-02-17 17:37:17.516"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "2. Klasse",
+    "requestAt": "2024-02-17 20:27:15.848"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Biologie\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "6. Klasse",
+    "requestAt": "2024-02-17 20:39:23.402"
+  },
+  {
+    "subjects": "[{\"name\":\"Physik\",\"mandatory\":true},{\"name\":\"Lernen lernen\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
+    "state": "ni",
+    "grade": "9. Klasse",
+    "requestAt": "2024-02-17 21:38:38.397"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2024-02-17 22:30:49.724"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-02-18 07:59:40.933"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2024-02-18 08:42:20.259"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "5. Klasse",
+    "requestAt": "2024-02-18 12:13:45.553"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "5. Klasse",
+    "requestAt": "2024-02-18 12:39:29.374"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2024-02-18 14:04:49.083"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "3. Klasse",
+    "requestAt": "2024-02-18 14:09:38.334"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "4. Klasse",
+    "requestAt": "2024-02-18 15:13:22.838"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "9. Klasse",
+    "requestAt": "2024-02-18 17:12:45.596"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "sh",
+    "grade": "9. Klasse",
+    "requestAt": "2024-02-18 20:48:20.449"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "6. Klasse",
+    "requestAt": "2024-02-18 22:27:09.238"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "8. Klasse",
+    "requestAt": "2024-02-19 13:05:21.222"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "6. Klasse",
+    "requestAt": "2024-02-19 14:49:02.508"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "6. Klasse",
+    "requestAt": "2024-02-19 15:15:14.737"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "11. Klasse",
+    "requestAt": "2024-02-19 15:52:11.75"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "11. Klasse",
+    "requestAt": "2024-02-19 16:44:46.63"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Musik\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "9. Klasse",
+    "requestAt": "2024-02-19 19:04:17.636"
+  },
+  {
+    "subjects": "[{\"name\":\"Pädagogik\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2024-02-19 19:21:02.68"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "9. Klasse",
+    "requestAt": "2024-02-19 19:24:36.02"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "9. Klasse",
+    "requestAt": "2024-02-19 19:30:59.242"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "7. Klasse",
+    "requestAt": "2024-02-19 19:33:24.391"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"mandatory\":true}]",
+    "state": "sh",
+    "grade": "10. Klasse",
+    "requestAt": "2024-02-19 19:46:40.556"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true},{\"name\":\"Spanisch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "9. Klasse",
+    "requestAt": "2024-02-20 17:28:58.631"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "7. Klasse",
+    "requestAt": "2024-02-20 20:52:56.984"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "6. Klasse",
+    "requestAt": "2024-02-20 21:14:09.625"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\"}]",
+    "state": "he",
+    "grade": "8. Klasse",
+    "requestAt": "2024-02-21 06:16:14.669"
+  },
+  {
+    "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2024-02-21 08:28:39.326"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2024-02-21 08:36:16.846"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
+    "state": "ni",
+    "grade": "5. Klasse",
+    "requestAt": "2024-02-21 19:02:05.429"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "7. Klasse",
+    "requestAt": "2024-02-21 21:46:09.08"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "10. Klasse",
+    "requestAt": "2024-02-22 09:22:02.535"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":false}]",
+    "state": "sh",
+    "grade": "9. Klasse",
+    "requestAt": "2024-02-22 12:41:26.485"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Politik\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
+    "state": "ni",
+    "grade": "10. Klasse",
+    "requestAt": "2024-02-22 14:41:59.201"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "6. Klasse",
+    "requestAt": "2024-02-22 14:54:39.263"
+  },
+  {
+    "subjects": "[{\"name\":\"Informatik\",\"mandatory\":true}]",
+    "state": "hb",
+    "grade": "13. Klasse",
+    "requestAt": "2024-02-22 15:10:50.984"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "11. Klasse",
+    "requestAt": "2024-02-22 15:23:36.805"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "7. Klasse",
+    "requestAt": "2024-02-22 20:57:10.573"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "ni",
+    "grade": "12. Klasse",
+    "requestAt": "2024-02-23 08:53:07.187"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "5. Klasse",
+    "requestAt": "2024-02-23 14:00:49.021"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "6. Klasse",
+    "requestAt": "2024-02-23 18:36:30.127"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "11. Klasse",
+    "requestAt": "2024-02-24 18:29:05.114"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Lernen lernen\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "8. Klasse",
+    "requestAt": "2024-02-25 08:56:04.6"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-02-25 10:34:00.528"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "7. Klasse",
+    "requestAt": "2024-02-25 10:43:26.224"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "6. Klasse",
+    "requestAt": "2024-02-25 17:00:25.379"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "9. Klasse",
+    "requestAt": "2024-02-25 17:14:22.937"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "th",
+    "grade": "8. Klasse",
+    "requestAt": "2024-02-26 14:37:05.32"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false}]",
+    "state": "other",
+    "grade": "10. Klasse",
+    "requestAt": "2024-02-26 17:31:54.351"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "12. Klasse",
+    "requestAt": "2024-02-26 17:33:49.984"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "7. Klasse",
+    "requestAt": "2024-02-26 17:56:54.815"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "ni",
+    "grade": "4. Klasse",
+    "requestAt": "2024-02-28 07:42:00.258"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2024-02-28 10:06:28.49"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "3. Klasse",
+    "requestAt": "2024-02-29 13:06:08.887"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":false}]",
+    "state": "other",
+    "grade": "13. Klasse",
+    "requestAt": "2024-02-29 14:27:03.101"
+  },
+  {
+    "subjects": "[{\"name\":\"Wirtschaft\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2024-02-29 17:02:46.703"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2024-02-29 18:59:22.892"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
+    "state": "sn",
+    "grade": "10. Klasse",
+    "requestAt": "2024-02-29 21:00:40.459"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "6. Klasse",
+    "requestAt": "2024-02-29 22:16:47.893"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-03-01 07:44:30.814"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2024-03-03 19:15:54.777"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "5. Klasse",
+    "requestAt": "2024-03-03 20:10:00.869"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":true}]",
+    "state": "sn",
+    "grade": "7. Klasse",
+    "requestAt": "2024-03-03 20:33:52.591"
+  },
+  {
+    "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-03-04 15:16:44.016"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "hh",
+    "grade": "5. Klasse",
+    "requestAt": "2024-03-05 07:28:04.081"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "12. Klasse",
+    "requestAt": "2024-03-05 14:20:28.395"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2024-03-05 18:16:16.427"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "9. Klasse",
+    "requestAt": "2024-03-05 19:24:00.629"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "9. Klasse",
+    "requestAt": "2024-03-06 11:00:08.711"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "sn",
+    "grade": "7. Klasse",
+    "requestAt": "2024-03-06 18:34:59.004"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-03-09 15:41:43.141"
+  },
+  {
+    "subjects": "[{\"name\":\"Wirtschaft\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2024-03-09 15:46:33.586"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "12. Klasse",
+    "requestAt": "2024-03-09 16:56:56.807"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2024-03-09 20:28:18.616"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "7. Klasse",
+    "requestAt": "2024-03-10 08:07:04.793"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "10. Klasse",
+    "requestAt": "2024-03-10 19:16:55.117"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "th",
+    "grade": "7. Klasse",
+    "requestAt": "2024-03-11 11:46:34.144"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "3. Klasse",
+    "requestAt": "2024-03-11 17:51:47.582"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "ni",
+    "grade": "6. Klasse",
+    "requestAt": "2024-03-11 23:41:28.463"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2024-03-13 10:24:51.696"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "8. Klasse",
+    "requestAt": "2024-03-13 14:04:12.158"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "8. Klasse",
+    "requestAt": "2024-03-14 14:55:09.003"
+  },
+  {
+    "subjects": "[{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":true}]",
+    "state": "hh",
+    "grade": "10. Klasse",
+    "requestAt": "2024-03-14 20:03:52.38"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Latein\",\"mandatory\":true}]",
+    "state": "ni",
+    "grade": "8. Klasse",
+    "requestAt": "2024-03-15 06:54:52.267"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2024-03-15 12:15:59.715"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Wirtschaft\",\"mandatory\":true},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "9. Klasse",
+    "requestAt": "2024-03-17 11:52:52.57"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true}]",
+    "state": "hh",
+    "grade": "13. Klasse",
+    "requestAt": "2024-03-19 09:21:28.287"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "ni",
+    "grade": "4. Klasse",
+    "requestAt": "2024-03-19 15:03:07.591"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "10. Klasse",
+    "requestAt": "2024-03-19 15:20:14.288"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "4. Klasse",
+    "requestAt": "2024-03-19 16:01:46.771"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true},{\"name\":\"Spanisch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-03-19 17:19:31.846"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "4. Klasse",
+    "requestAt": "2024-03-20 09:12:45.646"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "11. Klasse",
+    "requestAt": "2024-03-20 10:59:13.124"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "11. Klasse",
+    "requestAt": "2024-03-20 12:13:33.449"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "6. Klasse",
+    "requestAt": "2024-03-20 15:02:47.443"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "9. Klasse",
+    "requestAt": "2024-03-21 14:46:00.899"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "11. Klasse",
+    "requestAt": "2024-03-21 15:32:27.368"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "hh",
+    "grade": "13. Klasse",
+    "requestAt": "2024-03-22 00:03:00.113"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "3. Klasse",
+    "requestAt": "2024-03-22 13:40:57.105"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-03-22 13:48:36.079"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "8. Klasse",
+    "requestAt": "2024-03-23 23:25:16.706"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "5. Klasse",
+    "requestAt": "2024-03-25 17:37:18.699"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true}]",
+    "state": "th",
+    "grade": "10. Klasse",
+    "requestAt": "2024-03-26 16:06:33.401"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "12. Klasse",
+    "requestAt": "2024-03-27 14:04:45.063"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "11. Klasse",
+    "requestAt": "2024-03-27 17:25:59.215"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "8. Klasse",
+    "requestAt": "2024-03-27 19:22:00.485"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2024-03-27 23:24:09.235"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "9. Klasse",
+    "requestAt": "2024-03-28 20:33:20.886"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "5. Klasse",
+    "requestAt": "2024-03-31 18:36:43.508"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "13. Klasse",
+    "requestAt": "2024-04-01 11:11:06.091"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "3. Klasse",
+    "requestAt": "2024-04-01 13:53:25.519"
+  },
+  {
+    "subjects": "[{\"name\":\"Lernen lernen\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "sh",
+    "grade": "6. Klasse",
+    "requestAt": "2024-04-01 17:15:17.148"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "th",
+    "grade": "6. Klasse",
+    "requestAt": "2024-04-03 07:45:31.86"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "2. Klasse",
+    "requestAt": "2024-04-03 13:29:21.537"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "9. Klasse",
+    "requestAt": "2024-04-04 08:27:43.028"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2024-04-04 14:12:24.875"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "6. Klasse",
+    "requestAt": "2024-04-05 08:20:13.088"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "2. Klasse",
+    "requestAt": "2024-04-08 12:13:17.589"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "8. Klasse",
+    "requestAt": "2024-04-08 12:44:22.86"
+  },
+  {
+    "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-04-08 15:11:42.801"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "6. Klasse",
+    "requestAt": "2024-04-09 10:35:43.999"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "9. Klasse",
+    "requestAt": "2024-04-10 07:07:14.519"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "7. Klasse",
+    "requestAt": "2024-04-10 09:56:54.313"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2024-04-10 16:04:17.341"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "sn",
+    "grade": "10. Klasse",
+    "requestAt": "2024-04-11 14:49:47.71"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2024-04-12 08:33:33.371"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "7. Klasse",
+    "requestAt": "2024-04-12 10:07:33.217"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":true}]",
+    "state": "ni",
+    "grade": "10. Klasse",
+    "requestAt": "2024-04-12 12:17:34.821"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "11. Klasse",
+    "requestAt": "2024-04-12 14:28:38.568"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2024-04-12 19:45:53.443"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "6. Klasse",
+    "requestAt": "2024-04-13 04:23:43.633"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "6. Klasse",
+    "requestAt": "2024-04-14 19:03:36.935"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2024-04-14 19:48:22.17"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "7. Klasse",
+    "requestAt": "2024-04-15 12:10:28.151"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "6. Klasse",
+    "requestAt": "2024-04-16 12:40:34.116"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-04-16 14:37:11.016"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "6. Klasse",
+    "requestAt": "2024-04-16 17:29:21.288"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "11. Klasse",
+    "requestAt": "2024-04-16 18:18:38.051"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":false}]",
+    "state": "hh",
+    "grade": "12. Klasse",
+    "requestAt": "2024-04-17 09:13:50.558"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "2. Klasse",
+    "requestAt": "2024-04-18 13:14:04.763"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "2. Klasse",
+    "requestAt": "2024-04-18 14:04:13.805"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2024-04-18 14:10:30.6"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "9. Klasse",
+    "requestAt": "2024-04-18 18:23:34.539"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "th",
+    "grade": "3. Klasse",
+    "requestAt": "2024-04-18 19:18:37.566"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "5. Klasse",
+    "requestAt": "2024-04-19 13:50:09.994"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "3. Klasse",
+    "requestAt": "2024-04-22 14:18:26.413"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Wirtschaft\",\"mandatory\":true},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "9. Klasse",
+    "requestAt": "2024-04-23 11:01:50.207"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "sn",
+    "grade": "6. Klasse",
+    "requestAt": "2024-04-23 13:17:27.892"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":false}]",
+    "state": "other",
+    "grade": "6. Klasse",
+    "requestAt": "2024-04-23 13:20:10.854"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "10. Klasse",
+    "requestAt": "2024-04-24 20:51:03.424"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "6. Klasse",
+    "requestAt": "2024-04-25 12:14:09.008"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "6. Klasse",
+    "requestAt": "2024-04-25 14:07:31.542"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\"}]",
+    "state": "he",
+    "grade": "8. Klasse",
+    "requestAt": "2024-04-25 14:17:22.809"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2024-04-25 16:03:14.767"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "6. Klasse",
+    "requestAt": "2024-04-25 16:21:33.787"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "2. Klasse",
+    "requestAt": "2024-04-25 17:12:19.294"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2024-04-25 18:22:27.473"
+  },
+  {
+    "subjects": "[{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":true}]",
+    "state": "hh",
+    "grade": "10. Klasse",
+    "requestAt": "2024-04-26 09:21:01.78"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "ni",
+    "grade": "6. Klasse",
+    "requestAt": "2024-04-27 06:58:43.683"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "9. Klasse",
+    "requestAt": "2024-04-28 14:46:03.851"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "5. Klasse",
+    "requestAt": "2024-04-28 17:46:56.337"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "4. Klasse",
+    "requestAt": "2024-04-29 11:55:56.546"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "sn",
+    "grade": "8. Klasse",
+    "requestAt": "2024-04-29 12:22:54.284"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-04-29 18:17:56.025"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "5. Klasse",
+    "requestAt": "2024-04-29 18:25:44.651"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Latein\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-04-30 19:08:06.284"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "6. Klasse",
+    "requestAt": "2024-05-02 08:24:37.828"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "8. Klasse",
+    "requestAt": "2024-05-02 11:39:44.913"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
+    "state": "hh",
+    "grade": "6. Klasse",
+    "requestAt": "2024-05-02 14:21:08.59"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "12. Klasse",
+    "requestAt": "2024-05-02 16:32:17.981"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "8. Klasse",
+    "requestAt": "2024-05-02 17:44:47.898"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2024-05-03 09:45:25.685"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "4. Klasse",
+    "requestAt": "2024-05-03 10:46:15.457"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "3. Klasse",
+    "requestAt": "2024-05-03 14:19:50.776"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "13. Klasse",
+    "requestAt": "2024-05-05 11:23:48.051"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "sn",
+    "grade": "3. Klasse",
+    "requestAt": "2024-05-06 12:06:39.039"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "10. Klasse",
+    "requestAt": "2024-05-06 15:23:43.849"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "2. Klasse",
+    "requestAt": "2024-05-06 16:04:47.89"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "5. Klasse",
+    "requestAt": "2024-05-06 17:46:34.365"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "11. Klasse",
+    "requestAt": "2024-05-07 08:58:34.446"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "4. Klasse",
+    "requestAt": "2024-05-07 15:12:10.176"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "6. Klasse",
+    "requestAt": "2024-05-07 15:13:02.277"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "3. Klasse",
+    "requestAt": "2024-05-07 16:06:16.697"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-05-07 16:57:57.781"
+  },
+  {
+    "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-05-09 14:27:42.26"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true},{\"name\":\"Spanisch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "9. Klasse",
+    "requestAt": "2024-05-10 13:03:54.047"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "9. Klasse",
+    "requestAt": "2024-05-13 09:01:48.827"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "14. Klasse",
+    "requestAt": "2024-05-13 14:15:00.216"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "2. Klasse",
+    "requestAt": "2024-05-13 15:55:02.207"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "11. Klasse",
+    "requestAt": "2024-05-14 12:00:16.501"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "12. Klasse",
+    "requestAt": "2024-05-14 15:56:25.539"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "4. Klasse",
+    "requestAt": "2024-05-14 17:12:05.726"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "sn",
+    "grade": "9. Klasse",
+    "requestAt": "2024-05-16 03:56:35.825"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "6. Klasse",
+    "requestAt": "2024-05-16 08:15:34.446"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-05-16 13:49:20.577"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Pädagogik\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "14. Klasse",
+    "requestAt": "2024-05-16 16:32:11.215"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "th",
+    "grade": "3. Klasse",
+    "requestAt": "2024-05-16 19:14:17.24"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "9. Klasse",
+    "requestAt": "2024-05-17 12:11:00.495"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "6. Klasse",
+    "requestAt": "2024-05-17 12:23:29.828"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "6. Klasse",
+    "requestAt": "2024-05-17 22:20:48.23"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2024-05-18 13:28:04.688"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true},{\"name\":\"Politik\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "12. Klasse",
+    "requestAt": "2024-05-18 22:56:36.484"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "11. Klasse",
+    "requestAt": "2024-05-19 07:47:40.741"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "9. Klasse",
+    "requestAt": "2024-05-19 10:44:16.729"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "6. Klasse",
+    "requestAt": "2024-05-19 15:55:01.33"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2024-05-19 18:58:10.551"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "8. Klasse",
+    "requestAt": "2024-05-20 16:20:32.736"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "9. Klasse",
+    "requestAt": "2024-05-20 21:25:12.568"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "14. Klasse",
+    "requestAt": "2024-05-21 13:20:47.694"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "3. Klasse",
+    "requestAt": "2024-05-21 16:33:59.634"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Spanisch\",\"mandatory\":false}]",
+    "state": "sn",
+    "grade": "9. Klasse",
+    "requestAt": "2024-05-22 13:16:18.841"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":false}]",
+    "state": "hh",
+    "grade": "12. Klasse",
+    "requestAt": "2024-05-22 22:18:38.734"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "10. Klasse",
+    "requestAt": "2024-05-23 08:13:44.319"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "10. Klasse",
+    "requestAt": "2024-05-23 08:13:44.319"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "8. Klasse",
+    "requestAt": "2024-05-23 13:57:10.221"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2024-05-23 15:59:13.234"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "2. Klasse",
+    "requestAt": "2024-05-23 16:24:51.753"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "8. Klasse",
+    "requestAt": "2024-05-24 13:20:54.389"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "6. Klasse",
+    "requestAt": "2024-05-25 12:31:47.612"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "sh",
+    "grade": "9. Klasse",
+    "requestAt": "2024-05-25 17:28:03.062"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "3. Klasse",
+    "requestAt": "2024-05-26 11:44:40.407"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "7. Klasse",
+    "requestAt": "2024-05-26 15:40:16.084"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "2. Klasse",
+    "requestAt": "2024-05-27 12:46:20.754"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "8. Klasse",
+    "requestAt": "2024-05-27 14:14:01.119"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "14. Klasse",
+    "requestAt": "2024-05-27 15:55:03.889"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "6. Klasse",
+    "requestAt": "2024-05-28 11:51:21.787"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "14. Klasse",
+    "requestAt": "2024-05-28 13:48:29.868"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "ni",
+    "grade": "12. Klasse",
+    "requestAt": "2024-05-28 14:38:36.054"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "6. Klasse",
+    "requestAt": "2024-05-28 16:27:12.307"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "sn",
+    "grade": "5. Klasse",
+    "requestAt": "2024-05-28 17:19:18.471"
+  },
+  {
+    "subjects": "[{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2024-05-29 12:30:39.373"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "10. Klasse",
+    "requestAt": "2024-05-29 14:28:27.366"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "5. Klasse",
+    "requestAt": "2024-05-29 16:41:29.035"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "14. Klasse",
+    "requestAt": "2024-05-29 17:07:08.651"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "4. Klasse",
+    "requestAt": "2024-05-30 11:33:20.531"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true}]",
+    "state": "hh",
+    "grade": "13. Klasse",
+    "requestAt": "2024-05-30 21:09:35.272"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "6. Klasse",
+    "requestAt": "2024-05-31 07:01:06.281"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Erdkunde\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2024-05-31 08:08:15.167"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Französisch\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "9. Klasse",
+    "requestAt": "2024-05-31 20:54:18.743"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "8. Klasse",
+    "requestAt": "2024-06-02 22:45:39.795"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "14. Klasse",
+    "requestAt": "2024-06-03 12:35:12.299"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2024-06-04 05:27:04.723"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "11. Klasse",
+    "requestAt": "2024-06-04 08:14:22.957"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2024-06-04 17:55:20.071"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2024-06-05 05:12:25.796"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Biologie\",\"mandatory\":false}]",
+    "state": "sh",
+    "grade": "13. Klasse",
+    "requestAt": "2024-06-05 15:34:00.951"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "th",
+    "grade": "7. Klasse",
+    "requestAt": "2024-06-05 16:08:14.734"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Informatik\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "14. Klasse",
+    "requestAt": "2024-06-06 17:08:42.31"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "6. Klasse",
+    "requestAt": "2024-06-07 08:05:49.37"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Erdkunde\",\"mandatory\":false}]",
+    "state": "hh",
+    "grade": "13. Klasse",
+    "requestAt": "2024-06-07 12:38:34.733"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "6. Klasse",
+    "requestAt": "2024-06-07 13:14:01.065"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
+    "state": "sn",
+    "grade": "7. Klasse",
+    "requestAt": "2024-06-07 14:18:33.346"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2024-06-09 15:19:33.004"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2024-06-10 13:28:59.394"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "6. Klasse",
+    "requestAt": "2024-06-11 07:27:59.047"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "2. Klasse",
+    "requestAt": "2024-06-11 07:29:32.9"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "10. Klasse",
+    "requestAt": "2024-06-11 13:57:53.074"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "ni",
+    "grade": "10. Klasse",
+    "requestAt": "2024-06-11 15:42:17.351"
+  },
+  {
+    "subjects": "[{\"name\":\"Informatik\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "14. Klasse",
+    "requestAt": "2024-06-11 16:43:46.933"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "ni",
+    "grade": "3. Klasse",
+    "requestAt": "2024-06-11 16:44:38.293"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2024-06-11 16:45:23.033"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "2. Klasse",
+    "requestAt": "2024-06-11 17:41:24.208"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "6. Klasse",
+    "requestAt": "2024-06-12 11:13:55.535"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "8. Klasse",
+    "requestAt": "2024-06-12 18:27:41.742"
+  },
+  {
+    "subjects": "[{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":true}]",
+    "state": "hh",
+    "grade": "10. Klasse",
+    "requestAt": "2024-06-12 18:49:47.979"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Informatik\",\"mandatory\":true}]",
+    "state": "other",
+    "grade": "10. Klasse",
+    "requestAt": "2024-06-12 19:24:11.209"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "9. Klasse",
+    "requestAt": "2024-06-13 09:01:37.424"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "hb",
+    "grade": "14. Klasse",
+    "requestAt": "2024-06-13 12:47:29.957"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2024-06-13 15:27:48.614"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2024-06-13 19:42:40.106"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "6. Klasse",
+    "requestAt": "2024-06-14 11:27:17.929"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "ni",
+    "grade": "7. Klasse",
+    "requestAt": "2024-06-14 11:48:37.33"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "4. Klasse",
+    "requestAt": "2024-06-14 12:39:47.707"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "10. Klasse",
+    "requestAt": "2024-06-14 12:52:19.656"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"mandatory\":true}]",
+    "state": "hh",
+    "grade": "13. Klasse",
+    "requestAt": "2024-06-14 22:03:19.034"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "3. Klasse",
+    "requestAt": "2024-06-17 13:25:13.633"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "2. Klasse",
+    "requestAt": "2024-06-17 13:51:51.57"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "ni",
+    "grade": "13. Klasse",
+    "requestAt": "2024-06-17 17:10:11.907"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "th",
+    "grade": "5. Klasse",
+    "requestAt": "2024-06-18 05:36:58.806"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "4. Klasse",
+    "requestAt": "2024-06-18 11:50:53.084"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "10. Klasse",
+    "requestAt": "2024-06-18 12:19:25.665"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Spanisch\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "7. Klasse",
+    "requestAt": "2024-06-18 14:23:10.129"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Französisch\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "8. Klasse",
+    "requestAt": "2024-06-18 15:14:36.636"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "2. Klasse",
+    "requestAt": "2024-06-19 07:07:50.836"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "sn",
+    "grade": "6. Klasse",
+    "requestAt": "2024-06-19 14:18:04.015"
+  },
+  {
+    "subjects": "[{\"name\":\"Sachkunde\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "sn",
+    "grade": "4. Klasse",
+    "requestAt": "2024-06-19 14:40:05.602"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Spanisch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "7. Klasse",
+    "requestAt": "2024-06-19 16:04:44.279"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "8. Klasse",
+    "requestAt": "2024-06-19 16:37:31.68"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "th",
+    "grade": "8. Klasse",
+    "requestAt": "2024-06-19 20:46:22.208"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "3. Klasse",
+    "requestAt": "2024-06-21 03:26:51.934"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "7. Klasse",
+    "requestAt": "2024-06-21 19:49:53.233"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "5. Klasse",
+    "requestAt": "2024-06-22 20:49:52.049"
+  },
+  {
+    "subjects": "[{\"name\":\"Sachkunde\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "sn",
+    "grade": "4. Klasse",
+    "requestAt": "2024-06-23 14:08:34.469"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "3. Klasse",
+    "requestAt": "2024-06-24 07:34:12.643"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "th",
+    "grade": "5. Klasse",
+    "requestAt": "2024-06-24 14:19:09.335"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "3. Klasse",
+    "requestAt": "2024-06-24 14:52:30.262"
+  },
+  {
+    "subjects": "[{\"name\":\"Wirtschaft\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "14. Klasse",
+    "requestAt": "2024-06-24 16:44:00.571"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "3. Klasse",
+    "requestAt": "2024-06-24 17:32:02.74"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "10. Klasse",
+    "requestAt": "2024-06-24 20:02:49.177"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "13. Klasse",
+    "requestAt": "2024-06-25 04:57:09.927"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "4. Klasse",
+    "requestAt": "2024-06-25 09:44:02.536"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "5. Klasse",
+    "requestAt": "2024-06-26 13:26:05.129"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "8. Klasse",
+    "requestAt": "2024-06-26 14:35:02.638"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-06-26 18:38:31.956"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false}]",
+    "state": "sn",
+    "grade": "10. Klasse",
+    "requestAt": "2024-06-27 10:21:28.938"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "6. Klasse",
+    "requestAt": "2024-06-27 12:12:18.688"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":false}]",
+    "state": "other",
+    "grade": "14. Klasse",
+    "requestAt": "2024-06-27 15:55:58.427"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "14. Klasse",
+    "requestAt": "2024-06-28 11:54:44.33"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Technik\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2024-07-01 12:15:09.867"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2024-07-01 12:28:23.244"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "2. Klasse",
+    "requestAt": "2024-07-01 14:13:52.394"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2024-07-02 16:57:20.462"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "9. Klasse",
+    "requestAt": "2024-07-02 18:18:19.031"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "9. Klasse",
+    "requestAt": "2024-07-03 09:12:26.006"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "4. Klasse",
+    "requestAt": "2024-07-03 10:11:13.972"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "7. Klasse",
+    "requestAt": "2024-07-04 13:30:23.786"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "7. Klasse",
+    "requestAt": "2024-07-04 17:30:55.972"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "6. Klasse",
+    "requestAt": "2024-07-04 19:47:53.798"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "sh",
+    "grade": "9. Klasse",
+    "requestAt": "2024-07-05 17:48:37.445"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "sn",
+    "grade": "6. Klasse",
+    "requestAt": "2024-07-06 19:53:37.357"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "6. Klasse",
+    "requestAt": "2024-07-07 15:35:06.482"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "14. Klasse",
+    "requestAt": "2024-07-08 08:23:38.277"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-07-09 14:33:01.755"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "6. Klasse",
+    "requestAt": "2024-07-09 15:23:42.879"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "10. Klasse",
+    "requestAt": "2024-07-10 14:38:55.904"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "5. Klasse",
+    "requestAt": "2024-07-10 15:35:12.92"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-07-10 18:38:50.708"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true}]",
+    "state": "th",
+    "grade": "10. Klasse",
+    "requestAt": "2024-07-11 08:01:30.445"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2024-07-11 18:15:56.825"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2024-07-13 15:10:16.36"
+  },
+  {
+    "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "7. Klasse",
+    "requestAt": "2024-07-13 17:08:45.857"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "14. Klasse",
+    "requestAt": "2024-07-15 10:17:11.686"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":false}]",
+    "state": "ni",
+    "grade": "11. Klasse",
+    "requestAt": "2024-07-15 12:37:42.847"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2024-07-16 19:28:24.164"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "14. Klasse",
+    "requestAt": "2024-07-17 10:35:34.393"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Physik\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "9. Klasse",
+    "requestAt": "2024-07-18 11:26:38.788"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Chemie\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false}]",
+    "state": "be",
+    "grade": "10. Klasse",
+    "requestAt": "2024-07-18 16:13:23.047"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "8. Klasse",
+    "requestAt": "2024-07-19 19:15:52.285"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "rp",
+    "grade": "9. Klasse",
+    "requestAt": "2024-07-21 05:18:50.122"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "hh",
+    "grade": "7. Klasse",
+    "requestAt": "2024-07-22 10:23:16.716"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "6. Klasse",
+    "requestAt": "2024-07-22 15:55:35.267"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "14. Klasse",
+    "requestAt": "2024-07-24 10:09:21.899"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "4. Klasse",
+    "requestAt": "2024-07-24 12:40:14.597"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "hb",
+    "grade": "3. Klasse",
+    "requestAt": "2024-07-24 16:21:21.847"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "hb",
+    "grade": "9. Klasse",
+    "requestAt": "2024-07-25 11:46:07.287"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "sn",
+    "grade": "3. Klasse",
+    "requestAt": "2024-07-25 20:41:59.412"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Sachkunde\",\"mandatory\":true}]",
+    "state": "sn",
+    "grade": "5. Klasse",
+    "requestAt": "2024-07-26 15:09:59.087"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Latein\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "8. Klasse",
+    "requestAt": "2024-07-26 16:14:46.716"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "th",
+    "grade": "3. Klasse",
+    "requestAt": "2024-07-28 14:39:53.322"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2024-07-28 18:07:36.273"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "at",
+    "grade": "6. Klasse",
+    "requestAt": "2024-08-01 15:37:30.178"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "be",
+    "grade": "6. Klasse",
+    "requestAt": "2024-08-02 10:45:56.248"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "ni",
+    "grade": "3. Klasse",
+    "requestAt": "2024-08-02 19:58:54.911"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "at",
+    "grade": "6. Klasse",
+    "requestAt": "2024-08-05 16:07:25.376"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "ni",
+    "grade": "8. Klasse",
+    "requestAt": "2024-08-06 15:07:53.696"
+  },
+  {
+    "subjects": "[{\"name\":\"Wirtschaft\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "14. Klasse",
+    "requestAt": "2024-08-06 16:31:34.144"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "3. Klasse",
+    "requestAt": "2024-08-06 16:40:31.185"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "5. Klasse",
+    "requestAt": "2024-08-06 20:37:56.32"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "5. Klasse",
+    "requestAt": "2024-08-08 16:19:49.019"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Erdkunde\",\"mandatory\":false},{\"name\":\"Geschichte\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":false},{\"name\":\"Biologie\",\"mandatory\":false}]",
+    "state": "ni",
+    "grade": "5. Klasse",
+    "requestAt": "2024-08-10 12:34:48.003"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "7. Klasse",
+    "requestAt": "2024-08-12 13:58:24.625"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "11. Klasse",
+    "requestAt": "2024-08-12 15:10:02.944"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "3. Klasse",
+    "requestAt": "2024-08-12 15:39:32.497"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":false}]",
+    "state": "bw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-08-13 05:19:45.884"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "5. Klasse",
+    "requestAt": "2024-08-13 07:11:30.572"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Physik\",\"mandatory\":true}]",
+    "state": "th",
+    "grade": "10. Klasse",
+    "requestAt": "2024-08-13 12:24:02.861"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "12. Klasse",
+    "requestAt": "2024-08-13 14:03:11.918"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "7. Klasse",
+    "requestAt": "2024-08-13 14:27:27.087"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-08-13 16:21:32.936"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "7. Klasse",
+    "requestAt": "2024-08-14 11:49:04.744"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"mandatory\":true},{\"name\":\"Spanisch\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "9. Klasse",
+    "requestAt": "2024-08-14 18:07:19.993"
+  },
+  {
+    "subjects": "[{\"name\":\"Spanisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2024-08-15 09:30:11.178"
+  },
+  {
+    "subjects": "[{\"name\":\"Wirtschaft\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "11. Klasse",
+    "requestAt": "2024-08-15 11:07:37.168"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Gesundheit\",\"mandatory\":false},{\"name\":\"Pädagogik\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "14. Klasse",
+    "requestAt": "2024-08-15 11:22:51.978"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "14. Klasse",
+    "requestAt": "2024-08-15 16:27:37.599"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "11. Klasse",
+    "requestAt": "2024-08-16 09:42:49.732"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "5. Klasse",
+    "requestAt": "2024-08-20 09:27:27.413"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "7. Klasse",
+    "requestAt": "2024-08-20 16:55:25.369"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "10. Klasse",
+    "requestAt": "2024-08-22 14:02:06.231"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"mandatory\":true},{\"name\":\"Biologie\",\"mandatory\":false}]",
+    "state": "he",
+    "grade": "5. Klasse",
+    "requestAt": "2024-08-22 16:45:55.241"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Technik\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "9. Klasse",
+    "requestAt": "2024-08-23 14:48:46.84"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "12. Klasse",
+    "requestAt": "2024-08-23 16:20:46.836"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "bw",
+    "grade": "4. Klasse",
+    "requestAt": "2024-08-23 17:43:50.042"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "nw",
+    "grade": "5. Klasse",
+    "requestAt": "2024-08-24 16:47:30.011"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true}]",
+    "state": "rp",
+    "grade": "5. Klasse",
+    "requestAt": "2024-08-24 22:56:23.546"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Religion\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Deutsch\",\"mandatory\":false}]",
+    "state": "hb",
+    "grade": "12. Klasse",
+    "requestAt": "2024-08-26 15:21:54.515"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":true},{\"name\":\"Geschichte\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "10. Klasse",
+    "requestAt": "2024-08-26 16:12:27.535"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "sn",
+    "grade": "5. Klasse",
+    "requestAt": "2024-08-26 17:25:25.517"
+  },
+  {
+    "subjects": "[{\"name\":\"Informatik\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "14. Klasse",
+    "requestAt": "2024-08-28 15:52:30.365"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Mathematik\",\"mandatory\":false},{\"name\":\"Technik\",\"mandatory\":false}]",
+    "state": "by",
+    "grade": "11. Klasse",
+    "requestAt": "2024-08-29 12:49:19.821"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "11. Klasse",
+    "requestAt": "2024-08-30 10:21:11.257"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":true},{\"name\":\"Lernen lernen\",\"mandatory\":false}]",
+    "state": "nw",
+    "grade": "7. Klasse",
+    "requestAt": "2024-08-31 14:31:35.867"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "hb",
+    "grade": "14. Klasse",
+    "requestAt": "2024-09-03 05:34:41.869"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"mandatory\":true},{\"name\":\"Deutsch\",\"mandatory\":true}]",
+    "state": "bb",
+    "grade": "5. Klasse",
+    "requestAt": "2024-09-03 14:32:05.864"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "by",
+    "grade": "6. Klasse",
+    "requestAt": "2024-09-04 21:01:12.883"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"mandatory\":false},{\"name\":\"Englisch\",\"mandatory\":true}]",
+    "state": "he",
+    "grade": "6. Klasse",
+    "requestAt": "2024-09-08 13:39:57.606"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"mandatory\":false},{\"name\":\"Mathematik\",\"mandatory\":true}]",
+    "state": "sn",
+    "grade": "12. Klasse",
+    "requestAt": "2024-09-09 19:22:16.625"
+  }
+]

--- a/common/match/matching.perf.student.json
+++ b/common/match/matching.perf.student.json
@@ -1,6025 +1,7230 @@
 [
   {
+    "id": 15485,
     "subjects": "[{\"name\":\"Deutsch\",\"minGrade\":1,\"maxGrade\":6},{\"name\":\"Deutsch als Zweitsprache\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Mathematik\",\"minGrade\":1,\"maxGrade\":6},{\"name\":\"Sachkunde\",\"minGrade\":1,\"maxGrade\":4},{\"name\":\"Musik\",\"minGrade\":1,\"maxGrade\":5},{\"name\":\"Erdkunde\",\"minGrade\":1,\"maxGrade\":6},{\"name\":\"Biologie\",\"minGrade\":1,\"maxGrade\":6}]",
     "state": "nw",
     "requestAt": "2022-09-01 21:21:13.559"
   },
   {
+    "id": 5636,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "be",
     "requestAt": "2022-10-23 08:16:55.19"
   },
   {
+    "id": 15917,
     "subjects": "[{\"name\":\"Chemie\",\"minGrade\":5,\"maxGrade\":13},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":3},{\"name\":\"Mathematik\",\"minGrade\":1,\"maxGrade\":8},{\"name\":\"Sachkunde\",\"minGrade\":1,\"maxGrade\":6},{\"name\":\"Englisch\",\"minGrade\":1,\"maxGrade\":8}]",
     "state": "sh",
     "requestAt": "2022-10-23 08:18:19.684"
   },
   {
+    "id": 16440,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Chemie\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":8},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":8}]",
     "state": "nw",
     "requestAt": "2022-10-27 17:49:12.846"
   },
   {
+    "id": 5636,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "be",
     "requestAt": "2022-11-05 08:44:04.903"
   },
   {
+    "id": 16788,
     "subjects": "[{\"name\":\"Deutsch\",\"minGrade\":1,\"maxGrade\":13}]",
     "state": "nw",
     "requestAt": "2022-11-16 22:04:33.953"
   },
   {
+    "id": 16788,
     "subjects": "[{\"name\":\"Deutsch\",\"minGrade\":1,\"maxGrade\":13}]",
     "state": "nw",
     "requestAt": "2022-11-16 22:04:33.953"
   },
   {
+    "id": 16788,
     "subjects": "[{\"name\":\"Deutsch\",\"minGrade\":1,\"maxGrade\":13}]",
     "state": "nw",
     "requestAt": "2022-11-16 22:04:33.953"
   },
   {
+    "id": 16456,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "sl",
     "requestAt": "2022-11-22 09:00:04.987"
   },
   {
+    "id": 16836,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2022-11-23 21:21:30.221"
   },
   {
+    "id": 16846,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2022-11-29 09:01:49.789"
   },
   {
+    "id": 16456,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "sl",
     "requestAt": "2022-11-29 09:32:46.964"
   },
   {
+    "id": 16456,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "sl",
     "requestAt": "2022-11-29 09:32:46.964"
   },
   {
+    "id": 3577,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2022-12-04 10:26:59.112"
   },
   {
+    "id": 16456,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "sl",
     "requestAt": "2022-12-16 12:01:00.249"
   },
   {
+    "id": 16424,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "hb",
     "requestAt": "2023-01-06 09:03:09.085"
   },
   {
+    "id": 3577,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2023-01-09 13:21:36.239"
   },
   {
+    "id": 16456,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "sl",
     "requestAt": "2023-01-13 09:04:48.61"
   },
   {
+    "id": 16456,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "sl",
     "requestAt": "2023-01-13 09:04:48.61"
   },
   {
+    "id": 885,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":7}]",
     "state": "by",
     "requestAt": "2023-01-19 18:17:38.794"
   },
   {
+    "id": 3577,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2023-02-09 13:39:11.492"
   },
   {
+    "id": 16922,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-02-10 09:01:20.056"
   },
   {
+    "id": 16456,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "sl",
     "requestAt": "2023-02-14 09:50:01.883"
   },
   {
+    "id": 16456,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "sl",
     "requestAt": "2023-02-27 17:54:54.751"
   },
   {
+    "id": 17042,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-02-27 18:53:58.512"
   },
   {
+    "id": 12324,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":11},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":11},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":11}]",
     "state": "he",
     "requestAt": "2023-02-27 20:52:04.673"
   },
   {
+    "id": 16847,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-02-28 13:30:07.38"
   },
   {
+    "id": 17042,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-02-28 20:54:26.144"
   },
   {
+    "id": 12735,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":3},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":3},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":3}]",
     "state": "nw",
     "requestAt": "2023-03-01 17:04:26.16"
   },
   {
+    "id": 16900,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-03-01 21:33:59.748"
   },
   {
+    "id": 2934,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chinesisch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-03-02 14:49:15.623"
   },
   {
+    "id": 16673,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-03-02 17:09:08.322"
   },
   {
+    "id": 17042,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-03-03 20:44:16.125"
   },
   {
+    "id": 17042,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-03-03 20:44:16.125"
   },
   {
+    "id": 10398,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Latein\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2023-03-03 21:02:06.323"
   },
   {
+    "id": 13008,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-03-04 09:01:25.929"
   },
   {
+    "id": 16456,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "sl",
     "requestAt": "2023-03-08 16:11:25.503"
   },
   {
+    "id": 16456,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "sl",
     "requestAt": "2023-03-08 16:11:25.503"
   },
   {
+    "id": 17020,
     "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":8}]",
     "state": "other",
     "requestAt": "2023-03-09 09:20:03.74"
   },
   {
+    "id": 17041,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":12,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2023-03-09 09:30:12.505"
   },
   {
+    "id": 2506,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-03-09 13:42:19.912"
   },
   {
+    "id": 2506,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-03-09 13:42:19.912"
   },
   {
+    "id": 592,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "be",
     "requestAt": "2023-03-10 09:45:58.797"
   },
   {
+    "id": 592,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "be",
     "requestAt": "2023-03-10 09:45:58.797"
   },
   {
+    "id": 592,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "be",
     "requestAt": "2023-03-10 09:45:58.797"
   },
   {
+    "id": 592,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "be",
     "requestAt": "2023-03-10 09:45:58.797"
   },
   {
+    "id": 592,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "be",
     "requestAt": "2023-03-10 09:45:58.797"
   },
   {
+    "id": 9730,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-03-10 16:13:31.918"
   },
   {
+    "id": 16901,
     "subjects": "[{\"name\":\"Latein\",\"maxGrade\":11,\"minGrade\":5}]",
     "state": "ni",
     "requestAt": "2023-03-12 16:45:29.711"
   },
   {
+    "id": 16643,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":6},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":7,\"minGrade\":5}]",
     "state": "bw",
     "requestAt": "2023-03-12 20:52:37.433"
   },
   {
+    "id": 16621,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":9},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-03-13 17:31:42.902"
   },
   {
+    "id": 17122,
     "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "he",
     "requestAt": "2023-03-14 09:12:42.807"
   },
   {
+    "id": 17077,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-03-17 08:37:19.507"
   },
   {
+    "id": 17125,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":12,\"minGrade\":8}]",
     "state": "by",
     "requestAt": "2023-03-17 08:51:59.143"
   },
   {
+    "id": 17118,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "sh",
     "requestAt": "2023-03-17 09:24:44.574"
   },
   {
+    "id": 10827,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "by",
     "requestAt": "2023-03-17 10:37:44.518"
   },
   {
+    "id": 17127,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-03-17 11:07:09.452"
   },
   {
+    "id": 16877,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2023-03-20 07:29:29.665"
   },
   {
+    "id": 4076,
     "subjects": "[{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "he",
     "requestAt": "2023-03-20 11:48:00.051"
   },
   {
+    "id": 17142,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":4},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":4},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":9,\"minGrade\":4}]",
     "state": "other",
     "requestAt": "2023-03-21 08:41:48.976"
   },
   {
+    "id": 17129,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":4},{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":4},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-03-21 09:11:49.338"
   },
   {
+    "id": 17020,
     "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":8}]",
     "state": "other",
     "requestAt": "2023-03-22 14:28:11.41"
   },
   {
+    "id": 17041,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":12,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2023-03-22 14:29:11.553"
   },
   {
+    "id": 4920,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "he",
     "requestAt": "2023-03-23 07:19:43.514"
   },
   {
+    "id": 17132,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":4},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":2}]",
     "state": "sn",
     "requestAt": "2023-03-23 13:34:39.963"
   },
   {
+    "id": 17132,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":4},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":2}]",
     "state": "sn",
     "requestAt": "2023-03-23 13:34:39.963"
   },
   {
+    "id": 17140,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "be",
     "requestAt": "2023-03-23 14:53:48.063"
   },
   {
+    "id": 16502,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-03-23 18:59:24.994"
   },
   {
+    "id": 17118,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "sh",
     "requestAt": "2023-03-24 08:50:42.501"
   },
   {
+    "id": 17075,
     "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2023-03-24 09:06:42.402"
   },
   {
+    "id": 17147,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-03-24 09:48:51.269"
   },
   {
+    "id": 6818,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "he",
     "requestAt": "2023-03-24 11:22:00.485"
   },
   {
+    "id": 16399,
     "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "other",
     "requestAt": "2023-03-25 14:41:41.019"
   },
   {
+    "id": 5981,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "be",
     "requestAt": "2023-03-25 15:00:29.342"
   },
   {
+    "id": 16900,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-03-25 18:31:25.446"
   },
   {
+    "id": 16456,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "sl",
     "requestAt": "2023-03-26 16:42:42.896"
   },
   {
+    "id": 16456,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "sl",
     "requestAt": "2023-03-26 16:42:42.896"
   },
   {
+    "id": 17039,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-03-27 14:20:38.028"
   },
   {
+    "id": 329,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Italienisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-03-27 17:55:26.135"
   },
   {
+    "id": 17068,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-03-29 07:20:39.188"
   },
   {
+    "id": 17041,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":12,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2023-03-29 12:11:14.682"
   },
   {
+    "id": 17152,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-03-29 13:17:41.417"
   },
   {
+    "id": 17153,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-03-29 13:38:06.037"
   },
   {
+    "id": 17042,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-04-01 20:16:28.637"
   },
   {
+    "id": 17042,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-04-01 20:16:28.637"
   },
   {
+    "id": 11088,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "sn",
     "requestAt": "2023-04-03 13:44:34.322"
   },
   {
+    "id": 1995,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "mv",
     "requestAt": "2023-04-03 16:46:09.172"
   },
   {
+    "id": 14144,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "rp",
     "requestAt": "2023-04-04 15:07:14.34"
   },
   {
+    "id": 17125,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":12,\"minGrade\":8}]",
     "state": "by",
     "requestAt": "2023-04-05 11:04:33.785"
   },
   {
+    "id": 17159,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-04-05 13:15:02.624"
   },
   {
+    "id": 16876,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "be",
     "requestAt": "2023-04-07 13:51:40.157"
   },
   {
+    "id": 13488,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "he",
     "requestAt": "2023-04-09 15:38:02.655"
   },
   {
+    "id": 13488,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "he",
     "requestAt": "2023-04-09 15:38:02.655"
   },
   {
+    "id": 15857,
     "subjects": "[{\"name\":\"Russisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-04-09 16:27:25.369"
   },
   {
+    "id": 17052,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "be",
     "requestAt": "2023-04-12 16:28:26.223"
   },
   {
+    "id": 17029,
     "subjects": "[{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-04-13 15:15:47.621"
   },
   {
+    "id": 17176,
     "subjects": "[{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "by",
     "requestAt": "2023-04-16 07:59:04.31"
   },
   {
+    "id": 14013,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-04-16 16:42:54.182"
   },
   {
+    "id": 17180,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "he",
     "requestAt": "2023-04-18 19:45:38.9"
   },
   {
+    "id": 6908,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":11}]",
     "state": "be",
     "requestAt": "2023-04-19 13:36:28.988"
   },
   {
+    "id": 17170,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Altgriechisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1}]",
     "state": "be",
     "requestAt": "2023-04-19 14:19:34.975"
   },
   {
+    "id": 17169,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2023-04-19 14:44:18.746"
   },
   {
+    "id": 17020,
     "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":8}]",
     "state": "other",
     "requestAt": "2023-04-19 14:47:25.508"
   },
   {
+    "id": 17170,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Altgriechisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1}]",
     "state": "be",
     "requestAt": "2023-04-19 15:39:14.149"
   },
   {
+    "id": 1749,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Physik\",\"maxGrade\":12,\"minGrade\":8},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":8},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":8}]",
     "state": "hh",
     "requestAt": "2023-04-20 07:59:32.153"
   },
   {
+    "id": 16484,
     "subjects": "[{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "ni",
     "requestAt": "2023-04-20 08:04:05.25"
   },
   {
+    "id": 11901,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "rp",
     "requestAt": "2023-04-20 08:06:15.908"
   },
   {
+    "id": 16918,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":8}]",
     "state": "sl",
     "requestAt": "2023-04-20 08:08:32.399"
   },
   {
+    "id": 16931,
     "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":6}]",
     "state": "nw",
     "requestAt": "2023-04-20 08:09:30.847"
   },
   {
+    "id": 3561,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-04-20 08:10:15.919"
   },
   {
+    "id": 17205,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "bw",
     "requestAt": "2023-04-20 08:14:57.531"
   },
   {
+    "id": 17206,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":7},{\"name\":\"Geschichte\",\"maxGrade\":11,\"minGrade\":7},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-04-20 08:16:28.632"
   },
   {
+    "id": 17207,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-04-20 08:18:08.68"
   },
   {
+    "id": 17155,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-04-20 08:23:40.161"
   },
   {
+    "id": 17211,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2023-04-20 08:26:27.608"
   },
   {
+    "id": 530,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-04-20 10:04:13.546"
   },
   {
+    "id": 17195,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-04-20 11:00:41.769"
   },
   {
+    "id": 16405,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":4}]",
     "state": "nw",
     "requestAt": "2023-04-20 12:55:45.757"
   },
   {
+    "id": 17208,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-04-20 16:37:33.477"
   },
   {
+    "id": 17217,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":6}]",
     "state": "sh",
     "requestAt": "2023-04-20 16:43:48.679"
   },
   {
+    "id": 17188,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-04-21 08:09:41.184"
   },
   {
+    "id": 17204,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-04-21 08:40:20.154"
   },
   {
+    "id": 17189,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "bw",
     "requestAt": "2023-04-22 06:38:24.453"
   },
   {
+    "id": 17184,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-04-22 07:08:52.627"
   },
   {
+    "id": 17186,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "sl",
     "requestAt": "2023-04-22 08:01:37.021"
   },
   {
+    "id": 13930,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-04-24 09:22:58.55"
   },
   {
+    "id": 9237,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":3}]",
     "state": "nw",
     "requestAt": "2023-04-24 10:06:47.237"
   },
   {
+    "id": 17212,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-04-24 16:19:59.818"
   },
   {
+    "id": 17225,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":6}]",
     "state": "other",
     "requestAt": "2023-04-24 16:24:23.714"
   },
   {
+    "id": 8090,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":9}]",
     "state": "nw",
     "requestAt": "2023-04-27 04:22:48.791"
   },
   {
+    "id": 17227,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-04-27 13:42:49.442"
   },
   {
+    "id": 11374,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Italienisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-04-27 13:56:16.562"
   },
   {
+    "id": 11374,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Italienisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-04-27 13:56:16.562"
   },
   {
+    "id": 12307,
     "subjects": "[{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "nw",
     "requestAt": "2023-04-27 16:49:59.248"
   },
   {
+    "id": 10476,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Biologie\",\"maxGrade\":12,\"minGrade\":6},{\"name\":\"Informatik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2023-04-27 22:39:40.311"
   },
   {
+    "id": 17239,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-04-28 09:54:39.837"
   },
   {
+    "id": 17247,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "he",
     "requestAt": "2023-04-30 06:37:04.209"
   },
   {
+    "id": 934,
     "subjects": "[{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9}]",
     "state": "nw",
     "requestAt": "2023-04-30 08:22:41.708"
   },
   {
+    "id": 1565,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "hh",
     "requestAt": "2023-05-03 08:15:20.844"
   },
   {
+    "id": 17208,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-05-03 10:04:27.492"
   },
   {
+    "id": 14350,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "th",
     "requestAt": "2023-05-03 14:22:17.039"
   },
   {
+    "id": 17254,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-05-04 07:36:51.356"
   },
   {
+    "id": 2502,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1}]",
     "state": "ni",
     "requestAt": "2023-05-05 07:47:39.542"
   },
   {
+    "id": 17253,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":6}]",
     "state": "other",
     "requestAt": "2023-05-05 08:26:47.562"
   },
   {
+    "id": 17259,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-05-05 09:58:52.047"
   },
   {
+    "id": 17230,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "by",
     "requestAt": "2023-05-05 09:59:39.798"
   },
   {
+    "id": 15938,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-05-05 15:44:22.98"
   },
   {
+    "id": 17185,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "by",
     "requestAt": "2023-05-06 08:22:53.03"
   },
   {
+    "id": 16554,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":9}]",
     "state": "mv",
     "requestAt": "2023-05-06 15:15:11.675"
   },
   {
+    "id": 17262,
     "subjects": "[{\"name\":\"Altgriechisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2023-05-07 07:26:20.169"
   },
   {
+    "id": 17133,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":3},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":3}]",
     "state": "nw",
     "requestAt": "2023-05-08 18:49:42.209"
   },
   {
+    "id": 13930,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-05-09 06:29:45.331"
   },
   {
+    "id": 17219,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-05-09 12:13:51.691"
   },
   {
+    "id": 17219,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-05-09 12:13:51.691"
   },
   {
+    "id": 17219,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-05-09 12:13:51.691"
   },
   {
+    "id": 17219,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-05-09 12:13:51.691"
   },
   {
+    "id": 17219,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-05-09 12:13:51.691"
   },
   {
+    "id": 17220,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-05-09 12:13:54.171"
   },
   {
+    "id": 17220,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-05-09 12:13:54.171"
   },
   {
+    "id": 17220,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-05-09 12:13:54.171"
   },
   {
+    "id": 17220,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-05-09 12:13:54.171"
   },
   {
+    "id": 17220,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-05-09 12:13:54.171"
   },
   {
+    "id": 17063,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-05-09 14:35:12.697"
   },
   {
+    "id": 17206,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":7},{\"name\":\"Geschichte\",\"maxGrade\":11,\"minGrade\":7},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-05-10 08:21:25.611"
   },
   {
+    "id": 16602,
     "subjects": "[{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":13},{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":13},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":13}]",
     "state": "by",
     "requestAt": "2023-05-10 11:21:38.408"
   },
   {
+    "id": 1565,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "hh",
     "requestAt": "2023-05-10 11:59:34.461"
   },
   {
+    "id": 17235,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2023-05-10 14:17:26.451"
   },
   {
+    "id": 17132,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":4},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":2}]",
     "state": "sn",
     "requestAt": "2023-05-10 15:15:50.13"
   },
   {
+    "id": 17129,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":4},{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":4},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-05-11 09:17:43.894"
   },
   {
+    "id": 16405,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":4}]",
     "state": "nw",
     "requestAt": "2023-05-11 12:01:32.168"
   },
   {
+    "id": 17256,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":11,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2023-05-11 14:12:45.784"
   },
   {
+    "id": 12556,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":8,\"minGrade\":1}]",
     "state": "ni",
     "requestAt": "2023-05-11 18:32:58.649"
   },
   {
+    "id": 17273,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-05-13 15:06:47.209"
   },
   {
+    "id": 1818,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":2,\"minGrade\":1}]",
     "state": "be",
     "requestAt": "2023-05-13 15:21:22.753"
   },
   {
+    "id": 17154,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "ni",
     "requestAt": "2023-05-14 08:24:39.353"
   },
   {
+    "id": 17246,
     "subjects": "[{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":3},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":3},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":3}]",
     "state": "nw",
     "requestAt": "2023-05-14 21:39:45.985"
   },
   {
+    "id": 17246,
     "subjects": "[{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":3},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":3},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":3}]",
     "state": "nw",
     "requestAt": "2023-05-14 21:39:45.985"
   },
   {
+    "id": 17246,
     "subjects": "[{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":3},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":3},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":3}]",
     "state": "nw",
     "requestAt": "2023-05-14 21:39:45.985"
   },
   {
+    "id": 9075,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "be",
     "requestAt": "2023-05-15 01:04:54.616"
   },
   {
+    "id": 17180,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "he",
     "requestAt": "2023-05-15 18:07:43.394"
   },
   {
+    "id": 17154,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "ni",
     "requestAt": "2023-05-17 09:40:44.738"
   },
   {
+    "id": 17320,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-05-17 13:42:12.812"
   },
   {
+    "id": 17277,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2023-05-17 14:28:05.097"
   },
   {
+    "id": 17277,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2023-05-17 14:28:05.097"
   },
   {
+    "id": 17255,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "bw",
     "requestAt": "2023-05-17 14:43:17.08"
   },
   {
+    "id": 17329,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Chinesisch\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":11,\"minGrade\":5}]",
     "state": "he",
     "requestAt": "2023-05-18 14:52:05.216"
   },
   {
+    "id": 5753,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9}]",
     "state": "sn",
     "requestAt": "2023-05-18 22:09:06.165"
   },
   {
+    "id": 5753,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9}]",
     "state": "sn",
     "requestAt": "2023-05-18 22:09:06.165"
   },
   {
+    "id": 5753,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9}]",
     "state": "sn",
     "requestAt": "2023-05-18 22:09:06.165"
   },
   {
+    "id": 17191,
     "subjects": "[{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2023-05-19 15:58:36.415"
   },
   {
+    "id": 17333,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-05-21 08:07:25.827"
   },
   {
+    "id": 17147,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-05-21 08:28:53.299"
   },
   {
+    "id": 17335,
     "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":7,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":7,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":7,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-05-21 17:12:23.661"
   },
   {
+    "id": 16456,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "sl",
     "requestAt": "2023-05-25 07:49:55.421"
   },
   {
+    "id": 17125,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":12,\"minGrade\":8}]",
     "state": "by",
     "requestAt": "2023-05-26 16:43:51.803"
   },
   {
+    "id": 16564,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8}]",
     "state": "be",
     "requestAt": "2023-05-27 07:17:08.437"
   },
   {
+    "id": 17176,
     "subjects": "[{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "by",
     "requestAt": "2023-05-28 10:34:42.153"
   },
   {
+    "id": 17132,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":4},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":2}]",
     "state": "sn",
     "requestAt": "2023-05-29 17:49:47.985"
   },
   {
+    "id": 17133,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":3},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":3}]",
     "state": "nw",
     "requestAt": "2023-05-30 08:27:00.673"
   },
   {
+    "id": 16405,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":4}]",
     "state": "nw",
     "requestAt": "2023-05-30 13:19:53.334"
   },
   {
+    "id": 16456,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "sl",
     "requestAt": "2023-05-30 21:05:14.462"
   },
   {
+    "id": 12307,
     "subjects": "[{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "nw",
     "requestAt": "2023-06-01 11:47:14.367"
   },
   {
+    "id": 17352,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":2,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-06-01 14:49:38.063"
   },
   {
+    "id": 17352,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":2,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-06-01 14:49:38.063"
   },
   {
+    "id": 17352,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":2,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-06-01 14:49:38.063"
   },
   {
+    "id": 2398,
     "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":8}]",
     "state": "nw",
     "requestAt": "2023-06-04 20:44:45.575"
   },
   {
+    "id": 16456,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "sl",
     "requestAt": "2023-06-04 21:03:08.263"
   },
   {
+    "id": 17215,
     "subjects": "[{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Französisch\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Latein\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Niederländisch\",\"maxGrade\":11,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2023-06-05 09:08:57.265"
   },
   {
+    "id": 17346,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2023-06-05 18:11:52.087"
   },
   {
+    "id": 17354,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-06-05 18:48:53.266"
   },
   {
+    "id": 17357,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-06-08 07:40:43.577"
   },
   {
+    "id": 17345,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "other",
     "requestAt": "2023-06-08 10:20:12.331"
   },
   {
+    "id": 9320,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "he",
     "requestAt": "2023-06-09 21:47:41.456"
   },
   {
+    "id": 9320,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "he",
     "requestAt": "2023-06-09 21:47:41.456"
   },
   {
+    "id": 5753,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9}]",
     "state": "sn",
     "requestAt": "2023-06-10 22:58:02.433"
   },
   {
+    "id": 5753,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9}]",
     "state": "sn",
     "requestAt": "2023-06-10 22:58:02.433"
   },
   {
+    "id": 5753,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9}]",
     "state": "sn",
     "requestAt": "2023-06-10 22:58:02.433"
   },
   {
+    "id": 17362,
     "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":9,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2023-06-11 17:14:04.053"
   },
   {
+    "id": 7459,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "be",
     "requestAt": "2023-06-15 07:15:16.725"
   },
   {
+    "id": 17369,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "bw",
     "requestAt": "2023-06-15 08:48:20.118"
   },
   {
+    "id": 15938,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-06-15 12:00:06.748"
   },
   {
+    "id": 17362,
     "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":9,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2023-06-17 20:46:24.542"
   },
   {
+    "id": 17365,
     "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "ni",
     "requestAt": "2023-06-19 18:07:39.189"
   },
   {
+    "id": 17370,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-06-19 18:44:48.451"
   },
   {
+    "id": 17353,
     "subjects": "[{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "sn",
     "requestAt": "2023-06-19 19:12:09.848"
   },
   {
+    "id": 17372,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "ni",
     "requestAt": "2023-06-21 19:29:13.835"
   },
   {
+    "id": 17326,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-06-22 14:08:14.76"
   },
   {
+    "id": 17377,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-06-24 07:16:59.444"
   },
   {
+    "id": 17375,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-06-24 15:05:20.039"
   },
   {
+    "id": 12628,
     "subjects": "[{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-06-26 12:03:42.822"
   },
   {
+    "id": 17383,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-06-27 07:27:54.386"
   },
   {
+    "id": 12556,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":8,\"minGrade\":1}]",
     "state": "ni",
     "requestAt": "2023-06-27 08:02:23.537"
   },
   {
+    "id": 17384,
     "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-06-27 08:09:03.754"
   },
   {
+    "id": 12324,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":11},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":11},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":11}]",
     "state": "he",
     "requestAt": "2023-06-27 08:14:37.554"
   },
   {
+    "id": 12324,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":11},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":11},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":11}]",
     "state": "he",
     "requestAt": "2023-06-27 08:14:37.554"
   },
   {
+    "id": 17368,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-06-27 08:39:39.596"
   },
   {
+    "id": 17368,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-06-27 08:39:39.596"
   },
   {
+    "id": 17373,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-06-27 09:15:33.668"
   },
   {
+    "id": 17382,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-06-27 09:36:31.86"
   },
   {
+    "id": 17379,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Russisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "sn",
     "requestAt": "2023-06-27 10:56:13.232"
   },
   {
+    "id": 16068,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-06-27 16:45:24.542"
   },
   {
+    "id": 17352,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":2,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-06-27 21:25:56.509"
   },
   {
+    "id": 17352,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":2,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-06-27 21:25:56.509"
   },
   {
+    "id": 17394,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-07-01 15:16:31.326"
   },
   {
+    "id": 17396,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-07-02 09:37:39.906"
   },
   {
+    "id": 16644,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "nw",
     "requestAt": "2023-07-02 11:09:31.872"
   },
   {
+    "id": 14767,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Französisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "be",
     "requestAt": "2023-07-02 17:10:40.39"
   },
   {
+    "id": 13752,
     "subjects": "[{\"name\":\"Latein\",\"maxGrade\":6,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "ni",
     "requestAt": "2023-07-02 17:52:39.863"
   },
   {
+    "id": 3577,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2023-07-03 09:06:54.522"
   },
   {
+    "id": 17277,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2023-07-03 15:15:33.768"
   },
   {
+    "id": 17392,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":4}]",
     "state": "ni",
     "requestAt": "2023-07-04 07:13:39.384"
   },
   {
+    "id": 17389,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-07-04 09:25:53.689"
   },
   {
+    "id": 14350,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "th",
     "requestAt": "2023-07-04 16:11:54.309"
   },
   {
+    "id": 17393,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":12,\"minGrade\":8}]",
     "state": "other",
     "requestAt": "2023-07-04 20:10:36.715"
   },
   {
+    "id": 8180,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-07-05 06:28:45.455"
   },
   {
+    "id": 17390,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-07-06 07:08:27.565"
   },
   {
+    "id": 17401,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-07-06 09:57:12.572"
   },
   {
+    "id": 4092,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-07-07 10:44:52.247"
   },
   {
+    "id": 10476,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Biologie\",\"maxGrade\":12,\"minGrade\":6},{\"name\":\"Informatik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2023-07-08 10:03:01.919"
   },
   {
+    "id": 17399,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":4}]",
     "state": "ni",
     "requestAt": "2023-07-09 09:33:14.458"
   },
   {
+    "id": 17398,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-07-09 09:57:02.918"
   },
   {
+    "id": 17412,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "mv",
     "requestAt": "2023-07-09 11:11:16.737"
   },
   {
+    "id": 15323,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":6},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bb",
     "requestAt": "2023-07-10 12:02:43.58"
   },
   {
+    "id": 17352,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":2,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-07-10 13:04:16.962"
   },
   {
+    "id": 16499,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-07-10 14:00:23.208"
   },
   {
+    "id": 17413,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":7}]",
     "state": "be",
     "requestAt": "2023-07-11 19:00:03.526"
   },
   {
+    "id": 17387,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-07-13 15:57:20.909"
   },
   {
+    "id": 17416,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-07-14 08:24:27.235"
   },
   {
+    "id": 17409,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "be",
     "requestAt": "2023-07-14 09:14:55.37"
   },
   {
+    "id": 17419,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-07-16 08:10:46.913"
   },
   {
+    "id": 17406,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-07-16 09:12:39.569"
   },
   {
+    "id": 17407,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-07-16 09:52:24.209"
   },
   {
+    "id": 4092,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-07-18 10:43:48.569"
   },
   {
+    "id": 17398,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-07-19 04:51:37.841"
   },
   {
+    "id": 17427,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "rp",
     "requestAt": "2023-07-20 07:46:39.935"
   },
   {
+    "id": 17386,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "ni",
     "requestAt": "2023-07-23 15:13:49.666"
   },
   {
+    "id": 17430,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-07-24 08:49:37.467"
   },
   {
+    "id": 17392,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":4}]",
     "state": "ni",
     "requestAt": "2023-07-24 20:07:49.812"
   },
   {
+    "id": 17398,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-07-26 05:14:40.654"
   },
   {
+    "id": 17435,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2023-07-26 13:41:33.922"
   },
   {
+    "id": 17437,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2023-07-26 14:17:00.665"
   },
   {
+    "id": 17426,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-07-27 07:15:30.553"
   },
   {
+    "id": 17440,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-07-27 15:22:35.325"
   },
   {
+    "id": 345,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "rp",
     "requestAt": "2023-07-28 13:11:27.536"
   },
   {
+    "id": 17372,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "ni",
     "requestAt": "2023-07-29 14:17:57.823"
   },
   {
+    "id": 17443,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9}]",
     "state": "other",
     "requestAt": "2023-07-30 08:09:06.35"
   },
   {
+    "id": 17477,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":6}]",
     "state": "hh",
     "requestAt": "2023-07-30 09:54:29.287"
   },
   {
+    "id": 17436,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Französisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2023-07-31 18:26:00.606"
   },
   {
+    "id": 17479,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "bw",
     "requestAt": "2023-08-02 13:18:12.401"
   },
   {
+    "id": 17431,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":3,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-08-02 14:21:18.407"
   },
   {
+    "id": 17430,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-08-04 09:39:47.825"
   },
   {
+    "id": 17340,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "be",
     "requestAt": "2023-08-08 14:00:12.583"
   },
   {
+    "id": 17431,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":3,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-08-09 11:32:19.217"
   },
   {
+    "id": 17488,
     "subjects": "[{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "he",
     "requestAt": "2023-08-09 14:35:44.396"
   },
   {
+    "id": 11113,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "he",
     "requestAt": "2023-08-10 07:58:51.645"
   },
   {
+    "id": 17505,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2023-08-12 17:41:31.077"
   },
   {
+    "id": 17500,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-08-13 08:40:23.767"
   },
   {
+    "id": 17498,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-08-13 09:13:47.799"
   },
   {
+    "id": 17497,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "be",
     "requestAt": "2023-08-13 13:11:36.797"
   },
   {
+    "id": 17508,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":11},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":11}]",
     "state": "rp",
     "requestAt": "2023-08-13 16:44:57.175"
   },
   {
+    "id": 17499,
     "subjects": "[{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "nw",
     "requestAt": "2023-08-14 08:28:45.792"
   },
   {
+    "id": 1721,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "by",
     "requestAt": "2023-08-14 19:41:27.536"
   },
   {
+    "id": 15560,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-08-15 06:27:01.004"
   },
   {
+    "id": 8974,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-08-15 11:38:00.25"
   },
   {
+    "id": 3577,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2023-08-16 09:03:52.072"
   },
   {
+    "id": 17495,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-08-16 13:17:40.369"
   },
   {
+    "id": 17492,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-08-16 14:58:08.879"
   },
   {
+    "id": 17362,
     "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":9,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2023-08-18 22:58:22.728"
   },
   {
+    "id": 17509,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "sn",
     "requestAt": "2023-08-19 13:44:27.051"
   },
   {
+    "id": 17479,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "bw",
     "requestAt": "2023-08-21 09:26:48.16"
   },
   {
+    "id": 16399,
     "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "other",
     "requestAt": "2023-08-21 20:08:29.402"
   },
   {
+    "id": 17379,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Russisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "sn",
     "requestAt": "2023-08-22 12:20:45.489"
   },
   {
+    "id": 17436,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Französisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2023-08-22 17:06:05.614"
   },
   {
+    "id": 11480,
     "subjects": "[{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-08-22 21:15:09.873"
   },
   {
+    "id": 17499,
     "subjects": "[{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "nw",
     "requestAt": "2023-08-23 15:09:12.983"
   },
   {
+    "id": 15017,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-08-25 17:28:07.098"
   },
   {
+    "id": 15264,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-08-26 12:31:57.098"
   },
   {
+    "id": 7190,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "th",
     "requestAt": "2023-08-26 15:31:32.789"
   },
   {
+    "id": 17516,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "rp",
     "requestAt": "2023-08-27 08:07:50.94"
   },
   {
+    "id": 17477,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":6}]",
     "state": "hh",
     "requestAt": "2023-08-27 16:47:58.153"
   },
   {
+    "id": 17517,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2023-08-27 19:32:14.227"
   },
   {
+    "id": 17517,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2023-08-27 19:32:14.227"
   },
   {
+    "id": 17133,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":3},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":3}]",
     "state": "nw",
     "requestAt": "2023-08-28 10:14:52.866"
   },
   {
+    "id": 16758,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-08-29 13:27:50.457"
   },
   {
+    "id": 16758,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-08-29 13:27:50.457"
   },
   {
+    "id": 17424,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "ni",
     "requestAt": "2023-08-29 14:44:55.605"
   },
   {
+    "id": 17481,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "sn",
     "requestAt": "2023-08-29 18:08:36.621"
   },
   {
+    "id": 17515,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-08-29 18:47:15.732"
   },
   {
+    "id": 17519,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-08-30 13:13:33.484"
   },
   {
+    "id": 17522,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "ni",
     "requestAt": "2023-08-31 14:39:40.886"
   },
   {
+    "id": 17329,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Chinesisch\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":11,\"minGrade\":5}]",
     "state": "he",
     "requestAt": "2023-09-01 15:56:30.661"
   },
   {
+    "id": 17422,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":3},{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":3},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":6}]",
     "state": "he",
     "requestAt": "2023-09-01 19:03:53.062"
   },
   {
+    "id": 17390,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-09-02 21:11:24.179"
   },
   {
+    "id": 17529,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-09-04 08:29:07.815"
   },
   {
+    "id": 17533,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "ni",
     "requestAt": "2023-09-04 09:10:58.03"
   },
   {
+    "id": 592,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "be",
     "requestAt": "2023-09-04 14:31:38.258"
   },
   {
+    "id": 592,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "be",
     "requestAt": "2023-09-04 14:31:38.258"
   },
   {
+    "id": 16276,
     "subjects": "[{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":6}]",
     "state": "nw",
     "requestAt": "2023-09-06 15:46:00.8"
   },
   {
+    "id": 17539,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-09-06 19:12:19.368"
   },
   {
+    "id": 17486,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":8}]",
     "state": "nw",
     "requestAt": "2023-09-07 08:05:30.364"
   },
   {
+    "id": 17399,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":4}]",
     "state": "ni",
     "requestAt": "2023-09-08 13:24:41.878"
   },
   {
+    "id": 17399,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":4}]",
     "state": "ni",
     "requestAt": "2023-09-08 13:24:41.878"
   },
   {
+    "id": 2494,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "nw",
     "requestAt": "2023-09-09 21:42:59.288"
   },
   {
+    "id": 17540,
     "subjects": "[{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":11}]",
     "state": "be",
     "requestAt": "2023-09-10 08:38:16.224"
   },
   {
+    "id": 17542,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "hh",
     "requestAt": "2023-09-10 09:37:54.489"
   },
   {
+    "id": 17431,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":3,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-09-10 15:54:19.984"
   },
   {
+    "id": 17486,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":8}]",
     "state": "nw",
     "requestAt": "2023-09-11 11:11:08.209"
   },
   {
+    "id": 16870,
     "subjects": "[{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-09-11 12:14:35.217"
   },
   {
+    "id": 5003,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":8}]",
     "state": "nw",
     "requestAt": "2023-09-11 15:16:54.117"
   },
   {
+    "id": 1548,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":9}]",
     "state": "bw",
     "requestAt": "2023-09-11 20:02:49.744"
   },
   {
+    "id": 17499,
     "subjects": "[{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "nw",
     "requestAt": "2023-09-11 20:19:32.254"
   },
   {
+    "id": 17172,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "sn",
     "requestAt": "2023-09-11 21:07:31.051"
   },
   {
+    "id": 2494,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "nw",
     "requestAt": "2023-09-11 21:10:19.391"
   },
   {
+    "id": 16456,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "sl",
     "requestAt": "2023-09-13 06:46:03.088"
   },
   {
+    "id": 17543,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "he",
     "requestAt": "2023-09-13 13:49:51.567"
   },
   {
+    "id": 17549,
     "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-09-14 09:41:14.762"
   },
   {
+    "id": 17551,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-09-14 10:18:08.289"
   },
   {
+    "id": 17550,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2023-09-14 10:40:37.1"
   },
   {
+    "id": 5003,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":8}]",
     "state": "nw",
     "requestAt": "2023-09-14 11:17:53.478"
   },
   {
+    "id": 17546,
     "subjects": "[{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-09-15 08:25:34.76"
   },
   {
+    "id": 17543,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "he",
     "requestAt": "2023-09-15 13:54:14.388"
   },
   {
+    "id": 17398,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-09-15 16:49:06.23"
   },
   {
+    "id": 17563,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-09-16 10:21:22.505"
   },
   {
+    "id": 17565,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":6}]",
     "state": "nw",
     "requestAt": "2023-09-16 11:54:39.592"
   },
   {
+    "id": 17568,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-09-16 11:55:53.383"
   },
   {
+    "id": 17567,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-09-16 11:56:54.882"
   },
   {
+    "id": 17569,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":2},{\"name\":\"Mathematik\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":3}]",
     "state": "nw",
     "requestAt": "2023-09-16 12:01:58.973"
   },
   {
+    "id": 17570,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":3}]",
     "state": "nw",
     "requestAt": "2023-09-16 12:02:03.069"
   },
   {
+    "id": 17571,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-09-16 12:16:54.157"
   },
   {
+    "id": 17562,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":11}]",
     "state": "ni",
     "requestAt": "2023-09-16 14:19:10.939"
   },
   {
+    "id": 2385,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Italienisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-09-17 07:38:40.807"
   },
   {
+    "id": 10072,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2023-09-17 08:03:23.779"
   },
   {
+    "id": 17573,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Informatik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-09-17 13:42:28.454"
   },
   {
+    "id": 17541,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "sn",
     "requestAt": "2023-09-18 13:30:16.245"
   },
   {
+    "id": 4764,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2023-09-18 14:11:28.369"
   },
   {
+    "id": 17561,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-09-18 18:45:24.59"
   },
   {
+    "id": 17552,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":8,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-09-18 18:48:26.696"
   },
   {
+    "id": 6012,
     "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":6}]",
     "state": "mv",
     "requestAt": "2023-09-19 12:36:29.591"
   },
   {
+    "id": 16456,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "sl",
     "requestAt": "2023-09-19 12:58:17.665"
   },
   {
+    "id": 17556,
     "subjects": "[{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-09-20 14:17:36.957"
   },
   {
+    "id": 17560,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-09-21 06:12:28.604"
   },
   {
+    "id": 16930,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-09-21 07:42:26.462"
   },
   {
+    "id": 17583,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":4},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":4},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":4}]",
     "state": "other",
     "requestAt": "2023-09-21 10:10:15.49"
   },
   {
+    "id": 17407,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-09-21 23:11:07.254"
   },
   {
+    "id": 17572,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "ni",
     "requestAt": "2023-09-23 08:46:45.477"
   },
   {
+    "id": 17559,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bb",
     "requestAt": "2023-09-23 14:41:07.501"
   },
   {
+    "id": 17549,
     "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-09-25 08:40:13.655"
   },
   {
+    "id": 17546,
     "subjects": "[{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-09-27 15:10:41.811"
   },
   {
+    "id": 17573,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Informatik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-09-27 19:30:46.31"
   },
   {
+    "id": 17573,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Informatik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-09-27 19:30:46.31"
   },
   {
+    "id": 17573,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Informatik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-09-27 19:30:46.31"
   },
   {
+    "id": 17241,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-09-27 19:53:24.589"
   },
   {
+    "id": 16877,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2023-09-28 14:08:40.61"
   },
   {
+    "id": 17571,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-09-28 15:57:14.55"
   },
   {
+    "id": 17559,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bb",
     "requestAt": "2023-09-28 19:13:44.083"
   },
   {
+    "id": 17595,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-10-01 14:38:03.291"
   },
   {
+    "id": 17140,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "be",
     "requestAt": "2023-10-02 12:51:33.164"
   },
   {
+    "id": 13808,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "ni",
     "requestAt": "2023-10-02 15:45:57.628"
   },
   {
+    "id": 2194,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "he",
     "requestAt": "2023-10-02 18:54:06.429"
   },
   {
+    "id": 2194,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "he",
     "requestAt": "2023-10-02 18:54:06.429"
   },
   {
+    "id": 2194,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "he",
     "requestAt": "2023-10-02 18:54:06.429"
   },
   {
+    "id": 17589,
     "subjects": "[{\"name\":\"Chinesisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-10-03 07:41:20.47"
   },
   {
+    "id": 16276,
     "subjects": "[{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":6}]",
     "state": "nw",
     "requestAt": "2023-10-04 20:34:22.226"
   },
   {
+    "id": 17610,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":8,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-10-05 09:01:21.814"
   },
   {
+    "id": 17619,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":6}]",
     "state": "he",
     "requestAt": "2023-10-05 15:55:49.88"
   },
   {
+    "id": 17601,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":9}]",
     "state": "sn",
     "requestAt": "2023-10-05 16:16:04.828"
   },
   {
+    "id": 12628,
     "subjects": "[{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-10-06 13:57:08.973"
   },
   {
+    "id": 17590,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "be",
     "requestAt": "2023-10-06 14:10:29.81"
   },
   {
+    "id": 17577,
     "subjects": "[{\"name\":\"Politik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Italienisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-10-09 17:06:27.685"
   },
   {
+    "id": 17576,
     "subjects": "[{\"name\":\"Politik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Italienisch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":8,\"minGrade\":1}]",
     "state": "he",
     "requestAt": "2023-10-09 17:06:54.709"
   },
   {
+    "id": 17631,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-10-10 17:17:09.259"
   },
   {
+    "id": 592,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "be",
     "requestAt": "2023-10-11 08:36:00.394"
   },
   {
+    "id": 592,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "be",
     "requestAt": "2023-10-11 08:36:00.394"
   },
   {
+    "id": 592,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "be",
     "requestAt": "2023-10-11 08:36:00.394"
   },
   {
+    "id": 592,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "be",
     "requestAt": "2023-10-11 08:36:00.394"
   },
   {
+    "id": 592,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "be",
     "requestAt": "2023-10-11 08:36:00.394"
   },
   {
+    "id": 17492,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-10-12 06:26:27.018"
   },
   {
+    "id": 17575,
     "subjects": "[{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "nw",
     "requestAt": "2023-10-12 07:30:50.345"
   },
   {
+    "id": 17638,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "he",
     "requestAt": "2023-10-12 08:18:26.281"
   },
   {
+    "id": 17611,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-10-12 09:53:19.153"
   },
   {
+    "id": 17396,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-10-12 15:48:20.679"
   },
   {
+    "id": 17604,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-10-13 08:46:37.624"
   },
   {
+    "id": 13953,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Altgriechisch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2023-10-13 19:51:02.901"
   },
   {
+    "id": 11052,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-10-15 15:05:22.492"
   },
   {
+    "id": 17686,
     "subjects": "[{\"name\":\"Kunst\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1}]",
     "state": "be",
     "requestAt": "2023-10-15 17:44:17.652"
   },
   {
+    "id": 17686,
     "subjects": "[{\"name\":\"Kunst\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1}]",
     "state": "be",
     "requestAt": "2023-10-15 17:44:17.652"
   },
   {
+    "id": 17640,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-10-16 09:45:03.021"
   },
   {
+    "id": 16456,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "sl",
     "requestAt": "2023-10-16 13:55:38.913"
   },
   {
+    "id": 17628,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":9,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2023-10-16 16:02:26.461"
   },
   {
+    "id": 17680,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Russisch\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2023-10-16 16:33:39.6"
   },
   {
+    "id": 17682,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "sh",
     "requestAt": "2023-10-16 20:16:33.237"
   },
   {
+    "id": 3577,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2023-10-17 11:29:41.174"
   },
   {
+    "id": 17613,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-10-17 23:32:24.287"
   },
   {
+    "id": 17635,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-10-18 07:12:03.795"
   },
   {
+    "id": 17647,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-10-18 07:39:45.351"
   },
   {
+    "id": 17694,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "ni",
     "requestAt": "2023-10-18 09:12:35.817"
   },
   {
+    "id": 17696,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-10-18 13:21:21.541"
   },
   {
+    "id": 17631,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-10-18 14:03:24.115"
   },
   {
+    "id": 17699,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-10-20 17:09:13.12"
   },
   {
+    "id": 17699,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-10-20 17:09:13.12"
   },
   {
+    "id": 17577,
     "subjects": "[{\"name\":\"Politik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Italienisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-10-22 14:58:19.483"
   },
   {
+    "id": 13008,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-10-23 17:22:43.446"
   },
   {
+    "id": 16877,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2023-10-24 06:27:38.631"
   },
   {
+    "id": 17709,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-10-24 07:08:00.917"
   },
   {
+    "id": 17704,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":5}]",
     "state": "sn",
     "requestAt": "2023-10-25 09:40:39.251"
   },
   {
+    "id": 17481,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "sn",
     "requestAt": "2023-10-25 11:41:53.219"
   },
   {
+    "id": 17067,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "sn",
     "requestAt": "2023-10-25 13:03:27.042"
   },
   {
+    "id": 17690,
     "subjects": "[{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-10-25 13:13:45.329"
   },
   {
+    "id": 17619,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":6}]",
     "state": "he",
     "requestAt": "2023-10-25 17:03:14.533"
   },
   {
+    "id": 9795,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "bw",
     "requestAt": "2023-10-25 17:54:13.632"
   },
   {
+    "id": 17523,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-10-26 08:28:54.17"
   },
   {
+    "id": 17431,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":3,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-10-26 10:54:43.251"
   },
   {
+    "id": 17725,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-10-27 07:40:23.018"
   },
   {
+    "id": 17688,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-10-28 11:18:35.988"
   },
   {
+    "id": 17185,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "by",
     "requestAt": "2023-10-28 17:06:49.479"
   },
   {
+    "id": 17739,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-10-29 14:47:52.449"
   },
   {
+    "id": 17741,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "sl",
     "requestAt": "2023-10-29 15:09:13.602"
   },
   {
+    "id": 17741,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "sl",
     "requestAt": "2023-10-29 15:09:13.602"
   },
   {
+    "id": 17741,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "sl",
     "requestAt": "2023-10-29 15:09:13.602"
   },
   {
+    "id": 17740,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-10-29 15:44:33.43"
   },
   {
+    "id": 17720,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-10-30 12:35:29.811"
   },
   {
+    "id": 17627,
     "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":6},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":3},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":11},{\"name\":\"Italienisch\",\"maxGrade\":12,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-10-31 08:36:44.915"
   },
   {
+    "id": 17584,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":7}]",
     "state": "nw",
     "requestAt": "2023-10-31 09:04:13.158"
   },
   {
+    "id": 17572,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "ni",
     "requestAt": "2023-10-31 16:40:19.421"
   },
   {
+    "id": 17749,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "st",
     "requestAt": "2023-11-01 09:12:16.555"
   },
   {
+    "id": 17747,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "bw",
     "requestAt": "2023-11-01 09:41:04.551"
   },
   {
+    "id": 17743,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-11-02 09:26:26.404"
   },
   {
+    "id": 17751,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-11-03 08:15:05.306"
   },
   {
+    "id": 17729,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2023-11-03 09:49:25.939"
   },
   {
+    "id": 6649,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "rp",
     "requestAt": "2023-11-03 15:27:53.258"
   },
   {
+    "id": 16181,
     "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-11-03 15:46:12.55"
   },
   {
+    "id": 10913,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "bw",
     "requestAt": "2023-11-03 16:13:24.06"
   },
   {
+    "id": 17757,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-03 21:49:54.878"
   },
   {
+    "id": 17757,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-03 21:49:54.878"
   },
   {
+    "id": 17608,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":8}]",
     "state": "nw",
     "requestAt": "2023-11-04 07:15:30.318"
   },
   {
+    "id": 17767,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":2,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-04 07:22:03.068"
   },
   {
+    "id": 17763,
     "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-04 08:11:55.017"
   },
   {
+    "id": 17759,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":4}]",
     "state": "by",
     "requestAt": "2023-11-04 08:34:04.813"
   },
   {
+    "id": 17192,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2023-11-04 09:15:17.528"
   },
   {
+    "id": 17760,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-04 09:36:27.49"
   },
   {
+    "id": 17771,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-04 09:48:59.895"
   },
   {
+    "id": 17607,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-11-04 10:18:52.255"
   },
   {
+    "id": 17768,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":3,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Pädagogik\",\"maxGrade\":10,\"minGrade\":8},{\"name\":\"Erdkunde\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":5,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-04 10:26:37.041"
   },
   {
+    "id": 17769,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-04 10:51:29.775"
   },
   {
+    "id": 17683,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2023-11-04 11:56:59.346"
   },
   {
+    "id": 17766,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-04 12:12:40.809"
   },
   {
+    "id": 17609,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":8,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-11-04 12:14:00.286"
   },
   {
+    "id": 17764,
     "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":2,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-04 13:05:36.469"
   },
   {
+    "id": 17762,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-04 22:03:55.448"
   },
   {
+    "id": 17567,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-05 09:40:10.832"
   },
   {
+    "id": 17776,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2023-11-05 13:49:27.705"
   },
   {
+    "id": 17778,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-05 14:24:47.613"
   },
   {
+    "id": 17773,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-05 17:07:12.318"
   },
   {
+    "id": 17765,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":12,\"minGrade\":6},{\"name\":\"Religion\",\"maxGrade\":12,\"minGrade\":6}]",
     "state": "by",
     "requestAt": "2023-11-05 18:08:41.937"
   },
   {
+    "id": 17772,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-05 19:03:04.215"
   },
   {
+    "id": 17774,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2023-11-05 22:39:21.555"
   },
   {
+    "id": 17780,
     "subjects": "[{\"name\":\"Religion\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-06 09:05:54.095"
   },
   {
+    "id": 17711,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "be",
     "requestAt": "2023-11-06 14:41:27.442"
   },
   {
+    "id": 17777,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Sachkunde\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-06 18:16:51.816"
   },
   {
+    "id": 15908,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-06 19:27:26.367"
   },
   {
+    "id": 17758,
     "subjects": "[{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-07 08:13:56.969"
   },
   {
+    "id": 5473,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "by",
     "requestAt": "2023-11-07 09:47:30.237"
   },
   {
+    "id": 17499,
     "subjects": "[{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "nw",
     "requestAt": "2023-11-07 13:37:37.799"
   },
   {
+    "id": 17615,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8}]",
     "state": "nw",
     "requestAt": "2023-11-07 14:56:43.494"
   },
   {
+    "id": 17775,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-07 17:41:45.473"
   },
   {
+    "id": 17788,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-07 20:41:47.878"
   },
   {
+    "id": 17788,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-07 20:41:47.878"
   },
   {
+    "id": 17789,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Italienisch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-07 20:41:50.984"
   },
   {
+    "id": 17796,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-08 09:14:37.212"
   },
   {
+    "id": 13502,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "he",
     "requestAt": "2023-11-08 16:26:30.695"
   },
   {
+    "id": 13502,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "he",
     "requestAt": "2023-11-08 16:26:30.695"
   },
   {
+    "id": 16877,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2023-11-09 08:08:49.271"
   },
   {
+    "id": 16877,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2023-11-09 08:08:49.271"
   },
   {
+    "id": 17803,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-09 08:11:14.751"
   },
   {
+    "id": 17803,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-09 08:11:14.751"
   },
   {
+    "id": 17803,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-09 08:11:14.751"
   },
   {
+    "id": 17779,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-09 10:27:27.382"
   },
   {
+    "id": 17735,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-09 13:20:47.266"
   },
   {
+    "id": 17734,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-09 13:21:20.299"
   },
   {
+    "id": 17734,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-09 13:21:20.299"
   },
   {
+    "id": 17800,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "sn",
     "requestAt": "2023-11-10 10:46:21.217"
   },
   {
+    "id": 17808,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":12,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-11-10 10:56:47.685"
   },
   {
+    "id": 17607,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-11-10 11:35:52.683"
   },
   {
+    "id": 17770,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":4},{\"name\":\"Wirtschaft\",\"maxGrade\":12,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":7},{\"name\":\"Informatik\",\"maxGrade\":11,\"minGrade\":7}]",
     "state": "he",
     "requestAt": "2023-11-10 13:06:05.593"
   },
   {
+    "id": 17608,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":8}]",
     "state": "nw",
     "requestAt": "2023-11-10 16:41:54.74"
   },
   {
+    "id": 17797,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-10 18:50:40.417"
   },
   {
+    "id": 17791,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-11 14:53:27.2"
   },
   {
+    "id": 17734,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-11 15:23:59.192"
   },
   {
+    "id": 17735,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-12 21:41:09.788"
   },
   {
+    "id": 17614,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":13},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":13}]",
     "state": "nw",
     "requestAt": "2023-11-13 20:24:57.338"
   },
   {
+    "id": 17583,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":4},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":4},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":4}]",
     "state": "other",
     "requestAt": "2023-11-13 21:42:22.238"
   },
   {
+    "id": 15821,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-13 23:44:02.573"
   },
   {
+    "id": 17759,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":4}]",
     "state": "by",
     "requestAt": "2023-11-14 09:36:43.562"
   },
   {
+    "id": 17246,
     "subjects": "[{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":3},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":3},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":3}]",
     "state": "nw",
     "requestAt": "2023-11-14 09:45:02.18"
   },
   {
+    "id": 17813,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-14 10:46:21.306"
   },
   {
+    "id": 17707,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2023-11-14 11:19:20.282"
   },
   {
+    "id": 17707,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2023-11-14 11:19:20.282"
   },
   {
+    "id": 17750,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1}]",
     "state": "he",
     "requestAt": "2023-11-14 12:39:59.679"
   },
   {
+    "id": 17642,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-14 13:27:28.145"
   },
   {
+    "id": 17811,
     "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "hh",
     "requestAt": "2023-11-14 16:57:38.493"
   },
   {
+    "id": 17794,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-11-14 18:46:32.662"
   },
   {
+    "id": 17583,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":4},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":4},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":4}]",
     "state": "other",
     "requestAt": "2023-11-15 08:48:27.143"
   },
   {
+    "id": 3537,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-16 05:02:54.655"
   },
   {
+    "id": 3537,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-16 05:02:54.655"
   },
   {
+    "id": 17735,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-16 10:52:58.636"
   },
   {
+    "id": 17698,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-11-16 16:49:49.641"
   },
   {
+    "id": 17820,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-11-17 10:41:49.458"
   },
   {
+    "id": 17818,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "ni",
     "requestAt": "2023-11-17 16:18:33.206"
   },
   {
+    "id": 12547,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-18 06:27:45.13"
   },
   {
+    "id": 17614,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":13},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":13}]",
     "state": "nw",
     "requestAt": "2023-11-18 09:59:14.294"
   },
   {
+    "id": 17795,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Russisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":3,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":5,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-18 14:57:55.266"
   },
   {
+    "id": 17811,
     "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "hh",
     "requestAt": "2023-11-18 16:40:25.614"
   },
   {
+    "id": 17623,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-19 19:53:18.422"
   },
   {
+    "id": 17765,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":12,\"minGrade\":6},{\"name\":\"Religion\",\"maxGrade\":12,\"minGrade\":6}]",
     "state": "by",
     "requestAt": "2023-11-20 05:52:52.131"
   },
   {
+    "id": 17804,
     "subjects": "[{\"name\":\"Kunst\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-20 09:37:56.367"
   },
   {
+    "id": 17770,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":4},{\"name\":\"Wirtschaft\",\"maxGrade\":12,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":7},{\"name\":\"Informatik\",\"maxGrade\":11,\"minGrade\":7}]",
     "state": "he",
     "requestAt": "2023-11-20 16:31:02.471"
   },
   {
+    "id": 17683,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2023-11-21 14:13:12.854"
   },
   {
+    "id": 17481,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "sn",
     "requestAt": "2023-11-21 18:02:05.585"
   },
   {
+    "id": 17481,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "sn",
     "requestAt": "2023-11-21 18:02:05.585"
   },
   {
+    "id": 17759,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":4}]",
     "state": "by",
     "requestAt": "2023-11-22 07:42:33.388"
   },
   {
+    "id": 17684,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-11-22 08:24:42.172"
   },
   {
+    "id": 17684,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-11-22 08:24:42.172"
   },
   {
+    "id": 16554,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":9}]",
     "state": "mv",
     "requestAt": "2023-11-22 14:33:57.263"
   },
   {
+    "id": 17807,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-11-22 16:41:42.423"
   },
   {
+    "id": 17807,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-11-22 16:41:42.423"
   },
   {
+    "id": 17807,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-11-22 16:41:42.423"
   },
   {
+    "id": 17810,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2023-11-23 07:58:20.654"
   },
   {
+    "id": 17830,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-23 09:28:46.82"
   },
   {
+    "id": 17791,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-23 13:28:13.178"
   },
   {
+    "id": 17791,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-23 13:28:13.178"
   },
   {
+    "id": 17791,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-23 13:28:13.178"
   },
   {
+    "id": 17827,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "be",
     "requestAt": "2023-11-23 18:20:23.396"
   },
   {
+    "id": 17623,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-23 22:13:21.684"
   },
   {
+    "id": 17623,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-23 22:13:21.684"
   },
   {
+    "id": 17623,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-23 22:13:21.684"
   },
   {
+    "id": 17623,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-23 22:13:21.684"
   },
   {
+    "id": 17615,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8}]",
     "state": "nw",
     "requestAt": "2023-11-24 11:09:27.938"
   },
   {
+    "id": 17680,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Russisch\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2023-11-24 11:35:29.885"
   },
   {
+    "id": 17165,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-11-24 15:07:09.389"
   },
   {
+    "id": 17165,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-11-24 15:07:09.389"
   },
   {
+    "id": 17823,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "be",
     "requestAt": "2023-11-24 18:12:25.174"
   },
   {
+    "id": 17642,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-25 16:59:59.779"
   },
   {
+    "id": 17642,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-25 16:59:59.779"
   },
   {
+    "id": 17642,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-25 16:59:59.779"
   },
   {
+    "id": 17642,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-25 16:59:59.779"
   },
   {
+    "id": 17836,
     "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":14,\"minGrade\":9}]",
     "state": "ni",
     "requestAt": "2023-11-26 08:42:24.929"
   },
   {
+    "id": 17836,
     "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":14,\"minGrade\":9}]",
     "state": "ni",
     "requestAt": "2023-11-26 12:28:30.865"
   },
   {
+    "id": 17759,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":4}]",
     "state": "by",
     "requestAt": "2023-11-27 11:58:23.976"
   },
   {
+    "id": 17795,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Russisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":3,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":5,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-27 14:25:07.938"
   },
   {
+    "id": 17795,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Russisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":3,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":5,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-27 14:25:07.938"
   },
   {
+    "id": 17698,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-11-27 16:03:26.489"
   },
   {
+    "id": 17645,
     "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Französisch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-27 19:27:54.298"
   },
   {
+    "id": 17645,
     "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Französisch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-27 19:27:54.298"
   },
   {
+    "id": 17645,
     "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Französisch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-27 19:27:54.298"
   },
   {
+    "id": 17801,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-28 18:04:26.496"
   },
   {
+    "id": 17734,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-29 12:26:13.696"
   },
   {
+    "id": 17734,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-29 12:26:13.696"
   },
   {
+    "id": 17734,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-29 12:26:13.696"
   },
   {
+    "id": 13741,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "hb",
     "requestAt": "2023-11-29 13:47:35.637"
   },
   {
+    "id": 17623,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-11-29 20:48:38.121"
   },
   {
+    "id": 5579,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-29 20:56:08.712"
   },
   {
+    "id": 13008,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-11-30 14:47:30.317"
   },
   {
+    "id": 17613,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-11-30 14:58:22.79"
   },
   {
+    "id": 3537,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-12-02 12:45:40.439"
   },
   {
+    "id": 17563,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-12-03 08:04:27.889"
   },
   {
+    "id": 17623,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-12-04 14:58:24.744"
   },
   {
+    "id": 17779,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-12-04 15:11:45.84"
   },
   {
+    "id": 17779,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-12-04 15:11:45.84"
   },
   {
+    "id": 17431,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":3,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-12-04 18:25:00.538"
   },
   {
+    "id": 16915,
     "subjects": "[{\"name\":\"Physik\",\"maxGrade\":11,\"minGrade\":10},{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":10}]",
     "state": "ni",
     "requestAt": "2023-12-05 08:09:55.093"
   },
   {
+    "id": 17801,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-12-05 21:21:15.329"
   },
   {
+    "id": 17424,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "ni",
     "requestAt": "2023-12-06 13:30:46.685"
   },
   {
+    "id": 17393,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":12,\"minGrade\":8}]",
     "state": "other",
     "requestAt": "2023-12-06 14:30:11.84"
   },
   {
+    "id": 17845,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "by",
     "requestAt": "2023-12-06 17:25:53.568"
   },
   {
+    "id": 17847,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-12-07 08:07:58.323"
   },
   {
+    "id": 16901,
     "subjects": "[{\"name\":\"Latein\",\"maxGrade\":11,\"minGrade\":5}]",
     "state": "ni",
     "requestAt": "2023-12-07 08:28:17.083"
   },
   {
+    "id": 17540,
     "subjects": "[{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":11}]",
     "state": "be",
     "requestAt": "2023-12-07 17:07:10.966"
   },
   {
+    "id": 17683,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2023-12-07 17:46:53.348"
   },
   {
+    "id": 17683,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2023-12-07 17:46:53.348"
   },
   {
+    "id": 17737,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-12-07 18:08:20.43"
   },
   {
+    "id": 17849,
     "subjects": "[{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "rp",
     "requestAt": "2023-12-07 18:58:20.524"
   },
   {
+    "id": 17853,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-12-08 10:20:59.265"
   },
   {
+    "id": 17809,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-12-10 08:09:49.671"
   },
   {
+    "id": 17860,
     "subjects": "[{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "hh",
     "requestAt": "2023-12-10 09:59:01.904"
   },
   {
+    "id": 5001,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-12-10 22:27:04.397"
   },
   {
+    "id": 17852,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "ni",
     "requestAt": "2023-12-12 17:13:13.527"
   },
   {
+    "id": 17858,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2023-12-12 20:01:05.097"
   },
   {
+    "id": 17549,
     "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-12-13 13:02:30.28"
   },
   {
+    "id": 15821,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-12-13 20:19:37.336"
   },
   {
+    "id": 5505,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-12-14 09:28:17.24"
   },
   {
+    "id": 17133,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":3},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":3}]",
     "state": "nw",
     "requestAt": "2023-12-14 15:00:46.357"
   },
   {
+    "id": 15821,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-12-15 10:25:06.357"
   },
   {
+    "id": 15821,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-12-15 10:25:06.357"
   },
   {
+    "id": 15821,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-12-15 10:25:06.357"
   },
   {
+    "id": 17863,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8}]",
     "state": "ni",
     "requestAt": "2023-12-18 15:34:19.388"
   },
   {
+    "id": 17869,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "nw",
     "requestAt": "2023-12-18 17:54:39.295"
   },
   {
+    "id": 17866,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2023-12-19 10:12:48.937"
   },
   {
+    "id": 17848,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-12-19 10:39:45.261"
   },
   {
+    "id": 17803,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-12-19 14:51:20.333"
   },
   {
+    "id": 17759,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":4}]",
     "state": "by",
     "requestAt": "2023-12-20 10:44:00.589"
   },
   {
+    "id": 3577,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2023-12-20 11:33:38.476"
   },
   {
+    "id": 17872,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "sl",
     "requestAt": "2023-12-21 16:40:31.821"
   },
   {
+    "id": 4248,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "st",
     "requestAt": "2023-12-22 22:20:10.426"
   },
   {
+    "id": 16930,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2023-12-24 15:29:37.884"
   },
   {
+    "id": 15317,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2023-12-27 23:24:41.891"
   },
   {
+    "id": 17684,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-12-29 16:40:56.583"
   },
   {
+    "id": 17684,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2023-12-29 16:40:56.583"
   },
   {
+    "id": 17416,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-01-01 15:47:26.755"
   },
   {
+    "id": 17615,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8}]",
     "state": "nw",
     "requestAt": "2024-01-02 11:29:27.064"
   },
   {
+    "id": 17615,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8}]",
     "state": "nw",
     "requestAt": "2024-01-02 11:29:27.064"
   },
   {
+    "id": 17874,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-01-03 14:18:46.27"
   },
   {
+    "id": 14237,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":11}]",
     "state": "bw",
     "requestAt": "2024-01-04 17:52:33.611"
   },
   {
+    "id": 17924,
     "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "sn",
     "requestAt": "2024-01-04 19:04:56.057"
   },
   {
+    "id": 17924,
     "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "sn",
     "requestAt": "2024-01-04 19:04:56.057"
   },
   {
+    "id": 17929,
     "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":8}]",
     "state": "nw",
     "requestAt": "2024-01-05 12:12:22.414"
   },
   {
+    "id": 17824,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2024-01-06 22:34:33.653"
   },
   {
+    "id": 17875,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-01-07 19:16:56.967"
   },
   {
+    "id": 17930,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-01-08 16:19:41.225"
   },
   {
+    "id": 17941,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-01-08 16:31:03.257"
   },
   {
+    "id": 17937,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2024-01-08 17:50:26.265"
   },
   {
+    "id": 8021,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-01-08 19:54:18.601"
   },
   {
+    "id": 17750,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1}]",
     "state": "he",
     "requestAt": "2024-01-08 22:27:30.376"
   },
   {
+    "id": 14380,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-01-09 10:05:10.989"
   },
   {
+    "id": 17801,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-01-10 14:15:26.982"
   },
   {
+    "id": 17801,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-01-10 14:15:26.982"
   },
   {
+    "id": 17801,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-01-10 14:15:26.982"
   },
   {
+    "id": 17140,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "be",
     "requestAt": "2024-01-10 14:52:41.697"
   },
   {
+    "id": 17946,
     "subjects": "[{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-01-10 18:17:22"
   },
   {
+    "id": 17739,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2024-01-10 19:29:22.252"
   },
   {
+    "id": 17943,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":8,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-01-11 09:46:16.95"
   },
   {
+    "id": 17799,
     "subjects": "[{\"name\":\"Wirtschaft\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2024-01-11 16:09:45.113"
   },
   {
+    "id": 17880,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-01-11 18:50:43.031"
   },
   {
+    "id": 17953,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Spanisch\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Wirtschaft\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Politik\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Philosophie\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Französisch\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Erdkunde\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Lernen lernen\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Sachkunde\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Italienisch\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":9,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-01-12 09:18:18.662"
   },
   {
+    "id": 17949,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-01-12 09:43:26.78"
   },
   {
+    "id": 17947,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-01-12 10:35:47.079"
   },
   {
+    "id": 13861,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2024-01-12 21:24:26.895"
   },
   {
+    "id": 17936,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2024-01-13 13:54:07.852"
   },
   {
+    "id": 17788,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-01-15 10:49:14.222"
   },
   {
+    "id": 17869,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "nw",
     "requestAt": "2024-01-18 16:56:04.106"
   },
   {
+    "id": 17864,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":8}]",
     "state": "sh",
     "requestAt": "2024-01-18 17:48:20.927"
   },
   {
+    "id": 17976,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Erdkunde\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2024-01-18 19:37:07.989"
   },
   {
+    "id": 3577,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2024-01-19 10:29:08.373"
   },
   {
+    "id": 3577,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2024-01-19 10:29:08.373"
   },
   {
+    "id": 17957,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-01-19 10:38:23.045"
   },
   {
+    "id": 17965,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "hh",
     "requestAt": "2024-01-19 11:21:02.783"
   },
   {
+    "id": 17983,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Spanisch\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2024-01-19 16:23:44.163"
   },
   {
+    "id": 17810,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-01-20 08:21:57.059"
   },
   {
+    "id": 17608,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":8}]",
     "state": "nw",
     "requestAt": "2024-01-20 08:54:48.223"
   },
   {
+    "id": 17584,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":7}]",
     "state": "nw",
     "requestAt": "2024-01-20 14:32:54.527"
   },
   {
+    "id": 17917,
     "subjects": "[{\"name\":\"Erdkunde\",\"maxGrade\":10,\"minGrade\":8},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Religion\",\"maxGrade\":9,\"minGrade\":8}]",
     "state": "hh",
     "requestAt": "2024-01-20 16:41:28.092"
   },
   {
+    "id": 17988,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-01-20 17:42:06.815"
   },
   {
+    "id": 17964,
     "subjects": "[{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2024-01-21 09:07:50.939"
   },
   {
+    "id": 17707,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2024-01-21 15:40:05.093"
   },
   {
+    "id": 17917,
     "subjects": "[{\"name\":\"Erdkunde\",\"maxGrade\":10,\"minGrade\":8},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Religion\",\"maxGrade\":9,\"minGrade\":8}]",
     "state": "hh",
     "requestAt": "2024-01-22 14:09:00.012"
   },
   {
+    "id": 17992,
     "subjects": "[{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":6}]",
     "state": "other",
     "requestAt": "2024-01-23 18:42:48.056"
   },
   {
+    "id": 16877,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2024-01-24 07:27:24.38"
   },
   {
+    "id": 4764,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-01-24 12:38:38.227"
   },
   {
+    "id": 17994,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":3}]",
     "state": "bw",
     "requestAt": "2024-01-25 08:09:17.35"
   },
   {
+    "id": 17917,
     "subjects": "[{\"name\":\"Erdkunde\",\"maxGrade\":10,\"minGrade\":8},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Religion\",\"maxGrade\":9,\"minGrade\":8}]",
     "state": "hh",
     "requestAt": "2024-01-25 17:58:34.467"
   },
   {
+    "id": 17963,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-01-26 08:43:44.304"
   },
   {
+    "id": 17978,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-01-26 09:04:56.318"
   },
   {
+    "id": 17984,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-01-26 11:37:09.006"
   },
   {
+    "id": 17683,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2024-01-26 15:10:08.126"
   },
   {
+    "id": 17990,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2024-01-26 17:10:16.4"
   },
   {
+    "id": 17781,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2024-01-26 18:27:01.319"
   },
   {
+    "id": 17928,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":3},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":3},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":8,\"minGrade\":3},{\"name\":\"Französisch\",\"maxGrade\":8,\"minGrade\":3}]",
     "state": "by",
     "requestAt": "2024-01-27 14:01:38.439"
   },
   {
+    "id": 17433,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":6}]",
     "state": "by",
     "requestAt": "2024-01-27 14:13:40.385"
   },
   {
+    "id": 17936,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2024-01-28 21:16:30.725"
   },
   {
+    "id": 8021,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-01-30 08:07:09.287"
   },
   {
+    "id": 17978,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-02-01 09:27:17.989"
   },
   {
+    "id": 17978,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-02-01 09:27:17.989"
   },
   {
+    "id": 17978,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-02-01 09:27:17.989"
   },
   {
+    "id": 18012,
     "subjects": "[{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "hh",
     "requestAt": "2024-02-01 17:29:20.603"
   },
   {
+    "id": 16901,
     "subjects": "[{\"name\":\"Latein\",\"maxGrade\":11,\"minGrade\":5}]",
     "state": "ni",
     "requestAt": "2024-02-01 18:25:45.72"
   },
   {
+    "id": 17969,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "th",
     "requestAt": "2024-02-02 09:23:24.698"
   },
   {
+    "id": 18010,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":8}]",
     "state": "he",
     "requestAt": "2024-02-02 09:51:34.723"
   },
   {
+    "id": 18008,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-02-02 16:00:16.457"
   },
   {
+    "id": 17983,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Spanisch\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2024-02-02 20:47:29.502"
   },
   {
+    "id": 18025,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "bb",
     "requestAt": "2024-02-04 18:10:26.429"
   },
   {
+    "id": 18025,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "bb",
     "requestAt": "2024-02-04 18:10:26.429"
   },
   {
+    "id": 17823,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "be",
     "requestAt": "2024-02-05 00:39:51.06"
   },
   {
+    "id": 17988,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-02-05 11:41:56.017"
   },
   {
+    "id": 17953,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Spanisch\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Wirtschaft\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Politik\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Philosophie\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Französisch\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Erdkunde\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Lernen lernen\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Sachkunde\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Italienisch\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":9,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-02-05 13:37:27.7"
   },
   {
+    "id": 17953,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Spanisch\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Wirtschaft\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Politik\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Philosophie\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Französisch\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Erdkunde\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Lernen lernen\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Sachkunde\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Italienisch\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":9,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-02-05 13:37:27.7"
   },
   {
+    "id": 18026,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "sn",
     "requestAt": "2024-02-05 15:41:37.649"
   },
   {
+    "id": 18013,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-02-06 17:09:35.686"
   },
   {
+    "id": 18034,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":8,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-02-06 19:51:45.401"
   },
   {
+    "id": 17978,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-02-07 09:24:02.014"
   },
   {
+    "id": 17978,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-02-07 09:24:02.014"
   },
   {
+    "id": 17246,
     "subjects": "[{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":3},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":3},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":3}]",
     "state": "nw",
     "requestAt": "2024-02-07 13:34:16.968"
   },
   {
+    "id": 17246,
     "subjects": "[{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":3},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":3},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":3}]",
     "state": "nw",
     "requestAt": "2024-02-07 13:34:16.968"
   },
   {
+    "id": 18037,
     "subjects": "[{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Russisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-02-07 17:46:10.096"
   },
   {
+    "id": 17517,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2024-02-08 21:30:28.61"
   },
   {
+    "id": 18040,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-02-09 09:49:35.259"
   },
   {
+    "id": 17967,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Technik\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "rp",
     "requestAt": "2024-02-09 18:17:22.537"
   },
   {
+    "id": 18054,
     "subjects": "[{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-02-10 11:33:03.793"
   },
   {
+    "id": 18056,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":12,\"minGrade\":8},{\"name\":\"Englisch\",\"maxGrade\":12,\"minGrade\":8},{\"name\":\"Kunst\",\"maxGrade\":12,\"minGrade\":8}]",
     "state": "bw",
     "requestAt": "2024-02-10 11:33:22.324"
   },
   {
+    "id": 18058,
     "subjects": "[{\"name\":\"Musik\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":5,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2024-02-10 11:33:30.822"
   },
   {
+    "id": 18057,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "hh",
     "requestAt": "2024-02-10 11:34:00.851"
   },
   {
+    "id": 18055,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":4}]",
     "state": "nw",
     "requestAt": "2024-02-10 11:34:06.717"
   },
   {
+    "id": 18059,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Italienisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "ni",
     "requestAt": "2024-02-10 11:34:13.086"
   },
   {
+    "id": 18047,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Sachkunde\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-02-12 15:24:58.798"
   },
   {
+    "id": 18047,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Sachkunde\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-02-12 15:24:58.798"
   },
   {
+    "id": 18049,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "other",
     "requestAt": "2024-02-12 16:15:01.486"
   },
   {
+    "id": 17984,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-02-13 11:07:30.184"
   },
   {
+    "id": 10476,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Biologie\",\"maxGrade\":12,\"minGrade\":6},{\"name\":\"Informatik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2024-02-13 16:50:55.421"
   },
   {
+    "id": 10476,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Biologie\",\"maxGrade\":12,\"minGrade\":6},{\"name\":\"Informatik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2024-02-13 16:50:55.421"
   },
   {
+    "id": 18052,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":6}]",
     "state": "other",
     "requestAt": "2024-02-13 18:44:57.852"
   },
   {
+    "id": 18004,
     "subjects": "[{\"name\":\"Latein\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "sn",
     "requestAt": "2024-02-14 14:46:18.275"
   },
   {
+    "id": 17781,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2024-02-15 11:50:42.648"
   },
   {
+    "id": 17984,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-02-15 11:52:38.259"
   },
   {
+    "id": 18063,
     "subjects": "[{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "th",
     "requestAt": "2024-02-15 13:48:00.494"
   },
   {
+    "id": 17984,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-02-15 18:57:58.368"
   },
   {
+    "id": 17856,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-02-16 07:07:39.473"
   },
   {
+    "id": 18062,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-02-16 13:32:55.936"
   },
   {
+    "id": 11052,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2024-02-16 14:47:55.408"
   },
   {
+    "id": 11839,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bb",
     "requestAt": "2024-02-17 17:27:57.458"
   },
   {
+    "id": 17739,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2024-02-17 19:25:42.294"
   },
   {
+    "id": 17801,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-02-19 13:59:36.89"
   },
   {
+    "id": 17801,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-02-19 13:59:36.89"
   },
   {
+    "id": 17801,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-02-19 13:59:36.89"
   },
   {
+    "id": 17865,
     "subjects": "[{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2024-02-19 17:41:28.384"
   },
   {
+    "id": 18004,
     "subjects": "[{\"name\":\"Latein\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "sn",
     "requestAt": "2024-02-19 18:00:29.539"
   },
   {
+    "id": 13513,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":1}]",
     "state": "he",
     "requestAt": "2024-02-20 09:42:33.782"
   },
   {
+    "id": 17927,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-02-20 09:52:27.774"
   },
   {
+    "id": 12143,
     "subjects": "[{\"name\":\"Spanisch\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-02-20 12:24:39.933"
   },
   {
+    "id": 17978,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-02-20 13:05:23.863"
   },
   {
+    "id": 18064,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "rp",
     "requestAt": "2024-02-20 14:18:23.409"
   },
   {
+    "id": 18073,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-02-20 14:48:59.464"
   },
   {
+    "id": 18082,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "he",
     "requestAt": "2024-02-20 15:46:57.697"
   },
   {
+    "id": 17984,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-02-20 15:51:14.673"
   },
   {
+    "id": 18041,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-02-21 12:15:30.201"
   },
   {
+    "id": 18046,
     "subjects": "[{\"name\":\"Kunst\",\"maxGrade\":12,\"minGrade\":3},{\"name\":\"Philosophie\",\"maxGrade\":12,\"minGrade\":3},{\"name\":\"Englisch\",\"maxGrade\":11,\"minGrade\":3},{\"name\":\"Pädagogik\",\"maxGrade\":12,\"minGrade\":3},{\"name\":\"Religion\",\"maxGrade\":12,\"minGrade\":3},{\"name\":\"Lernen lernen\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":12,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-02-21 14:38:36.013"
   },
   {
+    "id": 18037,
     "subjects": "[{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Russisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-02-21 15:52:12.696"
   },
   {
+    "id": 17645,
     "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Französisch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-02-22 12:22:25.188"
   },
   {
+    "id": 17852,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "ni",
     "requestAt": "2024-02-23 10:05:14.983"
   },
   {
+    "id": 17489,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-02-23 12:10:13.479"
   },
   {
+    "id": 17645,
     "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Französisch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-02-23 20:34:12.556"
   },
   {
+    "id": 18065,
     "subjects": "[{\"name\":\"Wirtschaft\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "sn",
     "requestAt": "2024-02-24 08:32:52.587"
   },
   {
+    "id": 17932,
     "subjects": "[{\"name\":\"Lernen lernen\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "rp",
     "requestAt": "2024-02-25 10:52:49.027"
   },
   {
+    "id": 17380,
     "subjects": "[{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":4},{\"name\":\"Religion\",\"maxGrade\":10,\"minGrade\":4},{\"name\":\"Deutsch\",\"maxGrade\":5,\"minGrade\":4}]",
     "state": "other",
     "requestAt": "2024-02-26 17:40:50.642"
   },
   {
+    "id": 17431,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":3,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2024-02-26 20:03:17.323"
   },
   {
+    "id": 17431,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":3,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2024-02-26 20:03:17.323"
   },
   {
+    "id": 18064,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "rp",
     "requestAt": "2024-02-27 09:04:47.626"
   },
   {
+    "id": 17932,
     "subjects": "[{\"name\":\"Lernen lernen\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "rp",
     "requestAt": "2024-02-27 19:30:34.893"
   },
   {
+    "id": 17984,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-02-28 15:13:53.938"
   },
   {
+    "id": 18046,
     "subjects": "[{\"name\":\"Kunst\",\"maxGrade\":12,\"minGrade\":3},{\"name\":\"Philosophie\",\"maxGrade\":12,\"minGrade\":3},{\"name\":\"Englisch\",\"maxGrade\":11,\"minGrade\":3},{\"name\":\"Pädagogik\",\"maxGrade\":12,\"minGrade\":3},{\"name\":\"Religion\",\"maxGrade\":12,\"minGrade\":3},{\"name\":\"Lernen lernen\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":12,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-02-29 15:50:37.036"
   },
   {
+    "id": 17112,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "bw",
     "requestAt": "2024-03-01 08:29:07.987"
   },
   {
+    "id": 18092,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-03-01 09:24:41.297"
   },
   {
+    "id": 18093,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "rp",
     "requestAt": "2024-03-01 09:52:27.551"
   },
   {
+    "id": 17635,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2024-03-03 12:51:38.332"
   },
   {
+    "id": 18096,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-03-04 12:08:25.175"
   },
   {
+    "id": 18102,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-03-04 12:47:03.519"
   },
   {
+    "id": 17112,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "bw",
     "requestAt": "2024-03-04 13:34:26.104"
   },
   {
+    "id": 18096,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-03-04 13:51:21.152"
   },
   {
+    "id": 18103,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2024-03-04 14:18:28.685"
   },
   {
+    "id": 18108,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":13},{\"name\":\"Kunst\",\"maxGrade\":14,\"minGrade\":13},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":13},{\"name\":\"Pädagogik\",\"maxGrade\":14,\"minGrade\":13},{\"name\":\"Gesundheit\",\"maxGrade\":14,\"minGrade\":13}]",
     "state": "other",
     "requestAt": "2024-03-04 16:47:34.661"
   },
   {
+    "id": 17238,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2024-03-05 12:42:59.66"
   },
   {
+    "id": 18086,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-03-05 15:10:53.254"
   },
   {
+    "id": 17827,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "be",
     "requestAt": "2024-03-05 17:32:16.901"
   },
   {
+    "id": 18069,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2024-03-07 04:51:33.57"
   },
   {
+    "id": 18093,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "rp",
     "requestAt": "2024-03-07 12:23:34.27"
   },
   {
+    "id": 11839,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bb",
     "requestAt": "2024-03-07 13:21:42.909"
   },
   {
+    "id": 18063,
     "subjects": "[{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "th",
     "requestAt": "2024-03-07 16:43:59.706"
   },
   {
+    "id": 18090,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9}]",
     "state": "by",
     "requestAt": "2024-03-07 19:30:57.712"
   },
   {
+    "id": 18113,
     "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "hh",
     "requestAt": "2024-03-08 09:18:28.499"
   },
   {
+    "id": 18095,
     "subjects": "[{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2024-03-08 10:19:25.074"
   },
   {
+    "id": 18115,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-03-08 13:43:50.714"
   },
   {
+    "id": 16385,
     "subjects": "[{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2024-03-08 15:03:20.536"
   },
   {
+    "id": 18125,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-03-08 16:12:31.357"
   },
   {
+    "id": 18135,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":2},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":4,\"minGrade\":2},{\"name\":\"Englisch\",\"maxGrade\":4,\"minGrade\":2},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":2}]",
     "state": "ch",
     "requestAt": "2024-03-08 16:44:51.947"
   },
   {
+    "id": 10476,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Biologie\",\"maxGrade\":12,\"minGrade\":6},{\"name\":\"Informatik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2024-03-08 18:09:53.382"
   },
   {
+    "id": 18132,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-03-08 18:53:20.297"
   },
   {
+    "id": 17967,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Technik\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "rp",
     "requestAt": "2024-03-09 11:25:31.802"
   },
   {
+    "id": 10148,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "ni",
     "requestAt": "2024-03-09 13:15:09.239"
   },
   {
+    "id": 18113,
     "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "hh",
     "requestAt": "2024-03-09 16:10:14.089"
   },
   {
+    "id": 18125,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-03-11 17:25:29.413"
   },
   {
+    "id": 18117,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":9}]",
     "state": "other",
     "requestAt": "2024-03-11 17:42:17.914"
   },
   {
+    "id": 18121,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2024-03-13 12:14:31.172"
   },
   {
+    "id": 17956,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2024-03-13 15:09:53.816"
   },
   {
+    "id": 18113,
     "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "hh",
     "requestAt": "2024-03-14 07:48:33.532"
   },
   {
+    "id": 18123,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-03-14 13:13:09.867"
   },
   {
+    "id": 18127,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Niederländisch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "other",
     "requestAt": "2024-03-14 13:52:34.205"
   },
   {
+    "id": 17932,
     "subjects": "[{\"name\":\"Lernen lernen\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "rp",
     "requestAt": "2024-03-14 17:53:38.678"
   },
   {
+    "id": 18175,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":12,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-03-15 11:35:39.998"
   },
   {
+    "id": 8247,
     "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Altgriechisch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "sn",
     "requestAt": "2024-03-15 16:17:16.904"
   },
   {
+    "id": 18111,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-03-15 16:41:54.261"
   },
   {
+    "id": 18111,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-03-15 17:27:50.927"
   },
   {
+    "id": 8247,
     "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Altgriechisch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "sn",
     "requestAt": "2024-03-16 15:15:34.424"
   },
   {
+    "id": 17870,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-03-18 12:28:42.403"
   },
   {
+    "id": 18129,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":11,\"minGrade\":5}]",
     "state": "bw",
     "requestAt": "2024-03-18 19:27:39.989"
   },
   {
+    "id": 17632,
     "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-03-19 14:16:14.587"
   },
   {
+    "id": 16901,
     "subjects": "[{\"name\":\"Latein\",\"maxGrade\":11,\"minGrade\":5}]",
     "state": "ni",
     "requestAt": "2024-03-19 16:21:47.584"
   },
   {
+    "id": 18188,
     "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":4},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":4},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":4},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":4},{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":4},{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":4},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":4}]",
     "state": "be",
     "requestAt": "2024-03-19 18:14:49.84"
   },
   {
+    "id": 18136,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Lernen lernen\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2024-03-19 19:44:11.532"
   },
   {
+    "id": 18138,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-03-19 20:17:06.285"
   },
   {
+    "id": 18121,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2024-03-20 22:19:59.277"
   },
   {
+    "id": 18194,
     "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2024-03-21 10:27:20.644"
   },
   {
+    "id": 2332,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "bb",
     "requestAt": "2024-03-21 13:39:11.356"
   },
   {
+    "id": 18174,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "be",
     "requestAt": "2024-03-21 19:31:57.284"
   },
   {
+    "id": 18200,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-03-22 14:47:02.844"
   },
   {
+    "id": 18190,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-03-22 15:48:21.855"
   },
   {
+    "id": 18138,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-03-22 17:13:13.318"
   },
   {
+    "id": 18202,
     "subjects": "[{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":2},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-03-22 20:34:21.501"
   },
   {
+    "id": 18195,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "other",
     "requestAt": "2024-03-24 13:01:39.785"
   },
   {
+    "id": 17508,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":11},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":11}]",
     "state": "rp",
     "requestAt": "2024-03-24 18:15:03.872"
   },
   {
+    "id": 18205,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Latein\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-03-25 17:50:57.181"
   },
   {
+    "id": 2332,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "bb",
     "requestAt": "2024-03-25 19:05:53.246"
   },
   {
+    "id": 18216,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-03-26 14:42:37.951"
   },
   {
+    "id": 16915,
     "subjects": "[{\"name\":\"Physik\",\"maxGrade\":11,\"minGrade\":10},{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":10}]",
     "state": "ni",
     "requestAt": "2024-03-26 18:53:23.571"
   },
   {
+    "id": 18104,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-03-27 19:35:33.273"
   },
   {
+    "id": 18207,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-03-28 10:19:33.312"
   },
   {
+    "id": 13930,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2024-03-28 10:39:12.348"
   },
   {
+    "id": 18185,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":11},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":11}]",
     "state": "other",
     "requestAt": "2024-03-28 12:42:23.626"
   },
   {
+    "id": 18218,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-03-28 17:04:01.553"
   },
   {
+    "id": 18208,
     "subjects": "[{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-03-28 17:33:37.221"
   },
   {
+    "id": 18219,
     "subjects": "[{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2024-03-28 18:06:56.584"
   },
   {
+    "id": 18208,
     "subjects": "[{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-03-28 20:37:06.503"
   },
   {
+    "id": 17333,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2024-03-28 20:50:25.733"
   },
   {
+    "id": 17333,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2024-03-28 20:50:25.733"
   },
   {
+    "id": 18124,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":4},{\"name\":\"Politik\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-03-29 12:59:31.669"
   },
   {
+    "id": 18212,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-04-01 16:06:02.17"
   },
   {
+    "id": 17521,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":11}]",
     "state": "nw",
     "requestAt": "2024-04-01 20:59:50.749"
   },
   {
+    "id": 18049,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "other",
     "requestAt": "2024-04-02 12:56:53.519"
   },
   {
+    "id": 18231,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":8}]",
     "state": "by",
     "requestAt": "2024-04-02 13:18:42.885"
   },
   {
+    "id": 18134,
     "subjects": "[{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2024-04-02 16:48:51.725"
   },
   {
+    "id": 18211,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Chinesisch\",\"maxGrade\":13,\"minGrade\":9}]",
     "state": "other",
     "requestAt": "2024-04-03 09:43:34.618"
   },
   {
+    "id": 18235,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-03 16:19:33.628"
   },
   {
+    "id": 18118,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-03 16:49:16.314"
   },
   {
+    "id": 524,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "he",
     "requestAt": "2024-04-03 20:41:21.938"
   },
   {
+    "id": 18123,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-04 00:58:42.774"
   },
   {
+    "id": 18226,
     "subjects": "[{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":2}]",
     "state": "other",
     "requestAt": "2024-04-04 18:31:19.42"
   },
   {
+    "id": 18226,
     "subjects": "[{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":2}]",
     "state": "other",
     "requestAt": "2024-04-04 18:31:19.42"
   },
   {
+    "id": 18239,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-04-05 08:55:22.971"
   },
   {
+    "id": 18234,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-05 09:47:37.233"
   },
   {
+    "id": 18237,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Erdkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2024-04-05 15:47:08.362"
   },
   {
+    "id": 18209,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":6}]",
     "state": "ni",
     "requestAt": "2024-04-05 16:20:11.692"
   },
   {
+    "id": 18118,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-05 22:45:00.669"
   },
   {
+    "id": 18187,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":5,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-06 17:35:05.485"
   },
   {
+    "id": 18226,
     "subjects": "[{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":2}]",
     "state": "other",
     "requestAt": "2024-04-07 07:48:47.007"
   },
   {
+    "id": 18242,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":6}]",
     "state": "other",
     "requestAt": "2024-04-09 07:50:33.869"
   },
   {
+    "id": 18243,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-04-09 08:14:39.073"
   },
   {
+    "id": 17133,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":3},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":3}]",
     "state": "nw",
     "requestAt": "2024-04-09 09:58:16.377"
   },
   {
+    "id": 18250,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-09 12:48:30.441"
   },
   {
+    "id": 18249,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-09 13:19:55.703"
   },
   {
+    "id": 18104,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-04-09 20:55:30.519"
   },
   {
+    "id": 17241,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-04-10 06:48:39.263"
   },
   {
+    "id": 18226,
     "subjects": "[{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":2}]",
     "state": "other",
     "requestAt": "2024-04-10 18:13:07.716"
   },
   {
+    "id": 18252,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "by",
     "requestAt": "2024-04-11 11:21:43.327"
   },
   {
+    "id": 18245,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":7}]",
     "state": "other",
     "requestAt": "2024-04-12 08:17:08.618"
   },
   {
+    "id": 18245,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":7}]",
     "state": "other",
     "requestAt": "2024-04-12 08:34:43.078"
   },
   {
+    "id": 14528,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "ni",
     "requestAt": "2024-04-12 11:52:47.896"
   },
   {
+    "id": 18256,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-12 12:01:49.608"
   },
   {
+    "id": 18238,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-12 16:17:54.622"
   },
   {
+    "id": 18270,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-13 09:38:54.086"
   },
   {
+    "id": 18270,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-13 09:38:54.086"
   },
   {
+    "id": 18261,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-04-13 09:39:52.128"
   },
   {
+    "id": 18261,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-04-13 09:39:52.128"
   },
   {
+    "id": 18261,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-04-13 09:39:52.128"
   },
   {
+    "id": 18261,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-04-13 09:39:52.128"
   },
   {
+    "id": 18261,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-04-13 09:39:52.128"
   },
   {
+    "id": 18272,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-13 09:40:11.522"
   },
   {
+    "id": 18272,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-13 09:40:11.522"
   },
   {
+    "id": 18272,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-13 09:40:11.522"
   },
   {
+    "id": 18264,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":10}]",
     "state": "other",
     "requestAt": "2024-04-13 09:40:37.891"
   },
   {
+    "id": 18264,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":10}]",
     "state": "other",
     "requestAt": "2024-04-13 09:40:37.891"
   },
   {
+    "id": 18264,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":10}]",
     "state": "other",
     "requestAt": "2024-04-13 09:40:37.891"
   },
   {
+    "id": 18264,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":10}]",
     "state": "other",
     "requestAt": "2024-04-13 09:40:37.891"
   },
   {
+    "id": 18264,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":10}]",
     "state": "other",
     "requestAt": "2024-04-13 09:40:37.891"
   },
   {
+    "id": 18264,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":10}]",
     "state": "other",
     "requestAt": "2024-04-13 09:40:37.891"
   },
   {
+    "id": 18281,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-13 09:41:19.829"
   },
   {
+    "id": 18277,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-13 09:42:41.801"
   },
   {
+    "id": 18277,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-13 09:42:41.801"
   },
   {
+    "id": 18277,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-13 09:42:41.801"
   },
   {
+    "id": 18262,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-13 09:44:10.256"
   },
   {
+    "id": 18262,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-13 09:44:10.256"
   },
   {
+    "id": 18262,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-13 09:44:10.256"
   },
   {
+    "id": 18283,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-13 09:44:46.458"
   },
   {
+    "id": 18283,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-13 09:44:46.458"
   },
   {
+    "id": 18283,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-13 09:44:46.458"
   },
   {
+    "id": 16334,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-04-13 13:51:50.992"
   },
   {
+    "id": 16334,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-04-13 13:51:50.992"
   },
   {
+    "id": 18257,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-04-13 14:32:16.51"
   },
   {
+    "id": 18274,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-13 14:32:35.894"
   },
   {
+    "id": 18266,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-13 14:35:44.958"
   },
   {
+    "id": 18266,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-13 14:35:44.958"
   },
   {
+    "id": 18266,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-13 14:35:44.958"
   },
   {
+    "id": 18271,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-04-13 14:36:09.984"
   },
   {
+    "id": 18271,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-04-13 14:36:09.984"
   },
   {
+    "id": 18271,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-04-13 14:36:09.984"
   },
   {
+    "id": 18279,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-13 22:23:17.924"
   },
   {
+    "id": 18265,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-14 08:03:54.66"
   },
   {
+    "id": 18265,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-14 08:03:54.66"
   },
   {
+    "id": 18265,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-14 08:03:54.66"
   },
   {
+    "id": 18239,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-04-14 14:21:05.074"
   },
   {
+    "id": 18246,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-04-14 14:41:31.157"
   },
   {
+    "id": 18267,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-15 03:15:50.867"
   },
   {
+    "id": 18267,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-15 03:15:50.867"
   },
   {
+    "id": 18267,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-15 03:15:50.867"
   },
   {
+    "id": 17870,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-15 11:01:14.035"
   },
   {
+    "id": 18268,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-04-15 12:51:10.52"
   },
   {
+    "id": 18268,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-04-15 12:51:10.52"
   },
   {
+    "id": 18268,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-04-15 12:51:10.52"
   },
   {
+    "id": 18174,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "be",
     "requestAt": "2024-04-15 15:15:16.392"
   },
   {
+    "id": 18231,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":8}]",
     "state": "by",
     "requestAt": "2024-04-15 15:42:20.164"
   },
   {
+    "id": 18274,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-16 07:28:31.012"
   },
   {
+    "id": 16334,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-04-16 11:53:47.384"
   },
   {
+    "id": 16334,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-04-16 11:53:47.384"
   },
   {
+    "id": 16334,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-04-16 11:53:47.384"
   },
   {
+    "id": 18269,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-04-16 12:34:47.342"
   },
   {
+    "id": 18269,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-04-16 12:34:47.342"
   },
   {
+    "id": 16877,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2024-04-16 14:25:00.394"
   },
   {
+    "id": 18279,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-16 17:20:32.729"
   },
   {
+    "id": 18279,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-16 17:20:32.729"
   },
   {
+    "id": 18278,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-17 15:58:22.747"
   },
   {
+    "id": 18278,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-17 15:58:22.747"
   },
   {
+    "id": 15560,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2024-04-17 20:01:15.494"
   },
   {
+    "id": 18195,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "other",
     "requestAt": "2024-04-18 19:47:29.199"
   },
   {
+    "id": 18298,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Französisch\",\"maxGrade\":8,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-04-19 09:15:01.206"
   },
   {
+    "id": 18301,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Russisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-19 11:15:21.483"
   },
   {
+    "id": 17635,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2024-04-19 16:51:53.925"
   },
   {
+    "id": 18245,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":7}]",
     "state": "other",
     "requestAt": "2024-04-19 18:48:43.647"
   },
   {
+    "id": 18245,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":7}]",
     "state": "other",
     "requestAt": "2024-04-19 18:48:43.647"
   },
   {
+    "id": 18287,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-19 20:14:53.8"
   },
   {
+    "id": 18255,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-04-20 08:05:54.083"
   },
   {
+    "id": 18185,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":11},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":11}]",
     "state": "other",
     "requestAt": "2024-04-22 11:50:01.61"
   },
   {
+    "id": 18257,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-04-22 14:14:08.115"
   },
   {
+    "id": 18310,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-22 15:08:25.977"
   },
   {
+    "id": 18310,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-22 15:08:25.977"
   },
   {
+    "id": 18310,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-22 15:08:25.977"
   },
   {
+    "id": 18001,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-23 07:16:53.317"
   },
   {
+    "id": 18304,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-04-23 07:47:43.261"
   },
   {
+    "id": 18303,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-04-23 13:18:05.267"
   },
   {
+    "id": 18290,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-23 13:19:47.266"
   },
   {
+    "id": 18291,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-04-24 07:17:40.242"
   },
   {
+    "id": 3577,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2024-04-24 15:03:09.227"
   },
   {
+    "id": 17393,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":12,\"minGrade\":8}]",
     "state": "other",
     "requestAt": "2024-04-24 16:45:17.083"
   },
   {
+    "id": 18288,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":11,\"minGrade\":8}]",
     "state": "bw",
     "requestAt": "2024-04-25 10:22:53.83"
   },
   {
+    "id": 18285,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-27 13:50:33.146"
   },
   {
+    "id": 18323,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":5,\"minGrade\":3},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":2},{\"name\":\"Lernen lernen\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-04-28 11:46:35.391"
   },
   {
+    "id": 18001,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-04-29 12:25:12.122"
   },
   {
+    "id": 18327,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2024-04-29 15:53:38.624"
   },
   {
+    "id": 17963,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-05-01 11:29:11.057"
   },
   {
+    "id": 18185,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":11},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":11}]",
     "state": "other",
     "requestAt": "2024-05-02 06:29:16.369"
   },
   {
+    "id": 15323,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":6},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bb",
     "requestAt": "2024-05-02 14:20:46.415"
   },
   {
+    "id": 16877,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2024-05-04 14:36:47.39"
   },
   {
+    "id": 17870,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-05-04 16:54:10.209"
   },
   {
+    "id": 18281,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-05-04 19:12:32.198"
   },
   {
+    "id": 18313,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-05-05 10:16:08.398"
   },
   {
+    "id": 17988,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-05-05 16:30:09.445"
   },
   {
+    "id": 3659,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-05-06 05:49:24.822"
   },
   {
+    "id": 16262,
     "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "nw",
     "requestAt": "2024-05-06 15:26:17.335"
   },
   {
+    "id": 18290,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-05-06 17:01:13.396"
   },
   {
+    "id": 17645,
     "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Französisch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-05-07 06:10:02.779"
   },
   {
+    "id": 18263,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2024-05-07 15:47:59.641"
   },
   {
+    "id": 18350,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-05-08 08:51:55.335"
   },
   {
+    "id": 17691,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-05-08 10:17:56.017"
   },
   {
+    "id": 18287,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-05-08 10:31:55.396"
   },
   {
+    "id": 18287,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-05-08 10:31:55.396"
   },
   {
+    "id": 18287,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-05-08 10:31:55.396"
   },
   {
+    "id": 18209,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":6}]",
     "state": "ni",
     "requestAt": "2024-05-09 15:22:59.042"
   },
   {
+    "id": 18335,
     "subjects": "[{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-05-10 08:21:57.691"
   },
   {
+    "id": 18320,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Gesundheit\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "rp",
     "requestAt": "2024-05-10 16:45:16.595"
   },
   {
+    "id": 17540,
     "subjects": "[{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":11}]",
     "state": "be",
     "requestAt": "2024-05-11 07:31:31.715"
   },
   {
+    "id": 18342,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":7}]",
     "state": "nw",
     "requestAt": "2024-05-11 14:21:11.495"
   },
   {
+    "id": 18090,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9}]",
     "state": "by",
     "requestAt": "2024-05-13 08:29:37.503"
   },
   {
+    "id": 17916,
     "subjects": "[{\"name\":\"Spanisch\",\"maxGrade\":10,\"minGrade\":9}]",
     "state": "be",
     "requestAt": "2024-05-13 09:00:19.867"
   },
   {
+    "id": 18347,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Erdkunde\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":10}]",
     "state": "nw",
     "requestAt": "2024-05-13 11:20:20.773"
   },
   {
+    "id": 4106,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-05-13 13:24:55.555"
   },
   {
+    "id": 17645,
     "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Französisch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-05-13 13:29:56.464"
   },
   {
+    "id": 18348,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Spanisch\",\"maxGrade\":7,\"minGrade\":5}]",
     "state": "ni",
     "requestAt": "2024-05-13 13:31:17.595"
   },
   {
+    "id": 17000,
     "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":9,\"minGrade\":6}]",
     "state": "bw",
     "requestAt": "2024-05-13 17:34:53.917"
   },
   {
+    "id": 4190,
     "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "rp",
     "requestAt": "2024-05-13 19:48:19.298"
   },
   {
+    "id": 16548,
     "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2024-05-13 19:53:08.768"
   },
   {
+    "id": 16334,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-05-14 13:03:08.333"
   },
   {
+    "id": 18351,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-05-14 13:31:43.358"
   },
   {
+    "id": 18303,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-05-14 14:16:52.122"
   },
   {
+    "id": 18357,
     "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":7}]",
     "state": "sl",
     "requestAt": "2024-05-15 09:45:40.889"
   },
   {
+    "id": 18263,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2024-05-15 11:11:50.83"
   },
   {
+    "id": 14528,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "ni",
     "requestAt": "2024-05-15 23:33:37.506"
   },
   {
+    "id": 16334,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-05-16 08:48:35.961"
   },
   {
+    "id": 16334,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-05-16 08:48:35.961"
   },
   {
+    "id": 18332,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "other",
     "requestAt": "2024-05-16 15:36:39.239"
   },
   {
+    "id": 18324,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-05-17 08:27:36.314"
   },
   {
+    "id": 18364,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "other",
     "requestAt": "2024-05-17 08:48:27.885"
   },
   {
+    "id": 18365,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":10}]",
     "state": "other",
     "requestAt": "2024-05-17 09:46:50.888"
   },
   {
+    "id": 18372,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-05-17 16:51:14.191"
   },
   {
+    "id": 18373,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7}]",
     "state": "ni",
     "requestAt": "2024-05-17 17:59:58.374"
   },
   {
+    "id": 15971,
     "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "sn",
     "requestAt": "2024-05-17 22:04:58.894"
   },
   {
+    "id": 12391,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2024-05-17 23:59:56.352"
   },
   {
+    "id": 8090,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":9}]",
     "state": "nw",
     "requestAt": "2024-05-19 08:39:43.898"
   },
   {
+    "id": 14994,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "hh",
     "requestAt": "2024-05-20 09:32:43.357"
   },
   {
+    "id": 18344,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-05-20 11:11:19.084"
   },
   {
+    "id": 17413,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":7}]",
     "state": "be",
     "requestAt": "2024-05-21 07:59:55.564"
   },
   {
+    "id": 17869,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "nw",
     "requestAt": "2024-05-21 15:11:41.508"
   },
   {
+    "id": 17505,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2024-05-21 17:43:35.617"
   },
   {
+    "id": 18121,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2024-05-22 20:03:10.861"
   },
   {
+    "id": 17326,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-05-23 09:01:40.564"
   },
   {
+    "id": 18380,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":6}]",
     "state": "other",
     "requestAt": "2024-05-23 09:21:53.555"
   },
   {
+    "id": 18385,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":13},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "be",
     "requestAt": "2024-05-23 09:59:14.582"
   },
   {
+    "id": 18378,
     "subjects": "[{\"name\":\"Spanisch\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-05-23 12:20:16.06"
   },
   {
+    "id": 18374,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Russisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-05-23 14:39:29.713"
   },
   {
+    "id": 18376,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-05-23 16:28:52.296"
   },
   {
+    "id": 18393,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":3,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":2}]",
     "state": "other",
     "requestAt": "2024-05-23 17:26:02.144"
   },
   {
+    "id": 18390,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-05-24 10:14:25.954"
   },
   {
+    "id": 18396,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-05-24 11:13:41.297"
   },
   {
+    "id": 18384,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":9,\"minGrade\":6},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-05-24 17:19:54.238"
   },
   {
+    "id": 10247,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "nw",
     "requestAt": "2024-05-27 07:48:08.306"
   },
   {
+    "id": 261,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Italienisch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-05-27 16:24:43.581"
   },
   {
+    "id": 2505,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-05-27 17:14:52.104"
   },
   {
+    "id": 18371,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":2},{\"name\":\"Kunst\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":2},{\"name\":\"Philosophie\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "st",
     "requestAt": "2024-05-28 09:20:17.702"
   },
   {
+    "id": 18371,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":2},{\"name\":\"Kunst\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":2},{\"name\":\"Philosophie\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "st",
     "requestAt": "2024-05-28 09:20:17.702"
   },
   {
+    "id": 18332,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "other",
     "requestAt": "2024-05-29 19:16:29.174"
   },
   {
+    "id": 18357,
     "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":7}]",
     "state": "sl",
     "requestAt": "2024-05-30 11:49:24.578"
   },
   {
+    "id": 17165,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2024-05-31 16:46:14.203"
   },
   {
+    "id": 17964,
     "subjects": "[{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2024-06-02 10:50:36.374"
   },
   {
+    "id": 18435,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":12,\"minGrade\":8},{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":8},{\"name\":\"Physik\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-06-03 16:19:40.031"
   },
   {
+    "id": 18389,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Chemie\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":8}]",
     "state": "other",
     "requestAt": "2024-06-03 16:47:32.171"
   },
   {
+    "id": 18325,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-06-03 20:00:30.421"
   },
   {
+    "id": 18364,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "other",
     "requestAt": "2024-06-04 05:13:01.739"
   },
   {
+    "id": 18439,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-06-04 07:46:07.808"
   },
   {
+    "id": 18440,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-06-04 13:07:21.889"
   },
   {
+    "id": 17990,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2024-06-04 14:45:54.18"
   },
   {
+    "id": 16440,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Chemie\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":8},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":8}]",
     "state": "nw",
     "requestAt": "2024-06-07 16:23:15.948"
   },
   {
+    "id": 18433,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-06-07 16:54:08.925"
   },
   {
+    "id": 18443,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-06-07 17:32:20.3"
   },
   {
+    "id": 18377,
     "subjects": "[{\"name\":\"Physik\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-06-07 23:55:41.801"
   },
   {
+    "id": 18133,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2024-06-08 09:13:13.195"
   },
   {
+    "id": 17431,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":3,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2024-06-10 10:03:07.051"
   },
   {
+    "id": 18470,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-06-10 10:18:51.221"
   },
   {
+    "id": 12391,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2024-06-10 14:37:43.693"
   },
   {
+    "id": 18338,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Kunst\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Sachkunde\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":5}]",
     "state": "he",
     "requestAt": "2024-06-10 16:25:27.939"
   },
   {
+    "id": 18374,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Russisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-06-10 22:19:18.696"
   },
   {
+    "id": 18445,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-06-11 08:42:20.841"
   },
   {
+    "id": 18315,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-06-12 09:05:12.105"
   },
   {
+    "id": 18047,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Sachkunde\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-06-12 09:46:31.513"
   },
   {
+    "id": 18458,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-06-12 09:50:50.074"
   },
   {
+    "id": 18474,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-06-12 10:49:02.383"
   },
   {
+    "id": 18453,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-06-13 09:18:51.796"
   },
   {
+    "id": 18476,
     "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2024-06-13 10:24:14.833"
   },
   {
+    "id": 18463,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "ni",
     "requestAt": "2024-06-13 11:31:56.111"
   },
   {
+    "id": 18086,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-06-14 15:32:32.539"
   },
   {
+    "id": 18472,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-06-14 16:48:36.559"
   },
   {
+    "id": 18482,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-06-14 17:28:39.733"
   },
   {
+    "id": 18264,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":10}]",
     "state": "other",
     "requestAt": "2024-06-16 10:18:25.685"
   },
   {
+    "id": 18440,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-06-16 20:32:33.037"
   },
   {
+    "id": 17241,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-06-17 23:58:53.627"
   },
   {
+    "id": 17241,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-06-17 23:58:53.627"
   },
   {
+    "id": 17241,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-06-17 23:58:53.627"
   },
   {
+    "id": 18385,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":13},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "be",
     "requestAt": "2024-06-18 08:08:09.969"
   },
   {
+    "id": 18493,
     "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Philosophie\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Politik\",\"maxGrade\":14,\"minGrade\":6}]",
     "state": "be",
     "requestAt": "2024-06-18 10:24:50.933"
   },
   {
+    "id": 18487,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-06-18 12:38:56.621"
   },
   {
+    "id": 18441,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "he",
     "requestAt": "2024-06-18 13:50:21.902"
   },
   {
+    "id": 18364,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "other",
     "requestAt": "2024-06-19 08:38:22.142"
   },
   {
+    "id": 16334,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-06-19 15:29:14.389"
   },
   {
+    "id": 18447,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Latein\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-06-20 09:22:28.13"
   },
   {
+    "id": 18015,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "he",
     "requestAt": "2024-06-20 12:15:40.239"
   },
   {
+    "id": 18185,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":11},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":11}]",
     "state": "other",
     "requestAt": "2024-06-20 17:33:58.721"
   },
   {
+    "id": 18342,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":7}]",
     "state": "nw",
     "requestAt": "2024-06-21 07:00:17.339"
   },
   {
+    "id": 5981,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":7}]",
     "state": "be",
     "requestAt": "2024-06-21 12:22:22.265"
   },
   {
+    "id": 18454,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":8,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-06-21 16:19:48.436"
   },
   {
+    "id": 16262,
     "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "nw",
     "requestAt": "2024-06-23 03:29:43.11"
   },
   {
+    "id": 15524,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":10}]",
     "state": "be",
     "requestAt": "2024-06-23 08:16:12.046"
   },
   {
+    "id": 18468,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-06-26 09:27:36.636"
   },
   {
+    "id": 18485,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-06-26 09:55:55.635"
   },
   {
+    "id": 18326,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-06-26 13:45:08.145"
   },
   {
+    "id": 18104,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-06-26 20:26:16.031"
   },
   {
+    "id": 17750,
     "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1}]",
     "state": "he",
     "requestAt": "2024-06-26 22:13:11.494"
   },
   {
+    "id": 17505,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2024-06-28 19:40:59.399"
   },
   {
+    "id": 18285,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-06-29 08:42:08.023"
   },
   {
+    "id": 17165,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2024-06-29 12:04:46.959"
   },
   {
+    "id": 18020,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Latein\",\"maxGrade\":14,\"minGrade\":9},{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":12}]",
     "state": "be",
     "requestAt": "2024-07-01 10:43:36.728"
   },
   {
+    "id": 16334,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-07-01 12:55:46.716"
   },
   {
+    "id": 16334,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-07-01 12:55:46.716"
   },
   {
+    "id": 18086,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-07-02 08:52:00.385"
   },
   {
+    "id": 11783,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2024-07-02 21:41:03.219"
   },
   {
+    "id": 18364,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "other",
     "requestAt": "2024-07-03 10:19:17.285"
   },
   {
+    "id": 1072,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "rp",
     "requestAt": "2024-07-05 07:23:55.349"
   },
   {
+    "id": 18531,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-07-05 08:12:32.877"
   },
   {
+    "id": 18482,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-07-06 21:25:46.641"
   },
   {
+    "id": 17551,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2024-07-09 05:28:44.2"
   },
   {
+    "id": 18530,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-07-09 08:15:07.817"
   },
   {
+    "id": 17133,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":3},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":3}]",
     "state": "nw",
     "requestAt": "2024-07-09 08:43:15.514"
   },
   {
+    "id": 17635,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2024-07-11 09:34:29.883"
   },
   {
+    "id": 18302,
     "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-07-11 17:50:18.596"
   },
   {
+    "id": 18302,
     "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-07-11 17:50:18.596"
   },
   {
+    "id": 18302,
     "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-07-11 17:50:18.596"
   },
   {
+    "id": 18464,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":5,\"minGrade\":2},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":8,\"minGrade\":3},{\"name\":\"Sachkunde\",\"maxGrade\":4,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-07-14 13:29:40.895"
   },
   {
+    "id": 14380,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-07-16 06:25:34.561"
   },
   {
+    "id": 3577,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2024-07-16 08:17:16.308"
   },
   {
+    "id": 18509,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-07-16 08:29:48.416"
   },
   {
+    "id": 17273,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-07-16 12:36:13.226"
   },
   {
+    "id": 18517,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2024-07-16 19:22:45.739"
   },
   {
+    "id": 3577,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2024-07-17 07:11:11.256"
   },
   {
+    "id": 17431,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":3,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2024-07-18 07:13:13.639"
   },
   {
+    "id": 18096,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-07-18 09:23:02.733"
   },
   {
+    "id": 18566,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":12,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-07-18 10:01:05.53"
   },
   {
+    "id": 18537,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":5,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-07-18 15:55:32.246"
   },
   {
+    "id": 445,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2024-07-20 15:05:31.868"
   },
   {
+    "id": 17849,
     "subjects": "[{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "rp",
     "requestAt": "2024-07-21 18:47:17.051"
   },
   {
+    "id": 18538,
     "subjects": "[{\"name\":\"Politik\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":7}]",
     "state": "sh",
     "requestAt": "2024-07-24 09:29:12.404"
   },
   {
+    "id": 18542,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Politik\",\"maxGrade\":14,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-07-24 09:46:32.162"
   },
   {
+    "id": 18557,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Spanisch\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Erdkunde\",\"maxGrade\":14,\"minGrade\":7}]",
     "state": "hh",
     "requestAt": "2024-07-30 09:02:18.164"
   },
   {
+    "id": 18556,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-07-30 12:35:15.898"
   },
   {
+    "id": 18549,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Musik\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-07-30 13:31:38.61"
   },
   {
+    "id": 18557,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Spanisch\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Erdkunde\",\"maxGrade\":14,\"minGrade\":7}]",
     "state": "hh",
     "requestAt": "2024-07-31 16:44:56.448"
   },
   {
+    "id": 18542,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Politik\",\"maxGrade\":14,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-07-31 17:14:29.537"
   },
   {
+    "id": 18381,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "ni",
     "requestAt": "2024-07-31 17:29:12.173"
   },
   {
+    "id": 18563,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Ethik\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-08-01 09:46:50.874"
   },
   {
+    "id": 18562,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":11,\"minGrade\":1}]",
     "state": "sh",
     "requestAt": "2024-08-01 10:05:24.235"
   },
   {
+    "id": 18604,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-08-02 09:14:05.007"
   },
   {
+    "id": 18559,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-08-02 09:46:04.041"
   },
   {
+    "id": 18567,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Französisch\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Chemie\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":6}]",
     "state": "ni",
     "requestAt": "2024-08-05 16:11:54.175"
   },
   {
+    "id": 17811,
     "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "hh",
     "requestAt": "2024-08-07 15:12:50.904"
   },
   {
+    "id": 18450,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Ethik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-08-07 15:27:27.057"
   },
   {
+    "id": 18450,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Ethik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-08-07 15:27:27.057"
   },
   {
+    "id": 18554,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Ethik\",\"maxGrade\":13,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2024-08-08 09:42:01.259"
   },
   {
+    "id": 18335,
     "subjects": "[{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-08-08 11:03:43.474"
   },
   {
+    "id": 18604,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-08-09 10:39:26.464"
   },
   {
+    "id": 18069,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2024-08-09 12:19:48.908"
   },
   {
+    "id": 18586,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":11,\"minGrade\":5}]",
     "state": "ni",
     "requestAt": "2024-08-11 07:09:23.211"
   },
   {
+    "id": 17241,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-08-11 18:58:08.391"
   },
   {
+    "id": 17992,
     "subjects": "[{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":6}]",
     "state": "other",
     "requestAt": "2024-08-13 07:41:33.052"
   },
   {
+    "id": 17635,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2024-08-14 06:36:41.494"
   },
   {
+    "id": 13699,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "bw",
     "requestAt": "2024-08-14 14:45:14.423"
   },
   {
+    "id": 17849,
     "subjects": "[{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "rp",
     "requestAt": "2024-08-14 14:48:20.226"
   },
   {
+    "id": 18589,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":8}]",
     "state": "other",
     "requestAt": "2024-08-15 07:49:58.103"
   },
   {
+    "id": 18400,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Französisch\",\"maxGrade\":8,\"minGrade\":7}]",
     "state": "other",
     "requestAt": "2024-08-15 08:14:24.884"
   },
   {
+    "id": 18603,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "he",
     "requestAt": "2024-08-15 12:37:51.256"
   },
   {
+    "id": 18071,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-08-16 18:21:34.883"
   },
   {
+    "id": 18071,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-08-16 18:21:34.883"
   },
   {
+    "id": 16474,
     "subjects": "[{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7}]",
     "state": "by",
     "requestAt": "2024-08-19 01:01:41.642"
   },
   {
+    "id": 16474,
     "subjects": "[{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7}]",
     "state": "by",
     "requestAt": "2024-08-19 01:01:41.642"
   },
   {
+    "id": 18088,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Technik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-08-19 14:09:16.8"
   },
   {
+    "id": 10792,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Latein\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "ni",
     "requestAt": "2024-08-20 07:43:36.543"
   },
   {
+    "id": 18594,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Technik\",\"maxGrade\":13,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-08-20 14:00:49.12"
   },
   {
+    "id": 18644,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":4},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-08-20 14:46:08.795"
   },
   {
+    "id": 17508,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":11},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":11}]",
     "state": "rp",
     "requestAt": "2024-08-20 20:44:30.294"
   },
   {
+    "id": 18583,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":6},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Wirtschaft\",\"maxGrade\":12,\"minGrade\":6}]",
     "state": "other",
     "requestAt": "2024-08-21 10:15:53.761"
   },
   {
+    "id": 18511,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":6}]",
     "state": "other",
     "requestAt": "2024-08-21 20:28:05.923"
   },
   {
+    "id": 18603,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
     "state": "he",
     "requestAt": "2024-08-22 06:07:56.055"
   },
   {
+    "id": 18613,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Latein\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-08-22 09:49:23.468"
   },
   {
+    "id": 18627,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Französisch\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Erdkunde\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Wirtschaft\",\"maxGrade\":12,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2024-08-22 11:48:00.461"
   },
   {
+    "id": 18615,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":5,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-08-23 10:21:33.865"
   },
   {
+    "id": 18078,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Französisch\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":5}]",
     "state": "other",
     "requestAt": "2024-08-24 00:10:45.411"
   },
   {
+    "id": 18656,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Technik\",\"maxGrade\":14,\"minGrade\":5}]",
     "state": "st",
     "requestAt": "2024-08-26 11:37:25.393"
   },
   {
+    "id": 18587,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "nw",
     "requestAt": "2024-08-27 18:11:26.912"
   },
   {
+    "id": 18511,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":6}]",
     "state": "other",
     "requestAt": "2024-08-28 15:29:00.342"
   },
   {
+    "id": 18597,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "sh",
     "requestAt": "2024-08-29 06:21:14.151"
   },
   {
+    "id": 18373,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7}]",
     "state": "ni",
     "requestAt": "2024-08-30 06:47:04.695"
   },
   {
+    "id": 18652,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-09-02 13:20:04.42"
   },
   {
+    "id": 18611,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":7,\"minGrade\":1}]",
     "state": "bb",
     "requestAt": "2024-09-02 14:13:52.196"
   },
   {
+    "id": 18627,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Französisch\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Erdkunde\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Wirtschaft\",\"maxGrade\":12,\"minGrade\":5}]",
     "state": "by",
     "requestAt": "2024-09-03 05:15:46.05"
   },
   {
+    "id": 17928,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":3},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":3},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":8,\"minGrade\":3},{\"name\":\"Französisch\",\"maxGrade\":8,\"minGrade\":3}]",
     "state": "by",
     "requestAt": "2024-09-03 08:09:49.144"
   },
   {
+    "id": 18669,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-09-04 08:52:45.633"
   },
   {
+    "id": 18653,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-09-04 09:17:14.784"
   },
   {
+    "id": 18672,
     "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":7}]",
     "state": "other",
     "requestAt": "2024-09-04 12:16:04.382"
   },
   {
+    "id": 18678,
     "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Gesundheit\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Technik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":10}]",
     "state": "other",
     "requestAt": "2024-09-04 13:14:49.062"
   },
   {
+    "id": 18531,
     "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "other",
     "requestAt": "2024-09-05 09:40:45.269"
   },
   {
+    "id": 18674,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":5}]",
     "state": "bw",
     "requestAt": "2024-09-05 09:46:25.226"
   },
   {
+    "id": 18691,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":5}]",
     "state": "ni",
     "requestAt": "2024-09-05 11:31:15.738"
   },
   {
+    "id": 18466,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2024-09-05 14:55:45.21"
   },
   {
+    "id": 18466,
     "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "by",
     "requestAt": "2024-09-05 14:55:45.21"
   },
   {
+    "id": 18665,
     "subjects": "[{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":4},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":4},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":4},{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":4},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":4},{\"name\":\"Pädagogik\",\"maxGrade\":8,\"minGrade\":5}]",
     "state": "nw",
     "requestAt": "2024-09-06 10:25:11.202"
   },
   {
+    "id": 18689,
     "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Gesundheit\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Ethik\",\"maxGrade\":14,\"minGrade\":1}]",
     "state": "st",
     "requestAt": "2024-09-06 17:51:30.337"

--- a/common/match/matching.perf.student.json
+++ b/common/match/matching.perf.student.json
@@ -1,0 +1,6027 @@
+[
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"minGrade\":1,\"maxGrade\":6},{\"name\":\"Deutsch als Zweitsprache\",\"minGrade\":1,\"maxGrade\":13},{\"name\":\"Mathematik\",\"minGrade\":1,\"maxGrade\":6},{\"name\":\"Sachkunde\",\"minGrade\":1,\"maxGrade\":4},{\"name\":\"Musik\",\"minGrade\":1,\"maxGrade\":5},{\"name\":\"Erdkunde\",\"minGrade\":1,\"maxGrade\":6},{\"name\":\"Biologie\",\"minGrade\":1,\"maxGrade\":6}]",
+    "state": "nw",
+    "requestAt": "2022-09-01 21:21:13.559"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "be",
+    "requestAt": "2022-10-23 08:16:55.19"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"minGrade\":5,\"maxGrade\":13},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":3},{\"name\":\"Mathematik\",\"minGrade\":1,\"maxGrade\":8},{\"name\":\"Sachkunde\",\"minGrade\":1,\"maxGrade\":6},{\"name\":\"Englisch\",\"minGrade\":1,\"maxGrade\":8}]",
+    "state": "sh",
+    "requestAt": "2022-10-23 08:18:19.684"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Chemie\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":8},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":8}]",
+    "state": "nw",
+    "requestAt": "2022-10-27 17:49:12.846"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "be",
+    "requestAt": "2022-11-05 08:44:04.903"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"minGrade\":1,\"maxGrade\":13}]",
+    "state": "nw",
+    "requestAt": "2022-11-16 22:04:33.953"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"minGrade\":1,\"maxGrade\":13}]",
+    "state": "nw",
+    "requestAt": "2022-11-16 22:04:33.953"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"minGrade\":1,\"maxGrade\":13}]",
+    "state": "nw",
+    "requestAt": "2022-11-16 22:04:33.953"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "sl",
+    "requestAt": "2022-11-22 09:00:04.987"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2022-11-23 21:21:30.221"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2022-11-29 09:01:49.789"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "sl",
+    "requestAt": "2022-11-29 09:32:46.964"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "sl",
+    "requestAt": "2022-11-29 09:32:46.964"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2022-12-04 10:26:59.112"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "sl",
+    "requestAt": "2022-12-16 12:01:00.249"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "hb",
+    "requestAt": "2023-01-06 09:03:09.085"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2023-01-09 13:21:36.239"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "sl",
+    "requestAt": "2023-01-13 09:04:48.61"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "sl",
+    "requestAt": "2023-01-13 09:04:48.61"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":7}]",
+    "state": "by",
+    "requestAt": "2023-01-19 18:17:38.794"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2023-02-09 13:39:11.492"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-02-10 09:01:20.056"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "sl",
+    "requestAt": "2023-02-14 09:50:01.883"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "sl",
+    "requestAt": "2023-02-27 17:54:54.751"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-02-27 18:53:58.512"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":11},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":11},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":11}]",
+    "state": "he",
+    "requestAt": "2023-02-27 20:52:04.673"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-02-28 13:30:07.38"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-02-28 20:54:26.144"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":3},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":3},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":3}]",
+    "state": "nw",
+    "requestAt": "2023-03-01 17:04:26.16"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-03-01 21:33:59.748"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chinesisch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-03-02 14:49:15.623"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-03-02 17:09:08.322"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-03-03 20:44:16.125"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-03-03 20:44:16.125"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Latein\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2023-03-03 21:02:06.323"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-03-04 09:01:25.929"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "sl",
+    "requestAt": "2023-03-08 16:11:25.503"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "sl",
+    "requestAt": "2023-03-08 16:11:25.503"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":8}]",
+    "state": "other",
+    "requestAt": "2023-03-09 09:20:03.74"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":12,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2023-03-09 09:30:12.505"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-03-09 13:42:19.912"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-03-09 13:42:19.912"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "be",
+    "requestAt": "2023-03-10 09:45:58.797"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "be",
+    "requestAt": "2023-03-10 09:45:58.797"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "be",
+    "requestAt": "2023-03-10 09:45:58.797"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "be",
+    "requestAt": "2023-03-10 09:45:58.797"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "be",
+    "requestAt": "2023-03-10 09:45:58.797"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-03-10 16:13:31.918"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"maxGrade\":11,\"minGrade\":5}]",
+    "state": "ni",
+    "requestAt": "2023-03-12 16:45:29.711"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":6},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":7,\"minGrade\":5}]",
+    "state": "bw",
+    "requestAt": "2023-03-12 20:52:37.433"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":9},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-03-13 17:31:42.902"
+  },
+  {
+    "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "he",
+    "requestAt": "2023-03-14 09:12:42.807"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-03-17 08:37:19.507"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":12,\"minGrade\":8}]",
+    "state": "by",
+    "requestAt": "2023-03-17 08:51:59.143"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "sh",
+    "requestAt": "2023-03-17 09:24:44.574"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "by",
+    "requestAt": "2023-03-17 10:37:44.518"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-03-17 11:07:09.452"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2023-03-20 07:29:29.665"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "he",
+    "requestAt": "2023-03-20 11:48:00.051"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":4},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":4},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":9,\"minGrade\":4}]",
+    "state": "other",
+    "requestAt": "2023-03-21 08:41:48.976"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":4},{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":4},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-03-21 09:11:49.338"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":8}]",
+    "state": "other",
+    "requestAt": "2023-03-22 14:28:11.41"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":12,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2023-03-22 14:29:11.553"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "he",
+    "requestAt": "2023-03-23 07:19:43.514"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":4},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":2}]",
+    "state": "sn",
+    "requestAt": "2023-03-23 13:34:39.963"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":4},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":2}]",
+    "state": "sn",
+    "requestAt": "2023-03-23 13:34:39.963"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "be",
+    "requestAt": "2023-03-23 14:53:48.063"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-03-23 18:59:24.994"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "sh",
+    "requestAt": "2023-03-24 08:50:42.501"
+  },
+  {
+    "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2023-03-24 09:06:42.402"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-03-24 09:48:51.269"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "he",
+    "requestAt": "2023-03-24 11:22:00.485"
+  },
+  {
+    "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "other",
+    "requestAt": "2023-03-25 14:41:41.019"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "be",
+    "requestAt": "2023-03-25 15:00:29.342"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-03-25 18:31:25.446"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "sl",
+    "requestAt": "2023-03-26 16:42:42.896"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "sl",
+    "requestAt": "2023-03-26 16:42:42.896"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-03-27 14:20:38.028"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Italienisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-03-27 17:55:26.135"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-03-29 07:20:39.188"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":12,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2023-03-29 12:11:14.682"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-03-29 13:17:41.417"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-03-29 13:38:06.037"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-04-01 20:16:28.637"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-04-01 20:16:28.637"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "sn",
+    "requestAt": "2023-04-03 13:44:34.322"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "mv",
+    "requestAt": "2023-04-03 16:46:09.172"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "rp",
+    "requestAt": "2023-04-04 15:07:14.34"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":12,\"minGrade\":8}]",
+    "state": "by",
+    "requestAt": "2023-04-05 11:04:33.785"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-04-05 13:15:02.624"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "be",
+    "requestAt": "2023-04-07 13:51:40.157"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "he",
+    "requestAt": "2023-04-09 15:38:02.655"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "he",
+    "requestAt": "2023-04-09 15:38:02.655"
+  },
+  {
+    "subjects": "[{\"name\":\"Russisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-04-09 16:27:25.369"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "be",
+    "requestAt": "2023-04-12 16:28:26.223"
+  },
+  {
+    "subjects": "[{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-04-13 15:15:47.621"
+  },
+  {
+    "subjects": "[{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "by",
+    "requestAt": "2023-04-16 07:59:04.31"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-04-16 16:42:54.182"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "he",
+    "requestAt": "2023-04-18 19:45:38.9"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":11}]",
+    "state": "be",
+    "requestAt": "2023-04-19 13:36:28.988"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Altgriechisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1}]",
+    "state": "be",
+    "requestAt": "2023-04-19 14:19:34.975"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2023-04-19 14:44:18.746"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":8}]",
+    "state": "other",
+    "requestAt": "2023-04-19 14:47:25.508"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Altgriechisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1}]",
+    "state": "be",
+    "requestAt": "2023-04-19 15:39:14.149"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Physik\",\"maxGrade\":12,\"minGrade\":8},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":8},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":8}]",
+    "state": "hh",
+    "requestAt": "2023-04-20 07:59:32.153"
+  },
+  {
+    "subjects": "[{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "ni",
+    "requestAt": "2023-04-20 08:04:05.25"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "rp",
+    "requestAt": "2023-04-20 08:06:15.908"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":8}]",
+    "state": "sl",
+    "requestAt": "2023-04-20 08:08:32.399"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":6}]",
+    "state": "nw",
+    "requestAt": "2023-04-20 08:09:30.847"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-04-20 08:10:15.919"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "bw",
+    "requestAt": "2023-04-20 08:14:57.531"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":7},{\"name\":\"Geschichte\",\"maxGrade\":11,\"minGrade\":7},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-04-20 08:16:28.632"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-04-20 08:18:08.68"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-04-20 08:23:40.161"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2023-04-20 08:26:27.608"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-04-20 10:04:13.546"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-04-20 11:00:41.769"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":4}]",
+    "state": "nw",
+    "requestAt": "2023-04-20 12:55:45.757"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-04-20 16:37:33.477"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":6}]",
+    "state": "sh",
+    "requestAt": "2023-04-20 16:43:48.679"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-04-21 08:09:41.184"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-04-21 08:40:20.154"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "bw",
+    "requestAt": "2023-04-22 06:38:24.453"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-04-22 07:08:52.627"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "sl",
+    "requestAt": "2023-04-22 08:01:37.021"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-04-24 09:22:58.55"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":3}]",
+    "state": "nw",
+    "requestAt": "2023-04-24 10:06:47.237"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-04-24 16:19:59.818"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":6}]",
+    "state": "other",
+    "requestAt": "2023-04-24 16:24:23.714"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":9}]",
+    "state": "nw",
+    "requestAt": "2023-04-27 04:22:48.791"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-04-27 13:42:49.442"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Italienisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-04-27 13:56:16.562"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Italienisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-04-27 13:56:16.562"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "nw",
+    "requestAt": "2023-04-27 16:49:59.248"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Biologie\",\"maxGrade\":12,\"minGrade\":6},{\"name\":\"Informatik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2023-04-27 22:39:40.311"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-04-28 09:54:39.837"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "he",
+    "requestAt": "2023-04-30 06:37:04.209"
+  },
+  {
+    "subjects": "[{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9}]",
+    "state": "nw",
+    "requestAt": "2023-04-30 08:22:41.708"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "hh",
+    "requestAt": "2023-05-03 08:15:20.844"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-05-03 10:04:27.492"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "th",
+    "requestAt": "2023-05-03 14:22:17.039"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-05-04 07:36:51.356"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1}]",
+    "state": "ni",
+    "requestAt": "2023-05-05 07:47:39.542"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":6}]",
+    "state": "other",
+    "requestAt": "2023-05-05 08:26:47.562"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-05-05 09:58:52.047"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "by",
+    "requestAt": "2023-05-05 09:59:39.798"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-05-05 15:44:22.98"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "by",
+    "requestAt": "2023-05-06 08:22:53.03"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":9}]",
+    "state": "mv",
+    "requestAt": "2023-05-06 15:15:11.675"
+  },
+  {
+    "subjects": "[{\"name\":\"Altgriechisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2023-05-07 07:26:20.169"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":3},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":3}]",
+    "state": "nw",
+    "requestAt": "2023-05-08 18:49:42.209"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-05-09 06:29:45.331"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-05-09 12:13:51.691"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-05-09 12:13:51.691"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-05-09 12:13:51.691"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-05-09 12:13:51.691"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-05-09 12:13:51.691"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-05-09 12:13:54.171"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-05-09 12:13:54.171"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-05-09 12:13:54.171"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-05-09 12:13:54.171"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-05-09 12:13:54.171"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-05-09 14:35:12.697"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":7},{\"name\":\"Geschichte\",\"maxGrade\":11,\"minGrade\":7},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-05-10 08:21:25.611"
+  },
+  {
+    "subjects": "[{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":13},{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":13},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":13}]",
+    "state": "by",
+    "requestAt": "2023-05-10 11:21:38.408"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "hh",
+    "requestAt": "2023-05-10 11:59:34.461"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2023-05-10 14:17:26.451"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":4},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":2}]",
+    "state": "sn",
+    "requestAt": "2023-05-10 15:15:50.13"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":4},{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":4},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-05-11 09:17:43.894"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":4}]",
+    "state": "nw",
+    "requestAt": "2023-05-11 12:01:32.168"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":11,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2023-05-11 14:12:45.784"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":8,\"minGrade\":1}]",
+    "state": "ni",
+    "requestAt": "2023-05-11 18:32:58.649"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-05-13 15:06:47.209"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":2,\"minGrade\":1}]",
+    "state": "be",
+    "requestAt": "2023-05-13 15:21:22.753"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "ni",
+    "requestAt": "2023-05-14 08:24:39.353"
+  },
+  {
+    "subjects": "[{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":3},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":3},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":3}]",
+    "state": "nw",
+    "requestAt": "2023-05-14 21:39:45.985"
+  },
+  {
+    "subjects": "[{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":3},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":3},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":3}]",
+    "state": "nw",
+    "requestAt": "2023-05-14 21:39:45.985"
+  },
+  {
+    "subjects": "[{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":3},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":3},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":3}]",
+    "state": "nw",
+    "requestAt": "2023-05-14 21:39:45.985"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "be",
+    "requestAt": "2023-05-15 01:04:54.616"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "he",
+    "requestAt": "2023-05-15 18:07:43.394"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "ni",
+    "requestAt": "2023-05-17 09:40:44.738"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-05-17 13:42:12.812"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2023-05-17 14:28:05.097"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2023-05-17 14:28:05.097"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "bw",
+    "requestAt": "2023-05-17 14:43:17.08"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Chinesisch\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":11,\"minGrade\":5}]",
+    "state": "he",
+    "requestAt": "2023-05-18 14:52:05.216"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9}]",
+    "state": "sn",
+    "requestAt": "2023-05-18 22:09:06.165"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9}]",
+    "state": "sn",
+    "requestAt": "2023-05-18 22:09:06.165"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9}]",
+    "state": "sn",
+    "requestAt": "2023-05-18 22:09:06.165"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2023-05-19 15:58:36.415"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-05-21 08:07:25.827"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-05-21 08:28:53.299"
+  },
+  {
+    "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":7,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":7,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":7,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-05-21 17:12:23.661"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "sl",
+    "requestAt": "2023-05-25 07:49:55.421"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":12,\"minGrade\":8}]",
+    "state": "by",
+    "requestAt": "2023-05-26 16:43:51.803"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8}]",
+    "state": "be",
+    "requestAt": "2023-05-27 07:17:08.437"
+  },
+  {
+    "subjects": "[{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "by",
+    "requestAt": "2023-05-28 10:34:42.153"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":4},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":2}]",
+    "state": "sn",
+    "requestAt": "2023-05-29 17:49:47.985"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":3},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":3}]",
+    "state": "nw",
+    "requestAt": "2023-05-30 08:27:00.673"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":4}]",
+    "state": "nw",
+    "requestAt": "2023-05-30 13:19:53.334"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "sl",
+    "requestAt": "2023-05-30 21:05:14.462"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "nw",
+    "requestAt": "2023-06-01 11:47:14.367"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":2,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-06-01 14:49:38.063"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":2,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-06-01 14:49:38.063"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":2,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-06-01 14:49:38.063"
+  },
+  {
+    "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":8}]",
+    "state": "nw",
+    "requestAt": "2023-06-04 20:44:45.575"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "sl",
+    "requestAt": "2023-06-04 21:03:08.263"
+  },
+  {
+    "subjects": "[{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Französisch\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Latein\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Niederländisch\",\"maxGrade\":11,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2023-06-05 09:08:57.265"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2023-06-05 18:11:52.087"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-06-05 18:48:53.266"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-06-08 07:40:43.577"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "other",
+    "requestAt": "2023-06-08 10:20:12.331"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "he",
+    "requestAt": "2023-06-09 21:47:41.456"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "he",
+    "requestAt": "2023-06-09 21:47:41.456"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9}]",
+    "state": "sn",
+    "requestAt": "2023-06-10 22:58:02.433"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9}]",
+    "state": "sn",
+    "requestAt": "2023-06-10 22:58:02.433"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9}]",
+    "state": "sn",
+    "requestAt": "2023-06-10 22:58:02.433"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":9,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2023-06-11 17:14:04.053"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "be",
+    "requestAt": "2023-06-15 07:15:16.725"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "bw",
+    "requestAt": "2023-06-15 08:48:20.118"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-06-15 12:00:06.748"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":9,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2023-06-17 20:46:24.542"
+  },
+  {
+    "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "ni",
+    "requestAt": "2023-06-19 18:07:39.189"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-06-19 18:44:48.451"
+  },
+  {
+    "subjects": "[{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "sn",
+    "requestAt": "2023-06-19 19:12:09.848"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "ni",
+    "requestAt": "2023-06-21 19:29:13.835"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-06-22 14:08:14.76"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-06-24 07:16:59.444"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-06-24 15:05:20.039"
+  },
+  {
+    "subjects": "[{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-06-26 12:03:42.822"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-06-27 07:27:54.386"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":8,\"minGrade\":1}]",
+    "state": "ni",
+    "requestAt": "2023-06-27 08:02:23.537"
+  },
+  {
+    "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-06-27 08:09:03.754"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":11},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":11},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":11}]",
+    "state": "he",
+    "requestAt": "2023-06-27 08:14:37.554"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":11},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":11},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":11}]",
+    "state": "he",
+    "requestAt": "2023-06-27 08:14:37.554"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-06-27 08:39:39.596"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-06-27 08:39:39.596"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-06-27 09:15:33.668"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-06-27 09:36:31.86"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Russisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "sn",
+    "requestAt": "2023-06-27 10:56:13.232"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-06-27 16:45:24.542"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":2,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-06-27 21:25:56.509"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":2,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-06-27 21:25:56.509"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-07-01 15:16:31.326"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-07-02 09:37:39.906"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "nw",
+    "requestAt": "2023-07-02 11:09:31.872"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Französisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "be",
+    "requestAt": "2023-07-02 17:10:40.39"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"maxGrade\":6,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "ni",
+    "requestAt": "2023-07-02 17:52:39.863"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2023-07-03 09:06:54.522"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2023-07-03 15:15:33.768"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":4}]",
+    "state": "ni",
+    "requestAt": "2023-07-04 07:13:39.384"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-07-04 09:25:53.689"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "th",
+    "requestAt": "2023-07-04 16:11:54.309"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":12,\"minGrade\":8}]",
+    "state": "other",
+    "requestAt": "2023-07-04 20:10:36.715"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-07-05 06:28:45.455"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-07-06 07:08:27.565"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-07-06 09:57:12.572"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-07-07 10:44:52.247"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Biologie\",\"maxGrade\":12,\"minGrade\":6},{\"name\":\"Informatik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2023-07-08 10:03:01.919"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":4}]",
+    "state": "ni",
+    "requestAt": "2023-07-09 09:33:14.458"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-07-09 09:57:02.918"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "mv",
+    "requestAt": "2023-07-09 11:11:16.737"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":6},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bb",
+    "requestAt": "2023-07-10 12:02:43.58"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":2,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-07-10 13:04:16.962"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-07-10 14:00:23.208"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":7}]",
+    "state": "be",
+    "requestAt": "2023-07-11 19:00:03.526"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-07-13 15:57:20.909"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-07-14 08:24:27.235"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "be",
+    "requestAt": "2023-07-14 09:14:55.37"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-07-16 08:10:46.913"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-07-16 09:12:39.569"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-07-16 09:52:24.209"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-07-18 10:43:48.569"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-07-19 04:51:37.841"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "rp",
+    "requestAt": "2023-07-20 07:46:39.935"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "ni",
+    "requestAt": "2023-07-23 15:13:49.666"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-07-24 08:49:37.467"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":4}]",
+    "state": "ni",
+    "requestAt": "2023-07-24 20:07:49.812"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-07-26 05:14:40.654"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2023-07-26 13:41:33.922"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2023-07-26 14:17:00.665"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-07-27 07:15:30.553"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-07-27 15:22:35.325"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "rp",
+    "requestAt": "2023-07-28 13:11:27.536"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "ni",
+    "requestAt": "2023-07-29 14:17:57.823"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9}]",
+    "state": "other",
+    "requestAt": "2023-07-30 08:09:06.35"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":6}]",
+    "state": "hh",
+    "requestAt": "2023-07-30 09:54:29.287"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Französisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2023-07-31 18:26:00.606"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "bw",
+    "requestAt": "2023-08-02 13:18:12.401"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":3,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-08-02 14:21:18.407"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-08-04 09:39:47.825"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "be",
+    "requestAt": "2023-08-08 14:00:12.583"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":3,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-08-09 11:32:19.217"
+  },
+  {
+    "subjects": "[{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "he",
+    "requestAt": "2023-08-09 14:35:44.396"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "he",
+    "requestAt": "2023-08-10 07:58:51.645"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2023-08-12 17:41:31.077"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-08-13 08:40:23.767"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-08-13 09:13:47.799"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "be",
+    "requestAt": "2023-08-13 13:11:36.797"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":11},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":11}]",
+    "state": "rp",
+    "requestAt": "2023-08-13 16:44:57.175"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "nw",
+    "requestAt": "2023-08-14 08:28:45.792"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "by",
+    "requestAt": "2023-08-14 19:41:27.536"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-08-15 06:27:01.004"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-08-15 11:38:00.25"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2023-08-16 09:03:52.072"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-08-16 13:17:40.369"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-08-16 14:58:08.879"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":9,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2023-08-18 22:58:22.728"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "sn",
+    "requestAt": "2023-08-19 13:44:27.051"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "bw",
+    "requestAt": "2023-08-21 09:26:48.16"
+  },
+  {
+    "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "other",
+    "requestAt": "2023-08-21 20:08:29.402"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Russisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "sn",
+    "requestAt": "2023-08-22 12:20:45.489"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Französisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2023-08-22 17:06:05.614"
+  },
+  {
+    "subjects": "[{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-08-22 21:15:09.873"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "nw",
+    "requestAt": "2023-08-23 15:09:12.983"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-08-25 17:28:07.098"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-08-26 12:31:57.098"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "th",
+    "requestAt": "2023-08-26 15:31:32.789"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "rp",
+    "requestAt": "2023-08-27 08:07:50.94"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":6}]",
+    "state": "hh",
+    "requestAt": "2023-08-27 16:47:58.153"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2023-08-27 19:32:14.227"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2023-08-27 19:32:14.227"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":3},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":3}]",
+    "state": "nw",
+    "requestAt": "2023-08-28 10:14:52.866"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-08-29 13:27:50.457"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-08-29 13:27:50.457"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "ni",
+    "requestAt": "2023-08-29 14:44:55.605"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "sn",
+    "requestAt": "2023-08-29 18:08:36.621"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-08-29 18:47:15.732"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-08-30 13:13:33.484"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "ni",
+    "requestAt": "2023-08-31 14:39:40.886"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Chinesisch\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":11,\"minGrade\":5}]",
+    "state": "he",
+    "requestAt": "2023-09-01 15:56:30.661"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":3},{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":3},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":6}]",
+    "state": "he",
+    "requestAt": "2023-09-01 19:03:53.062"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-09-02 21:11:24.179"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-09-04 08:29:07.815"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "ni",
+    "requestAt": "2023-09-04 09:10:58.03"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "be",
+    "requestAt": "2023-09-04 14:31:38.258"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "be",
+    "requestAt": "2023-09-04 14:31:38.258"
+  },
+  {
+    "subjects": "[{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":6}]",
+    "state": "nw",
+    "requestAt": "2023-09-06 15:46:00.8"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-09-06 19:12:19.368"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":8}]",
+    "state": "nw",
+    "requestAt": "2023-09-07 08:05:30.364"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":4}]",
+    "state": "ni",
+    "requestAt": "2023-09-08 13:24:41.878"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":4}]",
+    "state": "ni",
+    "requestAt": "2023-09-08 13:24:41.878"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "nw",
+    "requestAt": "2023-09-09 21:42:59.288"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":11}]",
+    "state": "be",
+    "requestAt": "2023-09-10 08:38:16.224"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "hh",
+    "requestAt": "2023-09-10 09:37:54.489"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":3,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-09-10 15:54:19.984"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":8}]",
+    "state": "nw",
+    "requestAt": "2023-09-11 11:11:08.209"
+  },
+  {
+    "subjects": "[{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-09-11 12:14:35.217"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":8}]",
+    "state": "nw",
+    "requestAt": "2023-09-11 15:16:54.117"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":9}]",
+    "state": "bw",
+    "requestAt": "2023-09-11 20:02:49.744"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "nw",
+    "requestAt": "2023-09-11 20:19:32.254"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "sn",
+    "requestAt": "2023-09-11 21:07:31.051"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "nw",
+    "requestAt": "2023-09-11 21:10:19.391"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "sl",
+    "requestAt": "2023-09-13 06:46:03.088"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "he",
+    "requestAt": "2023-09-13 13:49:51.567"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-09-14 09:41:14.762"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-09-14 10:18:08.289"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2023-09-14 10:40:37.1"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":8}]",
+    "state": "nw",
+    "requestAt": "2023-09-14 11:17:53.478"
+  },
+  {
+    "subjects": "[{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-09-15 08:25:34.76"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "he",
+    "requestAt": "2023-09-15 13:54:14.388"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-09-15 16:49:06.23"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-09-16 10:21:22.505"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":6}]",
+    "state": "nw",
+    "requestAt": "2023-09-16 11:54:39.592"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-09-16 11:55:53.383"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-09-16 11:56:54.882"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":2},{\"name\":\"Mathematik\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":3}]",
+    "state": "nw",
+    "requestAt": "2023-09-16 12:01:58.973"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":3}]",
+    "state": "nw",
+    "requestAt": "2023-09-16 12:02:03.069"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-09-16 12:16:54.157"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":11}]",
+    "state": "ni",
+    "requestAt": "2023-09-16 14:19:10.939"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Italienisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-09-17 07:38:40.807"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2023-09-17 08:03:23.779"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Informatik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-09-17 13:42:28.454"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "sn",
+    "requestAt": "2023-09-18 13:30:16.245"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2023-09-18 14:11:28.369"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-09-18 18:45:24.59"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":8,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-09-18 18:48:26.696"
+  },
+  {
+    "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":6}]",
+    "state": "mv",
+    "requestAt": "2023-09-19 12:36:29.591"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "sl",
+    "requestAt": "2023-09-19 12:58:17.665"
+  },
+  {
+    "subjects": "[{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-09-20 14:17:36.957"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-09-21 06:12:28.604"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-09-21 07:42:26.462"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":4},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":4},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":4}]",
+    "state": "other",
+    "requestAt": "2023-09-21 10:10:15.49"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-09-21 23:11:07.254"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "ni",
+    "requestAt": "2023-09-23 08:46:45.477"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bb",
+    "requestAt": "2023-09-23 14:41:07.501"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-09-25 08:40:13.655"
+  },
+  {
+    "subjects": "[{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-09-27 15:10:41.811"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Informatik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-09-27 19:30:46.31"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Informatik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-09-27 19:30:46.31"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Informatik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-09-27 19:30:46.31"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-09-27 19:53:24.589"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2023-09-28 14:08:40.61"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-09-28 15:57:14.55"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bb",
+    "requestAt": "2023-09-28 19:13:44.083"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-10-01 14:38:03.291"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "be",
+    "requestAt": "2023-10-02 12:51:33.164"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "ni",
+    "requestAt": "2023-10-02 15:45:57.628"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "he",
+    "requestAt": "2023-10-02 18:54:06.429"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "he",
+    "requestAt": "2023-10-02 18:54:06.429"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "he",
+    "requestAt": "2023-10-02 18:54:06.429"
+  },
+  {
+    "subjects": "[{\"name\":\"Chinesisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-10-03 07:41:20.47"
+  },
+  {
+    "subjects": "[{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":6}]",
+    "state": "nw",
+    "requestAt": "2023-10-04 20:34:22.226"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":8,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-10-05 09:01:21.814"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":6}]",
+    "state": "he",
+    "requestAt": "2023-10-05 15:55:49.88"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":9}]",
+    "state": "sn",
+    "requestAt": "2023-10-05 16:16:04.828"
+  },
+  {
+    "subjects": "[{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-10-06 13:57:08.973"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "be",
+    "requestAt": "2023-10-06 14:10:29.81"
+  },
+  {
+    "subjects": "[{\"name\":\"Politik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Italienisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-10-09 17:06:27.685"
+  },
+  {
+    "subjects": "[{\"name\":\"Politik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Italienisch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":8,\"minGrade\":1}]",
+    "state": "he",
+    "requestAt": "2023-10-09 17:06:54.709"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-10-10 17:17:09.259"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "be",
+    "requestAt": "2023-10-11 08:36:00.394"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "be",
+    "requestAt": "2023-10-11 08:36:00.394"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "be",
+    "requestAt": "2023-10-11 08:36:00.394"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "be",
+    "requestAt": "2023-10-11 08:36:00.394"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "be",
+    "requestAt": "2023-10-11 08:36:00.394"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-10-12 06:26:27.018"
+  },
+  {
+    "subjects": "[{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "nw",
+    "requestAt": "2023-10-12 07:30:50.345"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "he",
+    "requestAt": "2023-10-12 08:18:26.281"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-10-12 09:53:19.153"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-10-12 15:48:20.679"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-10-13 08:46:37.624"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Altgriechisch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2023-10-13 19:51:02.901"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-10-15 15:05:22.492"
+  },
+  {
+    "subjects": "[{\"name\":\"Kunst\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1}]",
+    "state": "be",
+    "requestAt": "2023-10-15 17:44:17.652"
+  },
+  {
+    "subjects": "[{\"name\":\"Kunst\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1}]",
+    "state": "be",
+    "requestAt": "2023-10-15 17:44:17.652"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-10-16 09:45:03.021"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "sl",
+    "requestAt": "2023-10-16 13:55:38.913"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":9,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2023-10-16 16:02:26.461"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Russisch\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2023-10-16 16:33:39.6"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "sh",
+    "requestAt": "2023-10-16 20:16:33.237"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2023-10-17 11:29:41.174"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-10-17 23:32:24.287"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-10-18 07:12:03.795"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-10-18 07:39:45.351"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "ni",
+    "requestAt": "2023-10-18 09:12:35.817"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-10-18 13:21:21.541"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-10-18 14:03:24.115"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-10-20 17:09:13.12"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-10-20 17:09:13.12"
+  },
+  {
+    "subjects": "[{\"name\":\"Politik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Italienisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-10-22 14:58:19.483"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-10-23 17:22:43.446"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2023-10-24 06:27:38.631"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-10-24 07:08:00.917"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":5}]",
+    "state": "sn",
+    "requestAt": "2023-10-25 09:40:39.251"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "sn",
+    "requestAt": "2023-10-25 11:41:53.219"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "sn",
+    "requestAt": "2023-10-25 13:03:27.042"
+  },
+  {
+    "subjects": "[{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-10-25 13:13:45.329"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":6}]",
+    "state": "he",
+    "requestAt": "2023-10-25 17:03:14.533"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "bw",
+    "requestAt": "2023-10-25 17:54:13.632"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-10-26 08:28:54.17"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":3,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-10-26 10:54:43.251"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-10-27 07:40:23.018"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-10-28 11:18:35.988"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "by",
+    "requestAt": "2023-10-28 17:06:49.479"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-10-29 14:47:52.449"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "sl",
+    "requestAt": "2023-10-29 15:09:13.602"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "sl",
+    "requestAt": "2023-10-29 15:09:13.602"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "sl",
+    "requestAt": "2023-10-29 15:09:13.602"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-10-29 15:44:33.43"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-10-30 12:35:29.811"
+  },
+  {
+    "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":6},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":3},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":11},{\"name\":\"Italienisch\",\"maxGrade\":12,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-10-31 08:36:44.915"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":7}]",
+    "state": "nw",
+    "requestAt": "2023-10-31 09:04:13.158"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "ni",
+    "requestAt": "2023-10-31 16:40:19.421"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "st",
+    "requestAt": "2023-11-01 09:12:16.555"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "bw",
+    "requestAt": "2023-11-01 09:41:04.551"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-11-02 09:26:26.404"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-11-03 08:15:05.306"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2023-11-03 09:49:25.939"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "rp",
+    "requestAt": "2023-11-03 15:27:53.258"
+  },
+  {
+    "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-11-03 15:46:12.55"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "bw",
+    "requestAt": "2023-11-03 16:13:24.06"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-03 21:49:54.878"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-03 21:49:54.878"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":8}]",
+    "state": "nw",
+    "requestAt": "2023-11-04 07:15:30.318"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":2,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-04 07:22:03.068"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-04 08:11:55.017"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":4}]",
+    "state": "by",
+    "requestAt": "2023-11-04 08:34:04.813"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2023-11-04 09:15:17.528"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-04 09:36:27.49"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-04 09:48:59.895"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-11-04 10:18:52.255"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":3,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Pädagogik\",\"maxGrade\":10,\"minGrade\":8},{\"name\":\"Erdkunde\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":5,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-04 10:26:37.041"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-04 10:51:29.775"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2023-11-04 11:56:59.346"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-04 12:12:40.809"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":8,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-11-04 12:14:00.286"
+  },
+  {
+    "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":2,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-04 13:05:36.469"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-04 22:03:55.448"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-05 09:40:10.832"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2023-11-05 13:49:27.705"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-05 14:24:47.613"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-05 17:07:12.318"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":12,\"minGrade\":6},{\"name\":\"Religion\",\"maxGrade\":12,\"minGrade\":6}]",
+    "state": "by",
+    "requestAt": "2023-11-05 18:08:41.937"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-05 19:03:04.215"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2023-11-05 22:39:21.555"
+  },
+  {
+    "subjects": "[{\"name\":\"Religion\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-06 09:05:54.095"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "be",
+    "requestAt": "2023-11-06 14:41:27.442"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Sachkunde\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-06 18:16:51.816"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-06 19:27:26.367"
+  },
+  {
+    "subjects": "[{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-07 08:13:56.969"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "by",
+    "requestAt": "2023-11-07 09:47:30.237"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "nw",
+    "requestAt": "2023-11-07 13:37:37.799"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8}]",
+    "state": "nw",
+    "requestAt": "2023-11-07 14:56:43.494"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-07 17:41:45.473"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-07 20:41:47.878"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-07 20:41:47.878"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Italienisch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-07 20:41:50.984"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-08 09:14:37.212"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "he",
+    "requestAt": "2023-11-08 16:26:30.695"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "he",
+    "requestAt": "2023-11-08 16:26:30.695"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2023-11-09 08:08:49.271"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2023-11-09 08:08:49.271"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-09 08:11:14.751"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-09 08:11:14.751"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-09 08:11:14.751"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-09 10:27:27.382"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-09 13:20:47.266"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-09 13:21:20.299"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-09 13:21:20.299"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "sn",
+    "requestAt": "2023-11-10 10:46:21.217"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":12,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-11-10 10:56:47.685"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-11-10 11:35:52.683"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":4},{\"name\":\"Wirtschaft\",\"maxGrade\":12,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":7},{\"name\":\"Informatik\",\"maxGrade\":11,\"minGrade\":7}]",
+    "state": "he",
+    "requestAt": "2023-11-10 13:06:05.593"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":8}]",
+    "state": "nw",
+    "requestAt": "2023-11-10 16:41:54.74"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-10 18:50:40.417"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-11 14:53:27.2"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-11 15:23:59.192"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-12 21:41:09.788"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":13},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":13}]",
+    "state": "nw",
+    "requestAt": "2023-11-13 20:24:57.338"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":4},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":4},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":4}]",
+    "state": "other",
+    "requestAt": "2023-11-13 21:42:22.238"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-13 23:44:02.573"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":4}]",
+    "state": "by",
+    "requestAt": "2023-11-14 09:36:43.562"
+  },
+  {
+    "subjects": "[{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":3},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":3},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":3}]",
+    "state": "nw",
+    "requestAt": "2023-11-14 09:45:02.18"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-14 10:46:21.306"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2023-11-14 11:19:20.282"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2023-11-14 11:19:20.282"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1}]",
+    "state": "he",
+    "requestAt": "2023-11-14 12:39:59.679"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-14 13:27:28.145"
+  },
+  {
+    "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "hh",
+    "requestAt": "2023-11-14 16:57:38.493"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-11-14 18:46:32.662"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":4},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":4},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":4}]",
+    "state": "other",
+    "requestAt": "2023-11-15 08:48:27.143"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-16 05:02:54.655"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-16 05:02:54.655"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-16 10:52:58.636"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-11-16 16:49:49.641"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-11-17 10:41:49.458"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "ni",
+    "requestAt": "2023-11-17 16:18:33.206"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-18 06:27:45.13"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":13},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":13}]",
+    "state": "nw",
+    "requestAt": "2023-11-18 09:59:14.294"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Russisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":3,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":5,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-18 14:57:55.266"
+  },
+  {
+    "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "hh",
+    "requestAt": "2023-11-18 16:40:25.614"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-19 19:53:18.422"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":12,\"minGrade\":6},{\"name\":\"Religion\",\"maxGrade\":12,\"minGrade\":6}]",
+    "state": "by",
+    "requestAt": "2023-11-20 05:52:52.131"
+  },
+  {
+    "subjects": "[{\"name\":\"Kunst\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-20 09:37:56.367"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":4},{\"name\":\"Wirtschaft\",\"maxGrade\":12,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":7},{\"name\":\"Informatik\",\"maxGrade\":11,\"minGrade\":7}]",
+    "state": "he",
+    "requestAt": "2023-11-20 16:31:02.471"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2023-11-21 14:13:12.854"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "sn",
+    "requestAt": "2023-11-21 18:02:05.585"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "sn",
+    "requestAt": "2023-11-21 18:02:05.585"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":4}]",
+    "state": "by",
+    "requestAt": "2023-11-22 07:42:33.388"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-11-22 08:24:42.172"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-11-22 08:24:42.172"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":9}]",
+    "state": "mv",
+    "requestAt": "2023-11-22 14:33:57.263"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-11-22 16:41:42.423"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-11-22 16:41:42.423"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-11-22 16:41:42.423"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2023-11-23 07:58:20.654"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-23 09:28:46.82"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-23 13:28:13.178"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-23 13:28:13.178"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-23 13:28:13.178"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "be",
+    "requestAt": "2023-11-23 18:20:23.396"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-23 22:13:21.684"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-23 22:13:21.684"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-23 22:13:21.684"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-23 22:13:21.684"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8}]",
+    "state": "nw",
+    "requestAt": "2023-11-24 11:09:27.938"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Russisch\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2023-11-24 11:35:29.885"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-11-24 15:07:09.389"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-11-24 15:07:09.389"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "be",
+    "requestAt": "2023-11-24 18:12:25.174"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-25 16:59:59.779"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-25 16:59:59.779"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-25 16:59:59.779"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-25 16:59:59.779"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":14,\"minGrade\":9}]",
+    "state": "ni",
+    "requestAt": "2023-11-26 08:42:24.929"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":14,\"minGrade\":9}]",
+    "state": "ni",
+    "requestAt": "2023-11-26 12:28:30.865"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":4}]",
+    "state": "by",
+    "requestAt": "2023-11-27 11:58:23.976"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Russisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":3,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":5,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-27 14:25:07.938"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Russisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":3,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":5,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-27 14:25:07.938"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-11-27 16:03:26.489"
+  },
+  {
+    "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Französisch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-27 19:27:54.298"
+  },
+  {
+    "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Französisch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-27 19:27:54.298"
+  },
+  {
+    "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Französisch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-27 19:27:54.298"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-28 18:04:26.496"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-29 12:26:13.696"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-29 12:26:13.696"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-29 12:26:13.696"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "hb",
+    "requestAt": "2023-11-29 13:47:35.637"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-11-29 20:48:38.121"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-29 20:56:08.712"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-11-30 14:47:30.317"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-11-30 14:58:22.79"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-12-02 12:45:40.439"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-12-03 08:04:27.889"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-12-04 14:58:24.744"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-12-04 15:11:45.84"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-12-04 15:11:45.84"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":3,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-12-04 18:25:00.538"
+  },
+  {
+    "subjects": "[{\"name\":\"Physik\",\"maxGrade\":11,\"minGrade\":10},{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":10}]",
+    "state": "ni",
+    "requestAt": "2023-12-05 08:09:55.093"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-12-05 21:21:15.329"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "ni",
+    "requestAt": "2023-12-06 13:30:46.685"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":12,\"minGrade\":8}]",
+    "state": "other",
+    "requestAt": "2023-12-06 14:30:11.84"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "by",
+    "requestAt": "2023-12-06 17:25:53.568"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-12-07 08:07:58.323"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"maxGrade\":11,\"minGrade\":5}]",
+    "state": "ni",
+    "requestAt": "2023-12-07 08:28:17.083"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":11}]",
+    "state": "be",
+    "requestAt": "2023-12-07 17:07:10.966"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2023-12-07 17:46:53.348"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2023-12-07 17:46:53.348"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-12-07 18:08:20.43"
+  },
+  {
+    "subjects": "[{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "rp",
+    "requestAt": "2023-12-07 18:58:20.524"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-12-08 10:20:59.265"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-12-10 08:09:49.671"
+  },
+  {
+    "subjects": "[{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "hh",
+    "requestAt": "2023-12-10 09:59:01.904"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-12-10 22:27:04.397"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "ni",
+    "requestAt": "2023-12-12 17:13:13.527"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2023-12-12 20:01:05.097"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-12-13 13:02:30.28"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-12-13 20:19:37.336"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-12-14 09:28:17.24"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":3},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":3}]",
+    "state": "nw",
+    "requestAt": "2023-12-14 15:00:46.357"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-12-15 10:25:06.357"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-12-15 10:25:06.357"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-12-15 10:25:06.357"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8}]",
+    "state": "ni",
+    "requestAt": "2023-12-18 15:34:19.388"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "nw",
+    "requestAt": "2023-12-18 17:54:39.295"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2023-12-19 10:12:48.937"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-12-19 10:39:45.261"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-12-19 14:51:20.333"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":4}]",
+    "state": "by",
+    "requestAt": "2023-12-20 10:44:00.589"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2023-12-20 11:33:38.476"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "sl",
+    "requestAt": "2023-12-21 16:40:31.821"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "st",
+    "requestAt": "2023-12-22 22:20:10.426"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2023-12-24 15:29:37.884"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2023-12-27 23:24:41.891"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-12-29 16:40:56.583"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2023-12-29 16:40:56.583"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-01-01 15:47:26.755"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8}]",
+    "state": "nw",
+    "requestAt": "2024-01-02 11:29:27.064"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8}]",
+    "state": "nw",
+    "requestAt": "2024-01-02 11:29:27.064"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-01-03 14:18:46.27"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":11}]",
+    "state": "bw",
+    "requestAt": "2024-01-04 17:52:33.611"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "sn",
+    "requestAt": "2024-01-04 19:04:56.057"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "sn",
+    "requestAt": "2024-01-04 19:04:56.057"
+  },
+  {
+    "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":8}]",
+    "state": "nw",
+    "requestAt": "2024-01-05 12:12:22.414"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2024-01-06 22:34:33.653"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-01-07 19:16:56.967"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-01-08 16:19:41.225"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-01-08 16:31:03.257"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2024-01-08 17:50:26.265"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-01-08 19:54:18.601"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1}]",
+    "state": "he",
+    "requestAt": "2024-01-08 22:27:30.376"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-01-09 10:05:10.989"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-01-10 14:15:26.982"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-01-10 14:15:26.982"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-01-10 14:15:26.982"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "be",
+    "requestAt": "2024-01-10 14:52:41.697"
+  },
+  {
+    "subjects": "[{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-01-10 18:17:22"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2024-01-10 19:29:22.252"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":8,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-01-11 09:46:16.95"
+  },
+  {
+    "subjects": "[{\"name\":\"Wirtschaft\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2024-01-11 16:09:45.113"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-01-11 18:50:43.031"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Spanisch\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Wirtschaft\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Politik\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Philosophie\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Französisch\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Erdkunde\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Lernen lernen\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Sachkunde\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Italienisch\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":9,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-01-12 09:18:18.662"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-01-12 09:43:26.78"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-01-12 10:35:47.079"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2024-01-12 21:24:26.895"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2024-01-13 13:54:07.852"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-01-15 10:49:14.222"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "nw",
+    "requestAt": "2024-01-18 16:56:04.106"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":8}]",
+    "state": "sh",
+    "requestAt": "2024-01-18 17:48:20.927"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Erdkunde\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2024-01-18 19:37:07.989"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2024-01-19 10:29:08.373"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2024-01-19 10:29:08.373"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-01-19 10:38:23.045"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "hh",
+    "requestAt": "2024-01-19 11:21:02.783"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Spanisch\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2024-01-19 16:23:44.163"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-01-20 08:21:57.059"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":8}]",
+    "state": "nw",
+    "requestAt": "2024-01-20 08:54:48.223"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":7}]",
+    "state": "nw",
+    "requestAt": "2024-01-20 14:32:54.527"
+  },
+  {
+    "subjects": "[{\"name\":\"Erdkunde\",\"maxGrade\":10,\"minGrade\":8},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Religion\",\"maxGrade\":9,\"minGrade\":8}]",
+    "state": "hh",
+    "requestAt": "2024-01-20 16:41:28.092"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-01-20 17:42:06.815"
+  },
+  {
+    "subjects": "[{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2024-01-21 09:07:50.939"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2024-01-21 15:40:05.093"
+  },
+  {
+    "subjects": "[{\"name\":\"Erdkunde\",\"maxGrade\":10,\"minGrade\":8},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Religion\",\"maxGrade\":9,\"minGrade\":8}]",
+    "state": "hh",
+    "requestAt": "2024-01-22 14:09:00.012"
+  },
+  {
+    "subjects": "[{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":6}]",
+    "state": "other",
+    "requestAt": "2024-01-23 18:42:48.056"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2024-01-24 07:27:24.38"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-01-24 12:38:38.227"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":3}]",
+    "state": "bw",
+    "requestAt": "2024-01-25 08:09:17.35"
+  },
+  {
+    "subjects": "[{\"name\":\"Erdkunde\",\"maxGrade\":10,\"minGrade\":8},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Religion\",\"maxGrade\":9,\"minGrade\":8}]",
+    "state": "hh",
+    "requestAt": "2024-01-25 17:58:34.467"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-01-26 08:43:44.304"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-01-26 09:04:56.318"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-01-26 11:37:09.006"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2024-01-26 15:10:08.126"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2024-01-26 17:10:16.4"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2024-01-26 18:27:01.319"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":3},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":3},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":8,\"minGrade\":3},{\"name\":\"Französisch\",\"maxGrade\":8,\"minGrade\":3}]",
+    "state": "by",
+    "requestAt": "2024-01-27 14:01:38.439"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":6}]",
+    "state": "by",
+    "requestAt": "2024-01-27 14:13:40.385"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2024-01-28 21:16:30.725"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-01-30 08:07:09.287"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-02-01 09:27:17.989"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-02-01 09:27:17.989"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-02-01 09:27:17.989"
+  },
+  {
+    "subjects": "[{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "hh",
+    "requestAt": "2024-02-01 17:29:20.603"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"maxGrade\":11,\"minGrade\":5}]",
+    "state": "ni",
+    "requestAt": "2024-02-01 18:25:45.72"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "th",
+    "requestAt": "2024-02-02 09:23:24.698"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":8}]",
+    "state": "he",
+    "requestAt": "2024-02-02 09:51:34.723"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-02-02 16:00:16.457"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Spanisch\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2024-02-02 20:47:29.502"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "bb",
+    "requestAt": "2024-02-04 18:10:26.429"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "bb",
+    "requestAt": "2024-02-04 18:10:26.429"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "be",
+    "requestAt": "2024-02-05 00:39:51.06"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-02-05 11:41:56.017"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Spanisch\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Wirtschaft\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Politik\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Philosophie\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Französisch\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Erdkunde\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Lernen lernen\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Sachkunde\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Italienisch\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":9,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-02-05 13:37:27.7"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Spanisch\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Wirtschaft\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Politik\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Philosophie\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Französisch\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Erdkunde\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Lernen lernen\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Sachkunde\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Italienisch\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":9,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-02-05 13:37:27.7"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "sn",
+    "requestAt": "2024-02-05 15:41:37.649"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-02-06 17:09:35.686"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":8,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-02-06 19:51:45.401"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-02-07 09:24:02.014"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-02-07 09:24:02.014"
+  },
+  {
+    "subjects": "[{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":3},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":3},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":3}]",
+    "state": "nw",
+    "requestAt": "2024-02-07 13:34:16.968"
+  },
+  {
+    "subjects": "[{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":3},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":3},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":3}]",
+    "state": "nw",
+    "requestAt": "2024-02-07 13:34:16.968"
+  },
+  {
+    "subjects": "[{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Russisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-02-07 17:46:10.096"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2024-02-08 21:30:28.61"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-02-09 09:49:35.259"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Technik\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "rp",
+    "requestAt": "2024-02-09 18:17:22.537"
+  },
+  {
+    "subjects": "[{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-02-10 11:33:03.793"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":12,\"minGrade\":8},{\"name\":\"Englisch\",\"maxGrade\":12,\"minGrade\":8},{\"name\":\"Kunst\",\"maxGrade\":12,\"minGrade\":8}]",
+    "state": "bw",
+    "requestAt": "2024-02-10 11:33:22.324"
+  },
+  {
+    "subjects": "[{\"name\":\"Musik\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":5,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2024-02-10 11:33:30.822"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "hh",
+    "requestAt": "2024-02-10 11:34:00.851"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":4}]",
+    "state": "nw",
+    "requestAt": "2024-02-10 11:34:06.717"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Italienisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "ni",
+    "requestAt": "2024-02-10 11:34:13.086"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Sachkunde\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-02-12 15:24:58.798"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Sachkunde\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-02-12 15:24:58.798"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "other",
+    "requestAt": "2024-02-12 16:15:01.486"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-02-13 11:07:30.184"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Biologie\",\"maxGrade\":12,\"minGrade\":6},{\"name\":\"Informatik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2024-02-13 16:50:55.421"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Biologie\",\"maxGrade\":12,\"minGrade\":6},{\"name\":\"Informatik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2024-02-13 16:50:55.421"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":6}]",
+    "state": "other",
+    "requestAt": "2024-02-13 18:44:57.852"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "sn",
+    "requestAt": "2024-02-14 14:46:18.275"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2024-02-15 11:50:42.648"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-02-15 11:52:38.259"
+  },
+  {
+    "subjects": "[{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "th",
+    "requestAt": "2024-02-15 13:48:00.494"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-02-15 18:57:58.368"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-02-16 07:07:39.473"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-02-16 13:32:55.936"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2024-02-16 14:47:55.408"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bb",
+    "requestAt": "2024-02-17 17:27:57.458"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2024-02-17 19:25:42.294"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-02-19 13:59:36.89"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-02-19 13:59:36.89"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-02-19 13:59:36.89"
+  },
+  {
+    "subjects": "[{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2024-02-19 17:41:28.384"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "sn",
+    "requestAt": "2024-02-19 18:00:29.539"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":1}]",
+    "state": "he",
+    "requestAt": "2024-02-20 09:42:33.782"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-02-20 09:52:27.774"
+  },
+  {
+    "subjects": "[{\"name\":\"Spanisch\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-02-20 12:24:39.933"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-02-20 13:05:23.863"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "rp",
+    "requestAt": "2024-02-20 14:18:23.409"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-02-20 14:48:59.464"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "he",
+    "requestAt": "2024-02-20 15:46:57.697"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-02-20 15:51:14.673"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-02-21 12:15:30.201"
+  },
+  {
+    "subjects": "[{\"name\":\"Kunst\",\"maxGrade\":12,\"minGrade\":3},{\"name\":\"Philosophie\",\"maxGrade\":12,\"minGrade\":3},{\"name\":\"Englisch\",\"maxGrade\":11,\"minGrade\":3},{\"name\":\"Pädagogik\",\"maxGrade\":12,\"minGrade\":3},{\"name\":\"Religion\",\"maxGrade\":12,\"minGrade\":3},{\"name\":\"Lernen lernen\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":12,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-02-21 14:38:36.013"
+  },
+  {
+    "subjects": "[{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Russisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-02-21 15:52:12.696"
+  },
+  {
+    "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Französisch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-02-22 12:22:25.188"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "ni",
+    "requestAt": "2024-02-23 10:05:14.983"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-02-23 12:10:13.479"
+  },
+  {
+    "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Französisch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-02-23 20:34:12.556"
+  },
+  {
+    "subjects": "[{\"name\":\"Wirtschaft\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "sn",
+    "requestAt": "2024-02-24 08:32:52.587"
+  },
+  {
+    "subjects": "[{\"name\":\"Lernen lernen\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "rp",
+    "requestAt": "2024-02-25 10:52:49.027"
+  },
+  {
+    "subjects": "[{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":4},{\"name\":\"Religion\",\"maxGrade\":10,\"minGrade\":4},{\"name\":\"Deutsch\",\"maxGrade\":5,\"minGrade\":4}]",
+    "state": "other",
+    "requestAt": "2024-02-26 17:40:50.642"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":3,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2024-02-26 20:03:17.323"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":3,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2024-02-26 20:03:17.323"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "rp",
+    "requestAt": "2024-02-27 09:04:47.626"
+  },
+  {
+    "subjects": "[{\"name\":\"Lernen lernen\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "rp",
+    "requestAt": "2024-02-27 19:30:34.893"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-02-28 15:13:53.938"
+  },
+  {
+    "subjects": "[{\"name\":\"Kunst\",\"maxGrade\":12,\"minGrade\":3},{\"name\":\"Philosophie\",\"maxGrade\":12,\"minGrade\":3},{\"name\":\"Englisch\",\"maxGrade\":11,\"minGrade\":3},{\"name\":\"Pädagogik\",\"maxGrade\":12,\"minGrade\":3},{\"name\":\"Religion\",\"maxGrade\":12,\"minGrade\":3},{\"name\":\"Lernen lernen\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":12,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-02-29 15:50:37.036"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "bw",
+    "requestAt": "2024-03-01 08:29:07.987"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-03-01 09:24:41.297"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "rp",
+    "requestAt": "2024-03-01 09:52:27.551"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2024-03-03 12:51:38.332"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-03-04 12:08:25.175"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-03-04 12:47:03.519"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "bw",
+    "requestAt": "2024-03-04 13:34:26.104"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-03-04 13:51:21.152"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2024-03-04 14:18:28.685"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":13},{\"name\":\"Kunst\",\"maxGrade\":14,\"minGrade\":13},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":13},{\"name\":\"Pädagogik\",\"maxGrade\":14,\"minGrade\":13},{\"name\":\"Gesundheit\",\"maxGrade\":14,\"minGrade\":13}]",
+    "state": "other",
+    "requestAt": "2024-03-04 16:47:34.661"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2024-03-05 12:42:59.66"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-03-05 15:10:53.254"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "be",
+    "requestAt": "2024-03-05 17:32:16.901"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2024-03-07 04:51:33.57"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "rp",
+    "requestAt": "2024-03-07 12:23:34.27"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bb",
+    "requestAt": "2024-03-07 13:21:42.909"
+  },
+  {
+    "subjects": "[{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "th",
+    "requestAt": "2024-03-07 16:43:59.706"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9}]",
+    "state": "by",
+    "requestAt": "2024-03-07 19:30:57.712"
+  },
+  {
+    "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "hh",
+    "requestAt": "2024-03-08 09:18:28.499"
+  },
+  {
+    "subjects": "[{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2024-03-08 10:19:25.074"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-03-08 13:43:50.714"
+  },
+  {
+    "subjects": "[{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2024-03-08 15:03:20.536"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-03-08 16:12:31.357"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":2},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":4,\"minGrade\":2},{\"name\":\"Englisch\",\"maxGrade\":4,\"minGrade\":2},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":2}]",
+    "state": "ch",
+    "requestAt": "2024-03-08 16:44:51.947"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Biologie\",\"maxGrade\":12,\"minGrade\":6},{\"name\":\"Informatik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2024-03-08 18:09:53.382"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-03-08 18:53:20.297"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Technik\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "rp",
+    "requestAt": "2024-03-09 11:25:31.802"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "ni",
+    "requestAt": "2024-03-09 13:15:09.239"
+  },
+  {
+    "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "hh",
+    "requestAt": "2024-03-09 16:10:14.089"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-03-11 17:25:29.413"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":9}]",
+    "state": "other",
+    "requestAt": "2024-03-11 17:42:17.914"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2024-03-13 12:14:31.172"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2024-03-13 15:09:53.816"
+  },
+  {
+    "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "hh",
+    "requestAt": "2024-03-14 07:48:33.532"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-03-14 13:13:09.867"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Niederländisch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "other",
+    "requestAt": "2024-03-14 13:52:34.205"
+  },
+  {
+    "subjects": "[{\"name\":\"Lernen lernen\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "rp",
+    "requestAt": "2024-03-14 17:53:38.678"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":12,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-03-15 11:35:39.998"
+  },
+  {
+    "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Altgriechisch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "sn",
+    "requestAt": "2024-03-15 16:17:16.904"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-03-15 16:41:54.261"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-03-15 17:27:50.927"
+  },
+  {
+    "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Altgriechisch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "sn",
+    "requestAt": "2024-03-16 15:15:34.424"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-03-18 12:28:42.403"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":11,\"minGrade\":5}]",
+    "state": "bw",
+    "requestAt": "2024-03-18 19:27:39.989"
+  },
+  {
+    "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-03-19 14:16:14.587"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"maxGrade\":11,\"minGrade\":5}]",
+    "state": "ni",
+    "requestAt": "2024-03-19 16:21:47.584"
+  },
+  {
+    "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":4},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":4},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":4},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":4},{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":4},{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":4},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":4}]",
+    "state": "be",
+    "requestAt": "2024-03-19 18:14:49.84"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Lernen lernen\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2024-03-19 19:44:11.532"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-03-19 20:17:06.285"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2024-03-20 22:19:59.277"
+  },
+  {
+    "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2024-03-21 10:27:20.644"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "bb",
+    "requestAt": "2024-03-21 13:39:11.356"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "be",
+    "requestAt": "2024-03-21 19:31:57.284"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-03-22 14:47:02.844"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-03-22 15:48:21.855"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-03-22 17:13:13.318"
+  },
+  {
+    "subjects": "[{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":2},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-03-22 20:34:21.501"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "other",
+    "requestAt": "2024-03-24 13:01:39.785"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":11},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":11}]",
+    "state": "rp",
+    "requestAt": "2024-03-24 18:15:03.872"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Latein\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-03-25 17:50:57.181"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "bb",
+    "requestAt": "2024-03-25 19:05:53.246"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-03-26 14:42:37.951"
+  },
+  {
+    "subjects": "[{\"name\":\"Physik\",\"maxGrade\":11,\"minGrade\":10},{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":10}]",
+    "state": "ni",
+    "requestAt": "2024-03-26 18:53:23.571"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-03-27 19:35:33.273"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-03-28 10:19:33.312"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2024-03-28 10:39:12.348"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":11},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":11}]",
+    "state": "other",
+    "requestAt": "2024-03-28 12:42:23.626"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-03-28 17:04:01.553"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-03-28 17:33:37.221"
+  },
+  {
+    "subjects": "[{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2024-03-28 18:06:56.584"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-03-28 20:37:06.503"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2024-03-28 20:50:25.733"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2024-03-28 20:50:25.733"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":4},{\"name\":\"Politik\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-03-29 12:59:31.669"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-04-01 16:06:02.17"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":11}]",
+    "state": "nw",
+    "requestAt": "2024-04-01 20:59:50.749"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "other",
+    "requestAt": "2024-04-02 12:56:53.519"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":8}]",
+    "state": "by",
+    "requestAt": "2024-04-02 13:18:42.885"
+  },
+  {
+    "subjects": "[{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2024-04-02 16:48:51.725"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Chinesisch\",\"maxGrade\":13,\"minGrade\":9}]",
+    "state": "other",
+    "requestAt": "2024-04-03 09:43:34.618"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-03 16:19:33.628"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-03 16:49:16.314"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "he",
+    "requestAt": "2024-04-03 20:41:21.938"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-04 00:58:42.774"
+  },
+  {
+    "subjects": "[{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":2}]",
+    "state": "other",
+    "requestAt": "2024-04-04 18:31:19.42"
+  },
+  {
+    "subjects": "[{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":2}]",
+    "state": "other",
+    "requestAt": "2024-04-04 18:31:19.42"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-04-05 08:55:22.971"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-05 09:47:37.233"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Erdkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2024-04-05 15:47:08.362"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":6}]",
+    "state": "ni",
+    "requestAt": "2024-04-05 16:20:11.692"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-05 22:45:00.669"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":5,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-06 17:35:05.485"
+  },
+  {
+    "subjects": "[{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":2}]",
+    "state": "other",
+    "requestAt": "2024-04-07 07:48:47.007"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":6}]",
+    "state": "other",
+    "requestAt": "2024-04-09 07:50:33.869"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-04-09 08:14:39.073"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":3},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":3}]",
+    "state": "nw",
+    "requestAt": "2024-04-09 09:58:16.377"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-09 12:48:30.441"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-09 13:19:55.703"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-04-09 20:55:30.519"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-04-10 06:48:39.263"
+  },
+  {
+    "subjects": "[{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":2}]",
+    "state": "other",
+    "requestAt": "2024-04-10 18:13:07.716"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "by",
+    "requestAt": "2024-04-11 11:21:43.327"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":7}]",
+    "state": "other",
+    "requestAt": "2024-04-12 08:17:08.618"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":7}]",
+    "state": "other",
+    "requestAt": "2024-04-12 08:34:43.078"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "ni",
+    "requestAt": "2024-04-12 11:52:47.896"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-12 12:01:49.608"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-12 16:17:54.622"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-13 09:38:54.086"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-13 09:38:54.086"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-04-13 09:39:52.128"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-04-13 09:39:52.128"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-04-13 09:39:52.128"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-04-13 09:39:52.128"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-04-13 09:39:52.128"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-13 09:40:11.522"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-13 09:40:11.522"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-13 09:40:11.522"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":10}]",
+    "state": "other",
+    "requestAt": "2024-04-13 09:40:37.891"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":10}]",
+    "state": "other",
+    "requestAt": "2024-04-13 09:40:37.891"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":10}]",
+    "state": "other",
+    "requestAt": "2024-04-13 09:40:37.891"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":10}]",
+    "state": "other",
+    "requestAt": "2024-04-13 09:40:37.891"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":10}]",
+    "state": "other",
+    "requestAt": "2024-04-13 09:40:37.891"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":10}]",
+    "state": "other",
+    "requestAt": "2024-04-13 09:40:37.891"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-13 09:41:19.829"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-13 09:42:41.801"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-13 09:42:41.801"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-13 09:42:41.801"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-13 09:44:10.256"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-13 09:44:10.256"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-13 09:44:10.256"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-13 09:44:46.458"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-13 09:44:46.458"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-13 09:44:46.458"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-04-13 13:51:50.992"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-04-13 13:51:50.992"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-04-13 14:32:16.51"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-13 14:32:35.894"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-13 14:35:44.958"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-13 14:35:44.958"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-13 14:35:44.958"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-04-13 14:36:09.984"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-04-13 14:36:09.984"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-04-13 14:36:09.984"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-13 22:23:17.924"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-14 08:03:54.66"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-14 08:03:54.66"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-14 08:03:54.66"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-04-14 14:21:05.074"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-04-14 14:41:31.157"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-15 03:15:50.867"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-15 03:15:50.867"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-15 03:15:50.867"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-15 11:01:14.035"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-04-15 12:51:10.52"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-04-15 12:51:10.52"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-04-15 12:51:10.52"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "be",
+    "requestAt": "2024-04-15 15:15:16.392"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":8}]",
+    "state": "by",
+    "requestAt": "2024-04-15 15:42:20.164"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-16 07:28:31.012"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-04-16 11:53:47.384"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-04-16 11:53:47.384"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-04-16 11:53:47.384"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-04-16 12:34:47.342"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-04-16 12:34:47.342"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2024-04-16 14:25:00.394"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-16 17:20:32.729"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-16 17:20:32.729"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-17 15:58:22.747"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-17 15:58:22.747"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2024-04-17 20:01:15.494"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "other",
+    "requestAt": "2024-04-18 19:47:29.199"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Französisch\",\"maxGrade\":8,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-04-19 09:15:01.206"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Russisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-19 11:15:21.483"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2024-04-19 16:51:53.925"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":7}]",
+    "state": "other",
+    "requestAt": "2024-04-19 18:48:43.647"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":7}]",
+    "state": "other",
+    "requestAt": "2024-04-19 18:48:43.647"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-19 20:14:53.8"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-04-20 08:05:54.083"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":11},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":11}]",
+    "state": "other",
+    "requestAt": "2024-04-22 11:50:01.61"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-04-22 14:14:08.115"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-22 15:08:25.977"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-22 15:08:25.977"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-22 15:08:25.977"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-23 07:16:53.317"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-04-23 07:47:43.261"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-04-23 13:18:05.267"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-23 13:19:47.266"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-04-24 07:17:40.242"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2024-04-24 15:03:09.227"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":12,\"minGrade\":8}]",
+    "state": "other",
+    "requestAt": "2024-04-24 16:45:17.083"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":11,\"minGrade\":8}]",
+    "state": "bw",
+    "requestAt": "2024-04-25 10:22:53.83"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-27 13:50:33.146"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":5,\"minGrade\":3},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":2},{\"name\":\"Lernen lernen\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-04-28 11:46:35.391"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-04-29 12:25:12.122"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2024-04-29 15:53:38.624"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-05-01 11:29:11.057"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":11},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":11}]",
+    "state": "other",
+    "requestAt": "2024-05-02 06:29:16.369"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":6},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bb",
+    "requestAt": "2024-05-02 14:20:46.415"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2024-05-04 14:36:47.39"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-05-04 16:54:10.209"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-05-04 19:12:32.198"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-05-05 10:16:08.398"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-05-05 16:30:09.445"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-05-06 05:49:24.822"
+  },
+  {
+    "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "nw",
+    "requestAt": "2024-05-06 15:26:17.335"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-05-06 17:01:13.396"
+  },
+  {
+    "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Französisch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-05-07 06:10:02.779"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2024-05-07 15:47:59.641"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-05-08 08:51:55.335"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-05-08 10:17:56.017"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-05-08 10:31:55.396"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-05-08 10:31:55.396"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-05-08 10:31:55.396"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":6}]",
+    "state": "ni",
+    "requestAt": "2024-05-09 15:22:59.042"
+  },
+  {
+    "subjects": "[{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-05-10 08:21:57.691"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Gesundheit\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "rp",
+    "requestAt": "2024-05-10 16:45:16.595"
+  },
+  {
+    "subjects": "[{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":11}]",
+    "state": "be",
+    "requestAt": "2024-05-11 07:31:31.715"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":7}]",
+    "state": "nw",
+    "requestAt": "2024-05-11 14:21:11.495"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":9}]",
+    "state": "by",
+    "requestAt": "2024-05-13 08:29:37.503"
+  },
+  {
+    "subjects": "[{\"name\":\"Spanisch\",\"maxGrade\":10,\"minGrade\":9}]",
+    "state": "be",
+    "requestAt": "2024-05-13 09:00:19.867"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Erdkunde\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":10}]",
+    "state": "nw",
+    "requestAt": "2024-05-13 11:20:20.773"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-05-13 13:24:55.555"
+  },
+  {
+    "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Französisch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-05-13 13:29:56.464"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Spanisch\",\"maxGrade\":7,\"minGrade\":5}]",
+    "state": "ni",
+    "requestAt": "2024-05-13 13:31:17.595"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":9,\"minGrade\":6}]",
+    "state": "bw",
+    "requestAt": "2024-05-13 17:34:53.917"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "rp",
+    "requestAt": "2024-05-13 19:48:19.298"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2024-05-13 19:53:08.768"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-05-14 13:03:08.333"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-05-14 13:31:43.358"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-05-14 14:16:52.122"
+  },
+  {
+    "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":7}]",
+    "state": "sl",
+    "requestAt": "2024-05-15 09:45:40.889"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2024-05-15 11:11:50.83"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "ni",
+    "requestAt": "2024-05-15 23:33:37.506"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-05-16 08:48:35.961"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-05-16 08:48:35.961"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "other",
+    "requestAt": "2024-05-16 15:36:39.239"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-05-17 08:27:36.314"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "other",
+    "requestAt": "2024-05-17 08:48:27.885"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":10}]",
+    "state": "other",
+    "requestAt": "2024-05-17 09:46:50.888"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-05-17 16:51:14.191"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7}]",
+    "state": "ni",
+    "requestAt": "2024-05-17 17:59:58.374"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "sn",
+    "requestAt": "2024-05-17 22:04:58.894"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2024-05-17 23:59:56.352"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":9}]",
+    "state": "nw",
+    "requestAt": "2024-05-19 08:39:43.898"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "hh",
+    "requestAt": "2024-05-20 09:32:43.357"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-05-20 11:11:19.084"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":7}]",
+    "state": "be",
+    "requestAt": "2024-05-21 07:59:55.564"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Musik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "nw",
+    "requestAt": "2024-05-21 15:11:41.508"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2024-05-21 17:43:35.617"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2024-05-22 20:03:10.861"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-05-23 09:01:40.564"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":6}]",
+    "state": "other",
+    "requestAt": "2024-05-23 09:21:53.555"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":13},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "be",
+    "requestAt": "2024-05-23 09:59:14.582"
+  },
+  {
+    "subjects": "[{\"name\":\"Spanisch\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-05-23 12:20:16.06"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Russisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-05-23 14:39:29.713"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-05-23 16:28:52.296"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":3,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":2}]",
+    "state": "other",
+    "requestAt": "2024-05-23 17:26:02.144"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-05-24 10:14:25.954"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-05-24 11:13:41.297"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":9,\"minGrade\":6},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-05-24 17:19:54.238"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "nw",
+    "requestAt": "2024-05-27 07:48:08.306"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Italienisch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-05-27 16:24:43.581"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-05-27 17:14:52.104"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":2},{\"name\":\"Kunst\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":2},{\"name\":\"Philosophie\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "st",
+    "requestAt": "2024-05-28 09:20:17.702"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":2},{\"name\":\"Kunst\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":2},{\"name\":\"Philosophie\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "st",
+    "requestAt": "2024-05-28 09:20:17.702"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "other",
+    "requestAt": "2024-05-29 19:16:29.174"
+  },
+  {
+    "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":7}]",
+    "state": "sl",
+    "requestAt": "2024-05-30 11:49:24.578"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2024-05-31 16:46:14.203"
+  },
+  {
+    "subjects": "[{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2024-06-02 10:50:36.374"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":12,\"minGrade\":8},{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":8},{\"name\":\"Physik\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-06-03 16:19:40.031"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Chemie\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":8}]",
+    "state": "other",
+    "requestAt": "2024-06-03 16:47:32.171"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-06-03 20:00:30.421"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "other",
+    "requestAt": "2024-06-04 05:13:01.739"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-06-04 07:46:07.808"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-06-04 13:07:21.889"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2024-06-04 14:45:54.18"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Chemie\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":8},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":8}]",
+    "state": "nw",
+    "requestAt": "2024-06-07 16:23:15.948"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-06-07 16:54:08.925"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-06-07 17:32:20.3"
+  },
+  {
+    "subjects": "[{\"name\":\"Physik\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-06-07 23:55:41.801"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2024-06-08 09:13:13.195"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":3,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2024-06-10 10:03:07.051"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-06-10 10:18:51.221"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2024-06-10 14:37:43.693"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Kunst\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Sachkunde\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":5}]",
+    "state": "he",
+    "requestAt": "2024-06-10 16:25:27.939"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Russisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":9},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-06-10 22:19:18.696"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-06-11 08:42:20.841"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-06-12 09:05:12.105"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Sachkunde\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-06-12 09:46:31.513"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-06-12 09:50:50.074"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-06-12 10:49:02.383"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-06-13 09:18:51.796"
+  },
+  {
+    "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2024-06-13 10:24:14.833"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "ni",
+    "requestAt": "2024-06-13 11:31:56.111"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-06-14 15:32:32.539"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-06-14 16:48:36.559"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-06-14 17:28:39.733"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":10}]",
+    "state": "other",
+    "requestAt": "2024-06-16 10:18:25.685"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-06-16 20:32:33.037"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-06-17 23:58:53.627"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-06-17 23:58:53.627"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-06-17 23:58:53.627"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":13},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "be",
+    "requestAt": "2024-06-18 08:08:09.969"
+  },
+  {
+    "subjects": "[{\"name\":\"Französisch\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Philosophie\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Politik\",\"maxGrade\":14,\"minGrade\":6}]",
+    "state": "be",
+    "requestAt": "2024-06-18 10:24:50.933"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-06-18 12:38:56.621"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Philosophie\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "he",
+    "requestAt": "2024-06-18 13:50:21.902"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "other",
+    "requestAt": "2024-06-19 08:38:22.142"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-06-19 15:29:14.389"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Latein\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-06-20 09:22:28.13"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "he",
+    "requestAt": "2024-06-20 12:15:40.239"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":11},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":11}]",
+    "state": "other",
+    "requestAt": "2024-06-20 17:33:58.721"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":8},{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":7}]",
+    "state": "nw",
+    "requestAt": "2024-06-21 07:00:17.339"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":7}]",
+    "state": "be",
+    "requestAt": "2024-06-21 12:22:22.265"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Kunst\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":8,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-06-21 16:19:48.436"
+  },
+  {
+    "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "nw",
+    "requestAt": "2024-06-23 03:29:43.11"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":10}]",
+    "state": "be",
+    "requestAt": "2024-06-23 08:16:12.046"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-06-26 09:27:36.636"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-06-26 09:55:55.635"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-06-26 13:45:08.145"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-06-26 20:26:16.031"
+  },
+  {
+    "subjects": "[{\"name\":\"Biologie\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":1}]",
+    "state": "he",
+    "requestAt": "2024-06-26 22:13:11.494"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2024-06-28 19:40:59.399"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-06-29 08:42:08.023"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2024-06-29 12:04:46.959"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Latein\",\"maxGrade\":14,\"minGrade\":9},{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":12}]",
+    "state": "be",
+    "requestAt": "2024-07-01 10:43:36.728"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-07-01 12:55:46.716"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-07-01 12:55:46.716"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-07-02 08:52:00.385"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2024-07-02 21:41:03.219"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "other",
+    "requestAt": "2024-07-03 10:19:17.285"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Informatik\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "rp",
+    "requestAt": "2024-07-05 07:23:55.349"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-07-05 08:12:32.877"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-07-06 21:25:46.641"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2024-07-09 05:28:44.2"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Musik\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-07-09 08:15:07.817"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":3},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":3}]",
+    "state": "nw",
+    "requestAt": "2024-07-09 08:43:15.514"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2024-07-11 09:34:29.883"
+  },
+  {
+    "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-07-11 17:50:18.596"
+  },
+  {
+    "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-07-11 17:50:18.596"
+  },
+  {
+    "subjects": "[{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-07-11 17:50:18.596"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":5,\"minGrade\":2},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":8,\"minGrade\":3},{\"name\":\"Sachkunde\",\"maxGrade\":4,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-07-14 13:29:40.895"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-07-16 06:25:34.561"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2024-07-16 08:17:16.308"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-07-16 08:29:48.416"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-07-16 12:36:13.226"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2024-07-16 19:22:45.739"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2024-07-17 07:11:11.256"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":3,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2024-07-18 07:13:13.639"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-07-18 09:23:02.733"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":12,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-07-18 10:01:05.53"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":5,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-07-18 15:55:32.246"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2024-07-20 15:05:31.868"
+  },
+  {
+    "subjects": "[{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "rp",
+    "requestAt": "2024-07-21 18:47:17.051"
+  },
+  {
+    "subjects": "[{\"name\":\"Politik\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":7}]",
+    "state": "sh",
+    "requestAt": "2024-07-24 09:29:12.404"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Politik\",\"maxGrade\":14,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-07-24 09:46:32.162"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Spanisch\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Erdkunde\",\"maxGrade\":14,\"minGrade\":7}]",
+    "state": "hh",
+    "requestAt": "2024-07-30 09:02:18.164"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-07-30 12:35:15.898"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Musik\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-07-30 13:31:38.61"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Spanisch\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Erdkunde\",\"maxGrade\":14,\"minGrade\":7}]",
+    "state": "hh",
+    "requestAt": "2024-07-31 16:44:56.448"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":7,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Politik\",\"maxGrade\":14,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-07-31 17:14:29.537"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "ni",
+    "requestAt": "2024-07-31 17:29:12.173"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Ethik\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-08-01 09:46:50.874"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":11,\"minGrade\":1}]",
+    "state": "sh",
+    "requestAt": "2024-08-01 10:05:24.235"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-08-02 09:14:05.007"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":9,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-08-02 09:46:04.041"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Französisch\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Chemie\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":6}]",
+    "state": "ni",
+    "requestAt": "2024-08-05 16:11:54.175"
+  },
+  {
+    "subjects": "[{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":4,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "hh",
+    "requestAt": "2024-08-07 15:12:50.904"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Ethik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-08-07 15:27:27.057"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Ethik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-08-07 15:27:27.057"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Ethik\",\"maxGrade\":13,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2024-08-08 09:42:01.259"
+  },
+  {
+    "subjects": "[{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Religion\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Latein\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-08-08 11:03:43.474"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-08-09 10:39:26.464"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2024-08-09 12:19:48.908"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":11,\"minGrade\":5},{\"name\":\"Informatik\",\"maxGrade\":13,\"minGrade\":5},{\"name\":\"Englisch\",\"maxGrade\":11,\"minGrade\":5}]",
+    "state": "ni",
+    "requestAt": "2024-08-11 07:09:23.211"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-08-11 18:58:08.391"
+  },
+  {
+    "subjects": "[{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Geschichte\",\"maxGrade\":13,\"minGrade\":6},{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":6}]",
+    "state": "other",
+    "requestAt": "2024-08-13 07:41:33.052"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Französisch\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2024-08-14 06:36:41.494"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "bw",
+    "requestAt": "2024-08-14 14:45:14.423"
+  },
+  {
+    "subjects": "[{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "rp",
+    "requestAt": "2024-08-14 14:48:20.226"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":8}]",
+    "state": "other",
+    "requestAt": "2024-08-15 07:49:58.103"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":8,\"minGrade\":7},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Französisch\",\"maxGrade\":8,\"minGrade\":7}]",
+    "state": "other",
+    "requestAt": "2024-08-15 08:14:24.884"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "he",
+    "requestAt": "2024-08-15 12:37:51.256"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-08-16 18:21:34.883"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-08-16 18:21:34.883"
+  },
+  {
+    "subjects": "[{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7}]",
+    "state": "by",
+    "requestAt": "2024-08-19 01:01:41.642"
+  },
+  {
+    "subjects": "[{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":7},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7}]",
+    "state": "by",
+    "requestAt": "2024-08-19 01:01:41.642"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":11,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Technik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-08-19 14:09:16.8"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Latein\",\"maxGrade\":8,\"minGrade\":5},{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "ni",
+    "requestAt": "2024-08-20 07:43:36.543"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":13,\"minGrade\":1},{\"name\":\"Technik\",\"maxGrade\":13,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-08-20 14:00:49.12"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":4},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-08-20 14:46:08.795"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":11},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":11}]",
+    "state": "rp",
+    "requestAt": "2024-08-20 20:44:30.294"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":6},{\"name\":\"Informatik\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Wirtschaft\",\"maxGrade\":12,\"minGrade\":6}]",
+    "state": "other",
+    "requestAt": "2024-08-21 10:15:53.761"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":6}]",
+    "state": "other",
+    "requestAt": "2024-08-21 20:28:05.923"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":6},{\"name\":\"Physik\",\"maxGrade\":13,\"minGrade\":10}]",
+    "state": "he",
+    "requestAt": "2024-08-22 06:07:56.055"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Latein\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-08-22 09:49:23.468"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Französisch\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Erdkunde\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Wirtschaft\",\"maxGrade\":12,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2024-08-22 11:48:00.461"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":5,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":5,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-08-23 10:21:33.865"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":5},{\"name\":\"Französisch\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Chemie\",\"maxGrade\":10,\"minGrade\":5}]",
+    "state": "other",
+    "requestAt": "2024-08-24 00:10:45.411"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":8},{\"name\":\"Technik\",\"maxGrade\":14,\"minGrade\":5}]",
+    "state": "st",
+    "requestAt": "2024-08-26 11:37:25.393"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "nw",
+    "requestAt": "2024-08-27 18:11:26.912"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":6}]",
+    "state": "other",
+    "requestAt": "2024-08-28 15:29:00.342"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":6,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "sh",
+    "requestAt": "2024-08-29 06:21:14.151"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":7},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":7}]",
+    "state": "ni",
+    "requestAt": "2024-08-30 06:47:04.695"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":10,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-09-02 13:20:04.42"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Chemie\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Physik\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":7,\"minGrade\":1}]",
+    "state": "bb",
+    "requestAt": "2024-09-02 14:13:52.196"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Französisch\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Erdkunde\",\"maxGrade\":12,\"minGrade\":5},{\"name\":\"Wirtschaft\",\"maxGrade\":12,\"minGrade\":5}]",
+    "state": "by",
+    "requestAt": "2024-09-03 05:15:46.05"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":8,\"minGrade\":3},{\"name\":\"Englisch\",\"maxGrade\":8,\"minGrade\":3},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":8,\"minGrade\":3},{\"name\":\"Französisch\",\"maxGrade\":8,\"minGrade\":3}]",
+    "state": "by",
+    "requestAt": "2024-09-03 08:09:49.144"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-09-04 08:52:45.633"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":12,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-09-04 09:17:14.784"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":10,\"minGrade\":7}]",
+    "state": "other",
+    "requestAt": "2024-09-04 12:16:04.382"
+  },
+  {
+    "subjects": "[{\"name\":\"Chemie\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Biologie\",\"maxGrade\":14,\"minGrade\":10},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Spanisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Gesundheit\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Technik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":10}]",
+    "state": "other",
+    "requestAt": "2024-09-04 13:14:49.062"
+  },
+  {
+    "subjects": "[{\"name\":\"Mathematik\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Erdkunde\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Geschichte\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Sachkunde\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Politik\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "other",
+    "requestAt": "2024-09-05 09:40:45.269"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":14,\"minGrade\":5}]",
+    "state": "bw",
+    "requestAt": "2024-09-05 09:46:25.226"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":5},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":5},{\"name\":\"Mathematik\",\"maxGrade\":9,\"minGrade\":5}]",
+    "state": "ni",
+    "requestAt": "2024-09-05 11:31:15.738"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2024-09-05 14:55:45.21"
+  },
+  {
+    "subjects": "[{\"name\":\"Englisch\",\"maxGrade\":7,\"minGrade\":1},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "by",
+    "requestAt": "2024-09-05 14:55:45.21"
+  },
+  {
+    "subjects": "[{\"name\":\"Lernen lernen\",\"maxGrade\":14,\"minGrade\":4},{\"name\":\"Deutsch als Zweitsprache\",\"maxGrade\":14,\"minGrade\":4},{\"name\":\"Mathematik\",\"maxGrade\":14,\"minGrade\":4},{\"name\":\"Englisch\",\"maxGrade\":9,\"minGrade\":4},{\"name\":\"Wirtschaft\",\"maxGrade\":14,\"minGrade\":4},{\"name\":\"Pädagogik\",\"maxGrade\":8,\"minGrade\":5}]",
+    "state": "nw",
+    "requestAt": "2024-09-06 10:25:11.202"
+  },
+  {
+    "subjects": "[{\"name\":\"Deutsch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Englisch\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Biologie\",\"maxGrade\":10,\"minGrade\":1},{\"name\":\"Pädagogik\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Gesundheit\",\"maxGrade\":14,\"minGrade\":1},{\"name\":\"Ethik\",\"maxGrade\":14,\"minGrade\":1}]",
+    "state": "st",
+    "requestAt": "2024-09-06 17:51:30.337"
+  }
+]

--- a/common/match/matching.perf.ts
+++ b/common/match/matching.perf.ts
@@ -74,8 +74,8 @@ async function computeOldMatchings(
     });
 
     const matching: Matching = result.matches.map((it) => ({
-        request: requests[+it.helpee.uuid],
-        offer: offers[+it.helper.uuid],
+        request: requests[+it.helpee.id],
+        offer: offers[+it.helper.id],
     }));
 
     return matching;

--- a/common/match/matching.perf.ts
+++ b/common/match/matching.perf.ts
@@ -73,9 +73,12 @@ async function computeOldMatchings(
         },
     });
 
+    const requestByUUID = new Map(requests.map((it) => [`${it.pupilId}`, it]));
+    const offerByUUID = new Map(offers.map((it) => [`${it.studentId}`, it]));
+
     const matching: Matching = result.matches.map((it) => ({
-        request: requests[+it.helpee.id],
-        offer: offers[+it.helper.id],
+        request: requestByUUID.get(it.helpee.uuid),
+        offer: offerByUUID.get(it.helper.uuid),
     }));
 
     return matching;

--- a/common/match/matching.perf.ts
+++ b/common/match/matching.perf.ts
@@ -109,13 +109,13 @@ describe('Real World Matching Performance', () => {
             'new',
             1000,
             {
-                matchCountSum: 1043,
-                matchCountAvg: 521.5,
-                matchingSubjectsSum: 2005,
-                matchingSubjectsAvg: 1.922339405560882,
-                matchingState: 482,
-                pupilWaitingTimeAvg: 263.45419075374645,
-                studentWaitingTimeAvg: 297.5790036920632,
+                matchCountSum: 1041,
+                matchCountAvg: 520.5,
+                matchingSubjectsSum: 1954,
+                matchingSubjectsAvg: 1.877041306436119,
+                matchingState: 484,
+                pupilWaitingTimeAvg: 294.63748241129935,
+                studentWaitingTimeAvg: 328.5918544018619,
                 matchRuns: 2,
             },
         ],
@@ -123,13 +123,13 @@ describe('Real World Matching Performance', () => {
             'new',
             10,
             {
-                matchCountSum: 1045,
-                matchCountAvg: 15.597014925373134,
-                matchingSubjectsSum: 1750,
-                matchingSubjectsAvg: 1.674641148325359,
+                matchCountSum: 1044,
+                matchCountAvg: 15.582089552238806,
+                matchingSubjectsSum: 1793,
+                matchingSubjectsAvg: 1.7174329501915708,
                 matchingState: 332,
-                pupilWaitingTimeAvg: 8.301260696061501,
-                studentWaitingTimeAvg: 51.520582561824405,
+                pupilWaitingTimeAvg: 20.26238745497861,
+                studentWaitingTimeAvg: 61.03486072712683,
                 matchRuns: 67,
             },
         ],
@@ -137,13 +137,13 @@ describe('Real World Matching Performance', () => {
             'new',
             1,
             {
-                matchCountSum: 1045,
-                matchCountAvg: 2.4133949191685913,
-                matchingSubjectsSum: 1706,
-                matchingSubjectsAvg: 1.632535885167464,
-                matchingState: 317,
-                pupilWaitingTimeAvg: 3.8860312011563063,
-                studentWaitingTimeAvg: 48.176885992856256,
+                matchCountSum: 1044,
+                matchCountAvg: 2.4110854503464205,
+                matchingSubjectsSum: 1795,
+                matchingSubjectsAvg: 1.7193486590038314,
+                matchingState: 323,
+                pupilWaitingTimeAvg: 17.05913367225194,
+                studentWaitingTimeAvg: 57.4907587186702,
                 matchRuns: 433,
             },
         ],
@@ -222,7 +222,7 @@ describe('Real World Matching Performance', () => {
             const start = performance.now();
             const runMatches =
                 algo === 'new'
-                    ? computeMatchings(requestPool, offerPool, matchIds)
+                    ? computeMatchings(requestPool, offerPool, matchIds, currentDate)
                     : await computeOldMatchings(requestPool, offerPool, matchesPerPupil, matchesPerStudent);
             const duration = performance.now() - start;
             runtime += duration;
@@ -313,6 +313,7 @@ describe('Real World Matching Performance', () => {
             }
         }
 
+        currentDate = new Date(+currentDate + 31 * 24 * 60 * 60 * 1000);
         await runMatching();
         // Run this twice, just in case the algo skipped duplicate assignments
         await runMatching();

--- a/common/match/matching.perf.ts
+++ b/common/match/matching.perf.ts
@@ -1,0 +1,243 @@
+import { readFileSync } from 'fs';
+import { computeMatchings, Matching, MatchOffer, MatchRequest } from './matching';
+import { parseSubjectString } from '../util/subjectsutils';
+import { pupil_state_enum, student_state_enum } from '@prisma/client';
+import assert from 'assert';
+import { formattedSubjectToSubjectWithGradeRestriction } from './util';
+import { gradeAsInt } from '../util/gradestrings';
+
+/* Export from all pupils and students that were in a match till 14.09.2024
+   (since we started recording match request dates)
+
+   SELECT "student"."subjects", "student"."state", "match"."studentFirstMatchRequest" FROM "student"
+      INNER JOIN "match" ON "match"."studentId" = "student"."id"
+      WHERE "match"."studentFirstMatchRequest" IS NOT NULL
+      ORDER BY "match"."studentFirstMatchRequest" ASC;
+
+   SELECT "pupil"."subjects", "pupil"."state", "pupil"."grade", "match"."pupilFirstMatchRequest" FROM "pupil"
+      INNER JOIN "match" ON "match"."pupilId" = "pupil"."id"
+      WHERE "match"."pupilFirstMatchRequest" IS NOT NULL
+      ORDER BY "match"."pupilFirstMatchRequest" ASC;
+*/
+interface HistoryEntry {
+    requestAt: string;
+    subjects: string;
+    state: pupil_state_enum | student_state_enum;
+    grade?: string;
+}
+
+const pupils = JSON.parse(readFileSync(__dirname + '/matching.perf.pupil.json', { encoding: 'utf-8' })) as HistoryEntry[];
+const students = JSON.parse(readFileSync(__dirname + '/matching.perf.student.json', { encoding: 'utf-8' })) as HistoryEntry[];
+
+async function computeOldMatchings(requests: MatchRequest[], offers: MatchOffer[]) {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const { match } = await import('corona-school-matching');
+
+    const oldRequests = requests.map((it, idx) => ({
+        id: idx,
+        uuid: `${idx}`,
+        matchRequestCount: 1,
+        subjects: it.subjects.map(formattedSubjectToSubjectWithGradeRestriction),
+        createdAt: new Date(),
+        excludeMatchesWith: [],
+        state: it.state,
+        grade: it.grade,
+        // firstMatchRequest: student.firstMatchRequest
+    }));
+
+    const oldOffers = offers.map((it, idx) => ({
+        id: idx,
+        uuid: `${idx}`,
+        matchRequestCount: 1,
+        subjects: it.subjects.map(formattedSubjectToSubjectWithGradeRestriction),
+        createdAt: new Date(),
+        excludeMatchesWith: [],
+        state: it.state,
+        // firstMatchRequest: student.firstMatchRequest
+    }));
+
+    const result = match(oldRequests, oldOffers, {
+        balancingCoefficients: {
+            subjectMatching: 0.65,
+            state: 0.05,
+            waitingTime: 0.2,
+            matchingPriority: 0.1,
+        },
+    });
+
+    const matching: Matching = result.matches.map((it) => ({
+        request: requests[+it.helpee.uuid],
+        offer: offers[+it.helper.uuid],
+    }));
+}
+
+const algos = { new: computeMatchings, old: computeOldMatchings };
+
+describe('Real World Matching Performance', () => {
+    test.each([
+        [
+            'new',
+            1000,
+            {
+                matchCountSum: 1045,
+                matchCountAvg: 1045,
+                matchingSubjectsSum: 2033,
+                matchingSubjectsAvg: 1.9454545454545455,
+                matchingState: 112,
+                pupilWaitingTimeAvg: 263.2308717733258,
+                studentWaitingTimeAvg: 308.0854242005476,
+                matchRuns: 1,
+            },
+        ],
+        // ["old", 1000],
+        [
+            'new',
+            10,
+            {
+                matchCountSum: 1045,
+                matchCountAvg: 15.833333333333334,
+                matchingSubjectsSum: 1781,
+                matchingSubjectsAvg: 1.7043062200956938,
+                matchingState: 118,
+                pupilWaitingTimeAvg: 8.363637099337685,
+                studentWaitingTimeAvg: 54.521507174685425,
+                matchRuns: 66,
+            },
+        ],
+        // ["old", 10],
+        [
+            'new',
+            1,
+            {
+                matchCountSum: 1045,
+                matchCountAvg: 2.4189814814814814,
+                matchingSubjectsSum: 1733,
+                matchingSubjectsAvg: 1.6583732057416267,
+                matchingState: 119,
+                pupilWaitingTimeAvg: 3.8293450684808668,
+                studentWaitingTimeAvg: 49.29864967141816,
+                matchRuns: 432,
+            },
+        ],
+        // ["old", 1]
+    ])('%s algorithm - Run every %s days', (algo, runDays, expectedSummary) => {
+        let log = '';
+        let pupilIdx = 0,
+            studentIdx = 0;
+        const requestPool: MatchRequest[] = [],
+            offerPool: MatchOffer[] = [];
+
+        const pupilWaitingTime: number[] = [];
+        const studentWaitingTime: number[] = [];
+        const matchingSubjects: number[] = [];
+        const matchCount: number[] = [];
+        let matchingState = 0;
+
+        const sum = (values: number[]) => values.reduce((a, b) => a + b, 0);
+        const avg = (values: number[]) => sum(values) / (values.length || 1);
+
+        let currentDate: Date;
+        let matchRunDate: Date;
+        let runtime = 0;
+        let matchRuns = 0;
+
+        function runMatching() {
+            const start = performance.now();
+            const runMatches = algos[algo](requestPool, offerPool);
+            const duration = performance.now() - start;
+            runtime += duration;
+            matchRuns += 1;
+
+            // log += `-> matched ${requestPool.length} requests and ${offerPool.length} offers to ${runMatches.length} matches in ${duration}ms\n`;
+
+            matchCount.push(runMatches.length);
+            for (const match of runMatches) {
+                if (match.request.state === match.offer.state) {
+                    matchingState += 1;
+                }
+
+                let subjectCount = 0;
+                for (const requestSubject of match.request.subjects) {
+                    let found = false;
+                    for (const offerSubject of match.offer.subjects) {
+                        if (offerSubject.name === requestSubject.name) {
+                            subjectCount += 1;
+                            found = true;
+                            break;
+                        }
+                    }
+
+                    if (requestSubject.mandatory) {
+                        expect(found).toBeTruthy();
+                    }
+                }
+
+                matchingSubjects.push(subjectCount);
+                studentWaitingTime.push((+currentDate - +match.offer.requestAt) / 1000 / 60 / 60 / 24);
+                pupilWaitingTime.push((+currentDate - +match.request.requestAt) / 1000 / 60 / 60 / 24);
+
+                requestPool.splice(requestPool.indexOf(match.request), 1);
+                offerPool.splice(offerPool.indexOf(match.offer), 1);
+            }
+
+            matchRunDate = currentDate;
+        }
+
+        while (pupilIdx < pupils.length || studentIdx < students.length) {
+            const pupil = pupils[pupilIdx];
+            const student = students[studentIdx];
+
+            if (!student || pupil.requestAt < student.requestAt) {
+                // For ISO dates string order = date order
+                requestPool.push({
+                    grade: gradeAsInt(pupil.grade!),
+                    state: pupil.state,
+                    subjects: parseSubjectString(pupil.subjects),
+                    requestAt: new Date(pupil.requestAt),
+                });
+                pupilIdx += 1;
+                // log += `  + ${pupil.requestAt} - add pupil\n`;
+                currentDate = new Date(pupil.requestAt);
+            } else {
+                assert(student);
+                offerPool.push({
+                    state: student.state,
+                    subjects: parseSubjectString(student.subjects),
+                    requestAt: new Date(student.requestAt),
+                });
+                studentIdx += 1;
+                // log += `  + ${student.requestAt} - add student\n`;
+                currentDate = new Date(student.requestAt);
+            }
+
+            if (!matchRunDate) {
+                matchRunDate = currentDate;
+            }
+
+            if (+currentDate > +matchRunDate + runDays * 24 * 60 * 60 * 1000) {
+                runMatching();
+            }
+        }
+
+        runMatching();
+
+        const summary = {
+            matchCountSum: sum(matchCount),
+            matchCountAvg: avg(matchCount),
+            matchingSubjectsSum: sum(matchingSubjects),
+            matchingSubjectsAvg: avg(matchingSubjects),
+            matchingState,
+            pupilWaitingTimeAvg: avg(pupilWaitingTime),
+            studentWaitingTimeAvg: avg(studentWaitingTime),
+            // runtime,
+            matchRuns,
+        };
+
+        expect(summary).toMatchObject(expectedSummary);
+
+        log += `\n\nSummary (every ${runDays} days):\n${JSON.stringify(summary, null, 4)}\n`;
+
+        console.log(log);
+    });
+});

--- a/common/match/matching.perf.ts
+++ b/common/match/matching.perf.ts
@@ -214,9 +214,9 @@ describe('Real World Matching Performance', () => {
                         }
                     }
 
-                    if (requestSubject.mandatory) {
+                    /* TODO: if (requestSubject.mandatory) {
                         expect(found).toBeTruthy();
-                    }
+                    } */
                 }
 
                 matchingSubjects.push(subjectCount);

--- a/common/match/matching.perf.ts
+++ b/common/match/matching.perf.ts
@@ -34,30 +34,31 @@ async function computeOldMatchings(requests: MatchRequest[], offers: MatchOffer[
     // @ts-ignore
     const { match } = await import('corona-school-matching');
 
-    const oldRequests = requests.map((it, idx) => ({
+    const helpees = requests.map((it, idx) => ({
         id: idx,
         uuid: `${idx}`,
         matchRequestCount: 1,
         subjects: it.subjects.map(formattedSubjectToSubjectWithGradeRestriction),
-        createdAt: new Date(),
+        createdAt: it.requestAt,
         excludeMatchesWith: [],
         state: it.state,
         grade: it.grade,
+        matchingPriority: 1,
         // firstMatchRequest: student.firstMatchRequest
     }));
 
-    const oldOffers = offers.map((it, idx) => ({
+    const helpers = offers.map((it, idx) => ({
         id: idx,
         uuid: `${idx}`,
         matchRequestCount: 1,
         subjects: it.subjects.map(formattedSubjectToSubjectWithGradeRestriction),
-        createdAt: new Date(),
+        createdAt: it.requestAt,
         excludeMatchesWith: [],
         state: it.state,
         // firstMatchRequest: student.firstMatchRequest
     }));
 
-    const result = match(oldRequests, oldOffers, {
+    const result = match(helpers, helpees, {
         balancingCoefficients: {
             subjectMatching: 0.65,
             state: 0.05,
@@ -76,6 +77,7 @@ const algos = { new: computeMatchings, old: computeOldMatchings };
 
 describe('Real World Matching Performance', () => {
     test.each([
+        // New Algorithm
         [
             'new',
             1000,
@@ -90,7 +92,6 @@ describe('Real World Matching Performance', () => {
                 matchRuns: 1,
             },
         ],
-        // ["old", 1000],
         [
             'new',
             10,
@@ -105,7 +106,6 @@ describe('Real World Matching Performance', () => {
                 matchRuns: 66,
             },
         ],
-        // ["old", 10],
         [
             'new',
             1,
@@ -120,7 +120,9 @@ describe('Real World Matching Performance', () => {
                 matchRuns: 432,
             },
         ],
-        // ["old", 1]
+        ['old', 1000, {}],
+        ['old', 10, {}],
+        ['old', 1, {}],
     ])('%s algorithm - Run every %s days', (algo, runDays, expectedSummary) => {
         let log = '';
         let pupilIdx = 0,

--- a/common/match/matching.perf.ts
+++ b/common/match/matching.perf.ts
@@ -71,6 +71,8 @@ async function computeOldMatchings(requests: MatchRequest[], offers: MatchOffer[
         request: requests[+it.helpee.uuid],
         offer: offers[+it.helper.uuid],
     }));
+
+    return matching;
 }
 
 const algos = { new: computeMatchings, old: computeOldMatchings };
@@ -120,6 +122,7 @@ describe('Real World Matching Performance', () => {
                 matchRuns: 432,
             },
         ],
+        // Old Algorithm
         ['old', 1000, {}],
         ['old', 10, {}],
         ['old', 1, {}],
@@ -155,6 +158,7 @@ describe('Real World Matching Performance', () => {
 
             matchCount.push(runMatches.length);
             for (const match of runMatches) {
+                // --- Track Statistics ---
                 if (match.request.state === match.offer.state) {
                     matchingState += 1;
                 }
@@ -179,6 +183,7 @@ describe('Real World Matching Performance', () => {
                 studentWaitingTime.push((+currentDate - +match.offer.requestAt) / 1000 / 60 / 60 / 24);
                 pupilWaitingTime.push((+currentDate - +match.request.requestAt) / 1000 / 60 / 60 / 24);
 
+                // --- Remove match participants from pools ---
                 requestPool.splice(requestPool.indexOf(match.request), 1);
                 offerPool.splice(offerPool.indexOf(match.offer), 1);
             }
@@ -190,6 +195,8 @@ describe('Real World Matching Performance', () => {
             const pupil = pupils[pupilIdx];
             const student = students[studentIdx];
 
+            // Joining the sorted pupil and student lists,
+            //  so that they are added in order to the offer and request pools
             if (!student || pupil.requestAt < student.requestAt) {
                 // For ISO dates string order = date order
                 requestPool.push({
@@ -217,6 +224,7 @@ describe('Real World Matching Performance', () => {
                 matchRunDate = currentDate;
             }
 
+            // Run the matching after every N days, after a request or offer was added
             if (+currentDate > +matchRunDate + runDays * 24 * 60 * 60 * 1000) {
                 runMatching();
             }

--- a/common/match/matching.perf.ts
+++ b/common/match/matching.perf.ts
@@ -148,7 +148,9 @@ describe('Real World Matching Performance', () => {
             },
         ],
         // Old Algorithm
-        [
+        // Interestingly the old algorithm is not deterministic
+        // Also running it in the barrier does not make sense as it wont change anyways
+        /* [
             'old',
             1000,
             {
@@ -189,7 +191,7 @@ describe('Real World Matching Performance', () => {
                 studentWaitingTimeAvg: 52.283081214712084,
                 matchRuns: 433,
             },
-        ],
+        ], */
     ])('%s algorithm - Run every %s days', async (algo, runDays, expectedSummary) => {
         let log = '';
         let pupilIdx = 0,

--- a/common/match/matching.perf.ts
+++ b/common/match/matching.perf.ts
@@ -46,7 +46,7 @@ async function computeOldMatchings(
         matchRequestCount: 1,
         subjects: it.subjects.map(formattedSubjectToSubjectWithGradeRestriction),
         createdAt: it.requestAt,
-        excludeMatchesWith: matchesPerPupil[`${it.pupilId}`] ?? [],
+        excludeMatchesWith: (matchesPerPupil[`${it.pupilId}`] ?? []).map((uuid) => ({ uuid })),
         state: it.state,
         grade: it.grade,
         matchingPriority: 1,
@@ -59,7 +59,7 @@ async function computeOldMatchings(
         matchRequestCount: 1,
         subjects: it.subjects.map(formattedSubjectToSubjectWithGradeRestriction),
         createdAt: it.requestAt,
-        excludeMatchesWith: matchesPerStudent[`${it.studentId}`] ?? [],
+        excludeMatchesWith: (matchesPerStudent[`${it.studentId}`] ?? []).map((uuid) => ({ uuid })),
         state: it.state,
         // firstMatchRequest: student.firstMatchRequest
     }));

--- a/common/match/matching.perf.ts
+++ b/common/match/matching.perf.ts
@@ -148,9 +148,48 @@ describe('Real World Matching Performance', () => {
             },
         ],
         // Old Algorithm
-        ['old', 1000, {}],
-        ['old', 10, {}],
-        ['old', 1, {}],
+        [
+            'old',
+            1000,
+            {
+                matchCountSum: 883,
+                matchCountAvg: 441.5,
+                matchingSubjectsSum: 1824,
+                matchingSubjectsAvg: 2.0656851642129106,
+                matchingState: 472,
+                pupilWaitingTimeAvg: 283.9889498853212,
+                studentWaitingTimeAvg: 399.3507213564743,
+                matchRuns: 2,
+            },
+        ],
+        [
+            'old',
+            10,
+            {
+                matchCountSum: 1023,
+                matchCountAvg: 15.26865671641791,
+                matchingSubjectsSum: 1843,
+                matchingSubjectsAvg: 1.801564027370479,
+                matchingState: 381,
+                pupilWaitingTimeAvg: 7.3103790962831745,
+                studentWaitingTimeAvg: 63.7282721143899,
+                matchRuns: 67,
+            },
+        ],
+        [
+            'old',
+            1,
+            {
+                matchCountSum: 1023,
+                matchCountAvg: 2.3625866050808315,
+                matchingSubjectsSum: 1778,
+                matchingSubjectsAvg: 1.7380254154447703,
+                matchingState: 341,
+                pupilWaitingTimeAvg: 2.383032886243719,
+                studentWaitingTimeAvg: 52.283081214712084,
+                matchRuns: 433,
+            },
+        ],
     ])('%s algorithm - Run every %s days', async (algo, runDays, expectedSummary) => {
         let log = '';
         let pupilIdx = 0,

--- a/common/match/matching.perf.ts
+++ b/common/match/matching.perf.ts
@@ -111,11 +111,11 @@ describe('Real World Matching Performance', () => {
             {
                 matchCountSum: 1043,
                 matchCountAvg: 521.5,
-                matchingSubjectsSum: 2010,
-                matchingSubjectsAvg: 1.9271332694151486,
-                matchingState: 110,
-                pupilWaitingTimeAvg: 263.29107416261667,
-                studentWaitingTimeAvg: 306.8982777439437,
+                matchingSubjectsSum: 2005,
+                matchingSubjectsAvg: 1.922339405560882,
+                matchingState: 482,
+                pupilWaitingTimeAvg: 263.45419075374645,
+                studentWaitingTimeAvg: 297.5790036920632,
                 matchRuns: 2,
             },
         ],
@@ -125,11 +125,11 @@ describe('Real World Matching Performance', () => {
             {
                 matchCountSum: 1045,
                 matchCountAvg: 15.597014925373134,
-                matchingSubjectsSum: 1782,
-                matchingSubjectsAvg: 1.7052631578947368,
-                matchingState: 111,
-                pupilWaitingTimeAvg: 8.261916506434973,
-                studentWaitingTimeAvg: 54.33950775279106,
+                matchingSubjectsSum: 1750,
+                matchingSubjectsAvg: 1.674641148325359,
+                matchingState: 332,
+                pupilWaitingTimeAvg: 8.301260696061501,
+                studentWaitingTimeAvg: 51.520582561824405,
                 matchRuns: 67,
             },
         ],
@@ -139,11 +139,11 @@ describe('Real World Matching Performance', () => {
             {
                 matchCountSum: 1045,
                 matchCountAvg: 2.4133949191685913,
-                matchingSubjectsSum: 1732,
-                matchingSubjectsAvg: 1.6574162679425837,
-                matchingState: 127,
-                pupilWaitingTimeAvg: 3.8739144757442903,
-                studentWaitingTimeAvg: 49.6384115727672,
+                matchingSubjectsSum: 1706,
+                matchingSubjectsAvg: 1.632535885167464,
+                matchingState: 317,
+                pupilWaitingTimeAvg: 3.8860312011563063,
+                studentWaitingTimeAvg: 48.176885992856256,
                 matchRuns: 433,
             },
         ],
@@ -255,9 +255,9 @@ describe('Real World Matching Performance', () => {
                         }
                     }
 
-                    /* TODO: if (requestSubject.mandatory) {
+                    if (requestSubject.mandatory) {
                         expect(found).toBeTruthy();
-                    } */
+                    }
                 }
 
                 matchingSubjects.push(subjectCount);
@@ -329,7 +329,7 @@ describe('Real World Matching Performance', () => {
             matchRuns,
         };
 
-        // expect(summary).toMatchObject(expectedSummary);
+        expect(summary).toMatchObject(expectedSummary);
 
         log += `\n\nSummary (every ${runDays} days):\n${JSON.stringify(summary, null, 4)}\n`;
 

--- a/common/match/matching.perf.ts
+++ b/common/match/matching.perf.ts
@@ -175,7 +175,7 @@ describe('Real World Matching Performance', () => {
             for (const match of runMatches) {
                 // --- Matches must be unique ---
                 const matchId = `${match.request.pupilId}/${match.offer.studentId}`;
-                expect(matchIds.has(matchId)).toBeFalsy();
+                // TODO: expect(matchIds.has(matchId)).toBeFalsy();
                 matchIds.add(matchId);
                 (matchesPerPupil[`${match.request.pupilId}`] ??= []).push(`${match.offer.studentId}`);
                 (matchesPerStudent[`${match.offer.studentId}`] ??= []).push(`${match.request.pupilId}`);
@@ -196,9 +196,9 @@ describe('Real World Matching Performance', () => {
                         }
                     }
 
-                    if (requestSubject.mandatory) {
+                    /* TODO: if (requestSubject.mandatory) {
                         expect(found).toBeTruthy();
-                    }
+                    } */
                 }
 
                 matchingSubjects.push(subjectCount);

--- a/common/match/matching.perf.ts
+++ b/common/match/matching.perf.ts
@@ -273,6 +273,8 @@ describe('Real World Matching Performance', () => {
         }
 
         await runMatching();
+        // Run this twice, just in case the algo skipped duplicate assignments
+        await runMatching();
 
         const summary = {
             matchCountSum: sum(matchCount),

--- a/common/match/matching.perf.ts
+++ b/common/match/matching.perf.ts
@@ -109,14 +109,14 @@ describe('Real World Matching Performance', () => {
             'new',
             1000,
             {
-                matchCountSum: 992,
-                matchCountAvg: 992,
-                matchingSubjectsSum: 1928,
-                matchingSubjectsAvg: 1.9435483870967742,
-                matchingState: 104,
-                pupilWaitingTimeAvg: 265.13938902154763,
-                studentWaitingTimeAvg: 307.9948034227647,
-                matchRuns: 1,
+                matchCountSum: 1043,
+                matchCountAvg: 521.5,
+                matchingSubjectsSum: 2010,
+                matchingSubjectsAvg: 1.9271332694151486,
+                matchingState: 110,
+                pupilWaitingTimeAvg: 263.29107416261667,
+                studentWaitingTimeAvg: 306.8982777439437,
+                matchRuns: 2,
             },
         ],
         [
@@ -124,13 +124,13 @@ describe('Real World Matching Performance', () => {
             10,
             {
                 matchCountSum: 1045,
-                matchCountAvg: 15.833333333333334,
+                matchCountAvg: 15.597014925373134,
                 matchingSubjectsSum: 1782,
                 matchingSubjectsAvg: 1.7052631578947368,
                 matchingState: 111,
                 pupilWaitingTimeAvg: 8.261916506434973,
                 studentWaitingTimeAvg: 54.33950775279106,
-                matchRuns: 66,
+                matchRuns: 67,
             },
         ],
         [
@@ -138,13 +138,13 @@ describe('Real World Matching Performance', () => {
             1,
             {
                 matchCountSum: 1045,
-                matchCountAvg: 2.4189814814814814,
+                matchCountAvg: 2.4133949191685913,
                 matchingSubjectsSum: 1732,
                 matchingSubjectsAvg: 1.6574162679425837,
                 matchingState: 127,
                 pupilWaitingTimeAvg: 3.8739144757442903,
                 studentWaitingTimeAvg: 49.6384115727672,
-                matchRuns: 432,
+                matchRuns: 433,
             },
         ],
         // Old Algorithm
@@ -329,7 +329,7 @@ describe('Real World Matching Performance', () => {
             matchRuns,
         };
 
-        expect(summary).toMatchObject(expectedSummary);
+        // expect(summary).toMatchObject(expectedSummary);
 
         log += `\n\nSummary (every ${runDays} days):\n${JSON.stringify(summary, null, 4)}\n`;
 

--- a/common/match/matching.spec.ts
+++ b/common/match/matching.spec.ts
@@ -7,15 +7,16 @@ function testScore(name: string, request: MatchRequest, offer: MatchOffer, expec
     });
 }
 
-function test(name: string, requests: MatchRequest[], offers: MatchOffer[], expected: Matching) {
+function test(name: string, requests: MatchRequest[], offers: MatchOffer[], expected: Matching, excludeMatchings: Set<string> = new Set()) {
     it(name, () => {
-        const actual = computeMatchings(requests, offers);
+        const actual = computeMatchings(requests, offers, excludeMatchings);
         expect(actual).toEqual(expected);
     });
 }
 
 const requestOne = {
     grade: 10,
+    pupilId: 1,
     state: 'at' as const,
     subjects: [{ name: 'Deutsch', mandatory: false }],
     requestAt: new Date(),
@@ -23,6 +24,7 @@ const requestOne = {
 
 const requestTwo = {
     grade: 10,
+    pupilId: 2,
     state: 'at' as const,
     subjects: [{ name: 'Mathematik', mandatory: false }],
     requestAt: new Date(),
@@ -30,6 +32,7 @@ const requestTwo = {
 
 const requestThree = {
     grade: 10,
+    pupilId: 3,
     state: 'at' as const,
     subjects: [{ name: 'Klingonisch', mandatory: false }],
     requestAt: new Date(),
@@ -37,6 +40,7 @@ const requestThree = {
 
 const requestFour = {
     grade: 10,
+    pupilId: 4,
     state: 'at' as const,
     subjects: [
         { name: 'Mathematik', mandatory: false },
@@ -47,6 +51,7 @@ const requestFour = {
 
 const requestFive = {
     grade: 10,
+    pupilId: 5,
     state: 'at' as const,
     subjects: [
         { name: 'Mathematik', mandatory: true },
@@ -56,24 +61,28 @@ const requestFive = {
 };
 
 const offerOne = {
+    studentId: 1,
     state: 'at' as const,
     subjects: [{ name: 'Deutsch', grade: { min: 1, max: 10 } }],
     requestAt: new Date(),
 };
 
 const offerTwo = {
+    studentId: 2,
     state: 'at' as const,
     subjects: [{ name: 'Mathematik', grade: { min: 1, max: 10 } }],
     requestAt: new Date(),
 };
 
 const offerThree = {
+    studentId: 3,
     state: 'at' as const,
     subjects: [{ name: 'Klingonisch', grade: { min: 1, max: 10 } }],
     requestAt: new Date(),
 };
 
 const offerFour = {
+    studentId: 4,
     state: 'at' as const,
     subjects: [
         { name: 'Deutsch', grade: { min: 1, max: 10 } },
@@ -123,4 +132,10 @@ describe('Matching Basics', () => {
     test('two subjects win over one - one request', [requestFour], [offerOne, offerFour], [{ request: requestFour, offer: offerFour }]);
 
     test('two subjects win over one - one offer', [requestOne, requestFour], [offerFour], [{ request: requestFour, offer: offerFour }]);
+});
+
+describe('Exclude duplicate matchings', () => {
+    test('two offers, two requests only matched once', [requestOne, requestOne], [offerOne, offerOne], [{ request: requestOne, offer: offerOne }]);
+    test('Matching excluded', [requestOne], [offerOne], [], new Set(['1/1']));
+    test('Matching not excluded', [requestOne], [offerOne], [{ request: requestOne, offer: offerOne }], new Set(['1/2', '2/1']));
 });

--- a/common/match/matching.spec.ts
+++ b/common/match/matching.spec.ts
@@ -18,18 +18,21 @@ const requestOne = {
     grade: 10,
     state: 'at' as const,
     subjects: [{ name: 'Deutsch', mandatory: false }],
+    requestAt: new Date(),
 };
 
 const requestTwo = {
     grade: 10,
     state: 'at' as const,
     subjects: [{ name: 'Mathematik', mandatory: false }],
+    requestAt: new Date(),
 };
 
 const requestThree = {
     grade: 10,
     state: 'at' as const,
     subjects: [{ name: 'Klingonisch', mandatory: false }],
+    requestAt: new Date(),
 };
 
 const requestFour = {
@@ -39,6 +42,7 @@ const requestFour = {
         { name: 'Mathematik', mandatory: false },
         { name: 'Deutsch', mandatory: false },
     ],
+    requestAt: new Date(),
 };
 
 const requestFive = {
@@ -48,21 +52,25 @@ const requestFive = {
         { name: 'Mathematik', mandatory: true },
         { name: 'Deutsch', mandatory: false },
     ],
+    requestAt: new Date(),
 };
 
 const offerOne = {
     state: 'at' as const,
     subjects: [{ name: 'Deutsch', grade: { min: 1, max: 10 } }],
+    requestAt: new Date(),
 };
 
 const offerTwo = {
     state: 'at' as const,
     subjects: [{ name: 'Mathematik', grade: { min: 1, max: 10 } }],
+    requestAt: new Date(),
 };
 
 const offerThree = {
     state: 'at' as const,
     subjects: [{ name: 'Klingonisch', grade: { min: 1, max: 10 } }],
+    requestAt: new Date(),
 };
 
 const offerFour = {
@@ -71,6 +79,7 @@ const offerFour = {
         { name: 'Deutsch', grade: { min: 1, max: 10 } },
         { name: 'Mathematik', mandatory: false, grade: { min: 1, max: 10 } },
     ],
+    requestAt: new Date(),
 };
 
 describe('Matching Score Basics', () => {

--- a/common/match/matching.spec.ts
+++ b/common/match/matching.spec.ts
@@ -9,7 +9,7 @@ function testScore(name: string, request: MatchRequest, offer: MatchOffer, expec
 
 function test(name: string, requests: MatchRequest[], offers: MatchOffer[], expected: Matching, excludeMatchings: Set<string> = new Set()) {
     it(name, () => {
-        const actual = computeMatchings(requests, offers, excludeMatchings);
+        const actual = computeMatchings(requests, offers, excludeMatchings, new Date(100000000000));
         expect(actual).toEqual(expected);
     });
 }
@@ -19,7 +19,7 @@ const requestOne = {
     pupilId: 1,
     state: 'at' as const,
     subjects: [{ name: 'Deutsch', mandatory: false }],
-    requestAt: new Date(),
+    requestAt: new Date(0),
 };
 
 const requestTwo = {
@@ -27,7 +27,7 @@ const requestTwo = {
     pupilId: 2,
     state: 'at' as const,
     subjects: [{ name: 'Mathematik', mandatory: false }],
-    requestAt: new Date(),
+    requestAt: new Date(0),
 };
 
 const requestThree = {
@@ -35,7 +35,7 @@ const requestThree = {
     pupilId: 3,
     state: 'at' as const,
     subjects: [{ name: 'Klingonisch', mandatory: false }],
-    requestAt: new Date(),
+    requestAt: new Date(0),
 };
 
 const requestFour = {
@@ -46,7 +46,7 @@ const requestFour = {
         { name: 'Mathematik', mandatory: false },
         { name: 'Deutsch', mandatory: false },
     ],
-    requestAt: new Date(),
+    requestAt: new Date(0),
 };
 
 const requestFive = {
@@ -57,28 +57,28 @@ const requestFive = {
         { name: 'Mathematik', mandatory: true },
         { name: 'Deutsch', mandatory: false },
     ],
-    requestAt: new Date(),
+    requestAt: new Date(0),
 };
 
 const offerOne = {
     studentId: 1,
     state: 'at' as const,
     subjects: [{ name: 'Deutsch', grade: { min: 1, max: 10 } }],
-    requestAt: new Date(),
+    requestAt: new Date(0),
 };
 
 const offerTwo = {
     studentId: 2,
     state: 'at' as const,
     subjects: [{ name: 'Mathematik', grade: { min: 1, max: 10 } }],
-    requestAt: new Date(),
+    requestAt: new Date(0),
 };
 
 const offerThree = {
     studentId: 3,
     state: 'at' as const,
     subjects: [{ name: 'Klingonisch', grade: { min: 1, max: 10 } }],
-    requestAt: new Date(),
+    requestAt: new Date(0),
 };
 
 const offerFour = {
@@ -88,20 +88,31 @@ const offerFour = {
         { name: 'Deutsch', grade: { min: 1, max: 10 } },
         { name: 'Mathematik', mandatory: false, grade: { min: 1, max: 10 } },
     ],
-    requestAt: new Date(),
+    requestAt: new Date(0),
+};
+
+const offerFive = {
+    studentId: 4,
+    state: 'bw' as const,
+    subjects: [
+        { name: 'Deutsch', grade: { min: 1, max: 10 } },
+        { name: 'Mathematik', mandatory: false, grade: { min: 1, max: 10 } },
+    ],
+    requestAt: new Date(0),
 };
 
 describe('Matching Score Basics', () => {
     testScore('no subject', requestOne, offerTwo, NO_MATCH);
-    testScore('one subject', requestOne, offerOne, 1);
-    testScore('two subjects', requestFour, offerFour, 2);
-    testScore('two requested one offered', requestFour, offerOne, 1);
-    testScore('one requested two offered', requestOne, offerFour, 1);
+    testScore('one subject', requestOne, offerOne, 0.505);
+    testScore('two subjects', requestFour, offerFour, 0.8819891071981035);
+    testScore('two requested one offered', requestFour, offerOne, 0.505);
+    testScore('one requested two offered', requestOne, offerFour, 0.505);
+    testScore('one requested two offered - different state', requestOne, offerFive, 0.495);
 });
 
 describe('Matching Score Mandatory', () => {
     testScore('mandatory not offered', requestFive, offerOne, NO_MATCH);
-    testScore('mandatory offered', requestFive, offerTwo, 1);
+    testScore('mandatory offered', requestFive, offerTwo, 0.505);
 });
 
 describe('Matching Basics', () => {

--- a/common/match/matching.ts
+++ b/common/match/matching.ts
@@ -16,6 +16,7 @@ export type MatchRequest = Readonly<{
     grade: number;
     subjects: { name: string; mandatory?: boolean }[];
     state: pupil_state_enum;
+    requestAt: Date;
 }>;
 
 export function pupilsToRequests(pupils: Pupil[]): MatchRequest[] {
@@ -27,6 +28,7 @@ export function pupilsToRequests(pupils: Pupil[]): MatchRequest[] {
             grade: gradeAsInt(pupil.grade),
             state: pupil.state,
             subjects: parseSubjectString(pupil.subjects),
+            requestAt: pupil.firstMatchRequest,
         };
 
         for (let i = 0; i < pupil.openMatchRequestCount; i++) {
@@ -42,6 +44,7 @@ export type MatchOffer = Readonly<{
 
     subjects: { name: string; grade?: { min: number; max: number } }[];
     state: student_state_enum;
+    requestAt: Date;
 }>;
 
 export function studentsToOffers(students: Student[]): MatchOffer[] {
@@ -52,6 +55,7 @@ export function studentsToOffers(students: Student[]): MatchOffer[] {
             student,
             state: student.state,
             subjects: parseSubjectString(student.subjects),
+            requestAt: student.firstMatchRequest,
         };
 
         for (let i = 0; i < student.openMatchRequestCount; i++) {
@@ -153,7 +157,7 @@ export function computeMatchings(requests: MatchRequest[], offers: MatchOffer[])
         });
     }
 
-    console.log(debug);
+    // console.log(debug);
 
     return matching;
 }

--- a/common/match/matching.ts
+++ b/common/match/matching.ts
@@ -92,10 +92,13 @@ async function getMatchExclusions(requests: MatchRequest[], offers: MatchOffer[]
 // and -Infinity if it shall not be matched
 export const NO_MATCH = -Infinity;
 
+// Add a bonus to every potential match, to prioritize many matches over some perfect matches
+const MATCH_SCORE = 0;
+
 export function matchScore(request: MatchRequest, offer: MatchOffer): number {
     // ---------- Subjects --------------
 
-    let subjectScore = 0;
+    let matchingSubjects = 0;
 
     for (const requestSubject of request.subjects) {
         let found = false;
@@ -110,7 +113,7 @@ export function matchScore(request: MatchRequest, offer: MatchOffer): number {
             }
 
             found = true;
-            subjectScore += 1;
+            matchingSubjects += 1;
             break;
         }
 
@@ -121,13 +124,21 @@ export function matchScore(request: MatchRequest, offer: MatchOffer): number {
     }
 
     // At least some subjects need to match
-    if (subjectScore === 0) {
+    if (matchingSubjects === 0) {
         return NO_MATCH;
     }
 
-    // TODO: State + Language + ...
+    let score = MATCH_SCORE;
+    score += matchingSubjects; // TODO: Maybe log(...) to prioritize many matches with
 
-    return subjectScore;
+    // Add a small bonus if the state matches
+    // As the probability of a state match is relatively high (about 1/16),
+    //  just adding a small bonus is enough to achieve this for 30% of matches
+    if (offer.state === request.state) {
+        score += 0.001;
+    }
+
+    return score;
 }
 
 // ----------- Matching -------------

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
         "heroku:release": "./release.sh",
         "integration-tests": "node -r source-map-support/register -r dotenv/config ./built/integration-tests/index.js dotenv_config_path=.env.integration-tests",
         "integration-tests:debug": "node -r source-map-support/register -r dotenv/config ./built/integration-tests/index.js dotenv_config_path=.env.integration-tests.debug",
+        "unit": "TZ=UTC jest --selectProjects unit",
+        "perf": "TZ=UTC jest --selectProjects perf",
         "test": "TZ=UTC jest",
         "db:reset": "prisma migrate reset --skip-generate",
         "db:reset-hard": "prisma migrate reset -f --skip-generate",
@@ -144,36 +146,58 @@
         "lint-staged"
     ],
     "jest": {
-        "moduleFileExtensions": [
-            "js",
-            "json",
-            "ts"
-        ],
-        "preset": "ts-jest/presets/default-esm",
-        "extensionsToTreatAsEsm": [
-            ".ts"
-        ],
-        "testRegex": ".*\\.spec\\.ts$",
-        "moduleNameMapper": {
-            "^(\\.{1,2}/.*)\\.js$": "$1"
-        },
-        "transform": {
-            "^.+\\.[tj]sx?$": [
-                "ts-jest",
-                {
-                    "useESM": true
-                }
-            ]
-        },
-        "collectCoverageFrom": [
-            "**/*.(t|j)s"
-        ],
-        "coverageDirectory": "../coverage",
-        "testEnvironment": "node",
-        "verbose": true,
-        "clearMocks": true,
-        "setupFilesAfterEnv": [
-            "<rootDir>/jest/singletons.ts"
+        "projects": [
+            {
+                "displayName": "unit",
+                "testRegex": [".*\\.spec\\.ts$"],
+                "moduleFileExtensions": [
+                    "js",
+                    "json",
+                    "ts"
+                ],
+                "preset": "ts-jest/presets/default-esm",
+                "extensionsToTreatAsEsm": [
+                    ".ts"
+                ],
+                "moduleNameMapper": {
+                    "^(\\.{1,2}/.*)\\.js$": "$1"
+                },
+                "transform": {
+                    "^.+\\.[tj]sx?$": [
+                        "ts-jest",
+                        {
+                            "useESM": true
+                        }
+                    ]
+                },
+                "testEnvironment": "node",
+                "clearMocks": true,
+                "setupFilesAfterEnv": [
+                    "<rootDir>/jest/singletons.ts"
+                ]
+            },
+            {
+                "displayName": "perf",
+                "testRegex": [".*\\.perf\\.ts$"],
+                "moduleFileExtensions": [
+                    "js",
+                    "json",
+                    "ts"
+                ],
+                "preset": "ts-jest/presets/default-esm",
+                "extensionsToTreatAsEsm": [
+                    ".ts"
+                ],
+                "transform": {
+                    "^.+\\.[tj]sx?$": [
+                        "ts-jest",
+                        {
+                            "useESM": true
+                        }
+                    ]
+                },
+                "testEnvironment": "node"
+            }
         ]
     },
     "nodemonConfig": {


### PR DESCRIPTION
Splits the tests into small unit tests that are fast to run (`npm run unit`) and perf tests that might take longer (`npm run perf`) - `npm run test` runs all of them in the barrier. 

Adds a performance test for the matching algorithm, which simulates a real world matching - pupils and students continously request matches, every N days the matching algorithm is run using the current pools, matched users are removed from the pool. At the end, reports how many matches are created, how many subjects and states match, and how long the pupils and students had to wait for the match.

Extends the Matching Algorithm to exclude duplicate matches (as the old implementation does). Currently implemented as a postfilter after the matching, dont think it happens often and is worth considering in the assignment itself. 

https://github.com/corona-school/project-user/issues/1316