### PR TITLE
fix: Remove start-date limitation

### DIFF
--- a/jobs/slack-statistics.ts
+++ b/jobs/slack-statistics.ts
@@ -124,7 +124,6 @@ export async function postStatisticsToSlack() {
         },
         where: {
             lecture: {
-                every: { start: { lt: end } },
                 some: { start: { gte: begin, lt: end } },
             },
             published: true,


### PR DESCRIPTION
## What was done?

Updated the Slack-statistics query to remove limitation that force all lectures to start in the current month