### PR TITLE
fix: Require ethics onboarding after screening success

### DIFF
--- a/common/student/screening.ts
+++ b/common/student/screening.ts
@@ -18,6 +18,10 @@ interface ScreeningInput {
 
 const logger = getLogger('Student Screening');
 
+export const requireStudentOnboarding = async (studentId: number) => {
+    await prisma.student.update({ where: { id: studentId }, data: { hasDoneEthicsOnboarding: false } });
+};
+
 export async function addInstructorScreening(screener: Screener, student: Student, screening: ScreeningInput, skipCoC: boolean) {
     await prisma.instructor_screening.create({
         data: {
@@ -37,6 +41,7 @@ export async function addInstructorScreening(screener: Screener, student: Studen
 
         const asUser = userForStudent(student);
         await Notification.actionTaken(asUser, 'instructor_screening_success', {});
+        await requireStudentOnboarding(student.id);
         await updateSessionRolesOfUser(asUser.userID);
     } else {
         await Notification.actionTaken(userForStudent(student), 'instructor_screening_rejection', {});
@@ -66,6 +71,7 @@ export async function addTutorScreening(
             await updateSessionRolesOfUser(asUser.userID);
             await scheduleCoCReminders(student);
             await Notification.actionTaken(userForStudent(student), 'tutor_screening_success', {});
+            await requireStudentOnboarding(student.id);
         } else {
             await Notification.actionTaken(userForStudent(student), 'tutor_screening_rejection', {});
         }

--- a/graphql/student/mutations.ts
+++ b/graphql/student/mutations.ts
@@ -11,6 +11,7 @@ import {
     addInstructorScreening,
     addTutorScreening,
     cancelCoCReminders,
+    requireStudentOnboarding,
     scheduleCoCReminders,
     updateInstructorScreening,
     updateTutorScreening,
@@ -514,8 +515,7 @@ export class MutateStudentResolver {
     @Authorized(Role.STUDENT_SCREENER)
     async studentRequireOnboarding(@Ctx() context: GraphQLContext, @Arg('studentId') studentId: number) {
         const student = await getStudent(studentId);
-
-        await updateStudent(context, student, { hasDoneEthicsOnboarding: false });
+        await requireStudentOnboarding(student.id);
         return true;
     }
 }


### PR DESCRIPTION
## What was done?

- Added logic to require student ethics onboarding after a successful screening

This is currently done on the frontend but it'd be better to have it on the backend. For example, screenings done on Retool do not enforce this onboarding