### PR TITLE
Feat: Add new actions for DaZ Matches and Instructors Only Users

### DIFF
--- a/common/notification/actions.ts
+++ b/common/notification/actions.ts
@@ -279,6 +279,15 @@ const _notificationActions = {
             },
         },
     },
+    instructor_completed_first_appointment: {
+        description: 'Instructor / Completed first appointment',
+        sampleContext: {
+            course: {
+                name: 'Hallo Welt',
+                description: 'Ein Kurs',
+            },
+        },
+    },
     instructor_course_ended: {
         description: 'Instructor / Course ended',
         sampleContext: sampleCourse,
@@ -423,6 +432,26 @@ const _notificationActions = {
 
     tutor_matching_success: {
         description: 'Tutor / Match success',
+        sampleContext: {
+            pupil: sampleUser,
+            pupilGrade: '3. Klasse',
+            matchHash: '...',
+            matchDate: '...',
+            firstMatch: true,
+        },
+    },
+    tutor_daz_matching_success: {
+        description: 'Tutor / DaZ Match success',
+        sampleContext: {
+            pupil: sampleUser,
+            pupilGrade: '3. Klasse',
+            matchHash: '...',
+            matchDate: '...',
+            firstMatch: true,
+        },
+    },
+    tutor_standard_matching_success: {
+        description: 'Tutor / Standard Match success',
         sampleContext: {
             pupil: sampleUser,
             pupilGrade: '3. Klasse',

--- a/common/notification/actions.ts
+++ b/common/notification/actions.ts
@@ -279,13 +279,12 @@ const _notificationActions = {
             },
         },
     },
-    instructor_completed_first_appointment: {
+    instructor_first_appointment_completed: {
         description: 'Instructor / Completed first appointment',
         sampleContext: {
-            course: {
-                name: 'Hallo Welt',
-                description: 'Ein Kurs',
-            },
+            uniqueId: 'REQUIRED',
+            appointment: sampleAppointment,
+            ...sampleCourse,
         },
     },
     instructor_course_ended: {

--- a/common/notification/hook.ts
+++ b/common/notification/hook.ts
@@ -5,25 +5,26 @@
 
 import { student as Student, pupil as Pupil } from '@prisma/client';
 import { getPupil, getStudent, User } from '../user';
+import { NotificationContext } from './types';
 
-type NotificationHook = { fn: (user: User) => Promise<void>; description: string };
+type NotificationHook = { fn: (user: User, context: NotificationContext) => Promise<void>; description: string };
 
 const hooks: { [hookID: string]: NotificationHook } = {};
 
 export const hookExists = (hookID: string) => hookID in hooks;
 export const getHookDescription = (hookID: string) => hooks[hookID]?.description;
 
-export async function triggerHook(hookID: string, user: User) {
+export async function triggerHook(hookID: string, user: User, context: NotificationContext) {
     if (!hookExists(hookID)) {
         throw new Error(`Unknown hook ${hookID}`);
     }
 
     const hook = hooks[hookID];
 
-    await hook.fn(user);
+    await hook.fn(user, context);
 }
 
-export function registerHook(hookID: string, description: string, fn: (user: User) => Promise<void>) {
+export function registerHook(hookID: string, description: string, fn: (user: User, context: NotificationContext) => Promise<void>) {
     if (hookExists(hookID)) {
         throw new Error(`Hook may only be registered once`);
     }
@@ -31,8 +32,8 @@ export function registerHook(hookID: string, description: string, fn: (user: Use
     hooks[hookID] = { description, fn };
 }
 
-export const registerStudentHook = (hookID: string, description: string, hook: (student: Student) => Promise<void>) =>
-    registerHook(hookID, description, (user) => getStudent(user).then(hook));
+export const registerStudentHook = (hookID: string, description: string, hook: (student: Student, context: NotificationContext) => Promise<void>) =>
+    registerHook(hookID, description, (user, context) => getStudent(user).then((student) => hook(student, context)));
 
-export const registerPupilHook = (hookID: string, description: string, hook: (pupil: Pupil) => Promise<void>) =>
-    registerHook(hookID, description, (user) => getPupil(user).then(hook));
+export const registerPupilHook = (hookID: string, description: string, hook: (pupil: Pupil, context: NotificationContext) => Promise<void>) =>
+    registerHook(hookID, description, (user, context) => getPupil(user).then((pupil) => hook(pupil, context)));

--- a/common/notification/hooks.ts
+++ b/common/notification/hooks.ts
@@ -4,6 +4,10 @@ import { registerPupilHook, registerStudentHook } from './hook';
 //  this ensures that the hooks are always registered when the Notification is loaded (i.e. in the jobs Deno, which only loads parts of the backend)
 import { deactivateStudent } from '../student/activation';
 import { cancelRemissionRequest } from '../remission-request';
+import { prisma } from '../prisma';
+import { userForStudent } from '../user';
+import * as Notification from '../../common/notification';
+import { SpecificNotificationContext } from './actions';
 
 registerStudentHook(
     'deactivate-student',
@@ -16,6 +20,27 @@ registerStudentHook(
 registerStudentHook('cancel-remission-request', 'Cancels the remission request(s) of a student; called upon cancelling the CoC reminder', async (student) => {
     await cancelRemissionRequest(student);
 });
+
+registerStudentHook(
+    'attempt-invite-instructor-to-reflection-meeting',
+    'Instructors are invited to participate in a reflection meeting after their very first group appointment',
+    async (student, context) => {
+        if (student.isStudent) {
+            return;
+        }
+        const user = userForStudent(student);
+        const appointmentContext = context as SpecificNotificationContext<'student_group_appointment_starts'>;
+        const triggeredAppointmentId = Number(context.uniqueId);
+        const firstInstructorAppointment = await prisma.lecture.findFirst({
+            where: { organizerIds: { has: user.userID }, isCanceled: false, appointmentType: 'group' },
+            orderBy: { start: 'asc' },
+        });
+        const isFirstInstructorAppointment = triggeredAppointmentId === firstInstructorAppointment.id;
+        if (isFirstInstructorAppointment) {
+            await Notification.actionTaken(user, 'instructor_first_appointment_completed', appointmentContext);
+        }
+    }
+);
 
 import { deletePupilMatchRequest } from '../match/request';
 import { deactivatePupil } from '../pupil/activation';

--- a/common/notification/hooks.ts
+++ b/common/notification/hooks.ts
@@ -23,9 +23,10 @@ registerStudentHook('cancel-remission-request', 'Cancels the remission request(s
 
 registerStudentHook(
     'attempt-invite-instructor-to-reflection-meeting',
-    'Instructors are invited to participate in a reflection meeting after their very first group appointment',
+    'Instructors (without matches) are invited to participate in a reflection meeting after their very first group appointment',
     async (student, context) => {
-        if (student.isStudent) {
+        const activeMatches = await prisma.match.count({ where: { studentId: student.id, dissolved: false } });
+        if (activeMatches > 0) {
             return;
         }
         const user = userForStudent(student);

--- a/common/notification/index.ts
+++ b/common/notification/index.ts
@@ -106,7 +106,8 @@ async function deliverNotification(
     try {
         // Always trigger the hook, no matter whether we actually send something to the user
         if (notification.hookID) {
-            await triggerHook(notification.hookID, user);
+            logger.debug(`Running Hook(${notification.hookID}) for ConcreteNotification(${concreteNotification.id})`);
+            await triggerHook(notification.hookID, user, context);
         }
 
         const channelPreferencesForMessageType = await getNotificationChannelPreferences(user, concreteNotification);

--- a/common/util/subjectsutils.ts
+++ b/common/util/subjectsutils.ts
@@ -115,3 +115,5 @@ export function parseSubjectString(subjects: string): Subject[] {
         };
     });
 }
+
+export const DAZ = 'Deutsch als Zweitsprache';


### PR DESCRIPTION
## Ticket

- Resolves https://github.com/corona-school/project-user/issues/1275
- Resolves https://github.com/corona-school/project-user/issues/1281

## What was done?

- Add/Trigger new action when a DaZ match is created
- Add a hook/action to invite Instructors only users to reflection meetings after completing their very first group appointment