### PR TITLE
feat: Re-invite match when an appointment is rescheduled

### DIFF
--- a/common/appointment/update.ts
+++ b/common/appointment/update.ts
@@ -25,16 +25,17 @@ export async function updateAppointment(
         throw new Error(`Cannot update past appointment.`);
     }
 
-    const updatedAppointment = await prisma.lecture.update({
-        where: { id: id },
-        data: { ...appointmentUpdate },
-    });
-
-    logger.info(`User(${user.userID}) updated Appointment(${appointment.id})`, { appointment, appointmentUpdate });
-
     const sameStart = !newStart || start.toISOString() === newStart.toISOString();
     const sameDuration = !newDuration || duration === newDuration;
     const sameDate = sameStart && sameDuration;
+    const matchAppointmentDateChanged = appointmentType === 'match' && !sameDate;
+
+    const updatedAppointment = await prisma.lecture.update({
+        where: { id: id },
+        data: matchAppointmentDateChanged ? { ...appointmentUpdate, declinedBy: [] } : appointmentUpdate,
+    });
+
+    logger.info(`User(${user.userID}) updated Appointment(${appointment.id})`, { appointment, appointmentUpdate });
 
     if (sameDate) {
         return;


### PR DESCRIPTION
## Ticket

https://github.com/corona-school/project-user/issues/1303

## What was done?

- Remove match from declinedBy when the appointment is rescheduled