### PR TITLE
Fix: Webflow sync job pagination

### DIFF
--- a/jobs/periodic/sync-to-webflow/sync-courses.ts
+++ b/jobs/periodic/sync-to-webflow/sync-courses.ts
@@ -196,6 +196,9 @@ export default async function syncCourses(logger: Logger): Promise<void> {
     logger.info('Start course sync');
     const webflowCourses = await getCollectionItems<CourseDTO>(collectionId, courseDTOFactory);
     const webflowLectures = await getCollectionItems<LectureDTO>(lectureCollectionId, lectureDTOFactory);
+    logger.info(`Total courses retrieved from Webflow: ${webflowCourses.length}`);
+    logger.info(`Total lectures retrieved from Webflow: ${webflowLectures.length}`);
+
     const lectureDBIdMap = mapToDBId<LectureDTO>(webflowLectures);
 
     const subCourses = await getWebflowSubcourses();
@@ -207,8 +210,12 @@ export default async function syncCourses(logger: Logger): Promise<void> {
 
     const newIds: string[] = [];
     for (const row of result.new) {
-        const newId = await createNewItem(collectionId, row);
-        newIds.push(newId);
+        try {
+            const newId = await createNewItem(collectionId, row);
+            newIds.push(newId);
+        } catch (error) {
+            logger.error('Could not create course in Webflow', error, { row });
+        }
     }
     logger.info('created new items', { itemIds: newIds });
 

--- a/jobs/periodic/sync-to-webflow/sync-lectures.ts
+++ b/jobs/periodic/sync-to-webflow/sync-lectures.ts
@@ -45,6 +45,7 @@ export async function syncLectures(logger: Logger): Promise<{ itemsToDelete: Web
 
     logger.info('Start lecture sync');
     const webflowLectures = await getCollectionItems<WebflowMetadata>(lectureCollectionId, lectureDTOFactory);
+    logger.info(`Total lectures retrieved from Webflow: ${webflowLectures.length}`);
     const subCourses = await getWebflowSubcourses();
     const dbLectures = subCourses
         .map((lecture) => lecture.lecture)
@@ -56,8 +57,12 @@ export async function syncLectures(logger: Logger): Promise<{ itemsToDelete: Web
 
     const newIds: string[] = [];
     for (const row of result.new) {
-        const newId = await createNewItem(lectureCollectionId, row);
-        newIds.push(newId);
+        try {
+            const newId = await createNewItem(lectureCollectionId, row);
+            newIds.push(newId);
+        } catch (error) {
+            logger.error('Could not create lecture in Webflow', error, { row });
+        }
     }
     logger.info('created new items', { itemIds: newIds });
 


### PR DESCRIPTION
## Ticket

Resolves https://github.com/corona-school/project-user/issues/1377

## What was done?

- Added a basic pagination implementation to allow the job to delete the excess data from Webflow CMS
- Added some try-catch to prevent the job from failing due to it not being able to create more items (It won't be able to do it, at least on the first try because right now Webflow has reached max capacity 😅)

## Next steps

- I'd try to monitor how it would work using the `WEBFLOW_SYNC_DRY_RUN` flag before actually running it on Prod.