### PR TITLE
feat: Add student field descriptionForScreening

### DIFF
--- a/graphql/authorizations.ts
+++ b/graphql/authorizations.ts
@@ -516,6 +516,7 @@ export const authorizationModelEnhanceMap: ModelsEnhanceMap = {
             descriptionForMatch: onlyAdminOrScreener,
             hasSpecialExperience: onlyAdminOrScreener,
             gender: onlyAdminOrScreener,
+            descriptionForScreening: onlyAdminOrScreener,
         }),
     },
 

--- a/graphql/student/mutations.ts
+++ b/graphql/student/mutations.ts
@@ -172,6 +172,9 @@ export class StudentUpdateInput {
 
     @Field((type) => String, { nullable: true })
     descriptionForMatch?: string;
+
+    @Field((type) => String, { nullable: true })
+    descriptionForScreening?: string;
 }
 
 const logger = getLogger('Student Mutations');
@@ -199,6 +202,7 @@ export async function updateStudent(
         hasSpecialExperience,
         gender,
         descriptionForMatch,
+        descriptionForScreening,
     } = update;
 
     if (projectFields && !student.isProjectCoach) {
@@ -229,6 +233,10 @@ export async function updateStudent(
         throw new PrerequisiteError('descriptionForMatch may only be changed by elevated users');
     }
 
+    if (descriptionForScreening !== undefined && !isElevated(context)) {
+        throw new PrerequisiteError('descriptionForScreening may only be changed by elevated users');
+    }
+
     if (projectFields) {
         await setProjectFields(student, projectFields);
     }
@@ -250,6 +258,7 @@ export async function updateStudent(
             hasSpecialExperience: ensureNoNull(hasSpecialExperience),
             gender: ensureNoNull(gender),
             descriptionForMatch,
+            descriptionForScreening,
         },
         where: { id: student.id },
     });

--- a/prisma/migrations/20241213093513_add_description_for_screening_to_student/migration.sql
+++ b/prisma/migrations/20241213093513_add_description_for_screening_to_student/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "student" ADD COLUMN     "descriptionForScreening" VARCHAR NOT NULL DEFAULT '';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -914,14 +914,16 @@ model student {
   // Should stay null for users who where registered before the onboarding got added
   hasDoneEthicsOnboarding              Boolean?
 
-  cooperationID        Int?
-  cooperation          cooperation? @relation(fields: [cooperationID], references: [id])
+  cooperationID           Int?
+  cooperation             cooperation? @relation(fields: [cooperationID], references: [id])
   // Used to match students that have have experience supporting pupils with learning difficulties
-  hasSpecialExperience Boolean      @default(false)
+  hasSpecialExperience    Boolean      @default(false)
+  // Used as an "AboutMe" for screening or for other type of Meetings between Lern-Fair and the student
+  descriptionForScreening String       @default("") @db.VarChar
   // Screeners provide future matches tips or information about the student to help improve the collaboration
-  descriptionForMatch  String       @default("") @db.VarChar
+  descriptionForMatch     String       @default("") @db.VarChar
   // Used to match pupils that may prefer be matched only with a specific gender. See pupil.onlyMatchWith
-  gender               gender_enum?
+  gender                  gender_enum?
 }
 
 // A concrete course with participants, each course might have multiple subcourses with different instructors


### PR DESCRIPTION
## What was done?

Added a new field `descriptionForScreening` that Student screenings use to keep general information about students across different meetings they have with them (I forgot to add this field in my previous [PR](https://github.com/corona-school/backend/pull/1163)