### PR TITLE
feat: Cleanup match to match_pool_run relation

### DIFF
--- a/common/achievement/evaluate.spec.ts
+++ b/common/achievement/evaluate.spec.ts
@@ -270,6 +270,7 @@ function createTestMatch({ lectures }: { lectures: lecture[] }): MatchWithLectur
         matchPool: null,
         studentId: null,
         pupilId: null,
+        matchPoolRunId: null,
     };
 }
 

--- a/common/achievement/evaluate.spec.ts
+++ b/common/achievement/evaluate.spec.ts
@@ -265,7 +265,6 @@ function createTestMatch({ lectures }: { lectures: lecture[] }): MatchWithLectur
         feedbackToStudentMail: false,
         followUpToPupilMail: false,
         followUpToStudentMail: false,
-        source: 'imported',
         studentFirstMatchRequest: null,
         pupilFirstMatchRequest: null,
         matchPool: null,

--- a/common/match/create.ts
+++ b/common/match/create.ts
@@ -38,6 +38,7 @@ export async function createMatch(pupil: Pupil, student: Student, pool: Concrete
             pupilFirstMatchRequest: pupil.firstMatchRequest,
             studentFirstMatchRequest: student.firstMatchRequest,
             matchPool: pool.name,
+            matchPoolRunId: null,
         },
     });
 

--- a/common/match/create.ts
+++ b/common/match/create.ts
@@ -1,4 +1,4 @@
-import { student as Student, pupil as Pupil } from '@prisma/client';
+import { student as Student, pupil as Pupil, match as Match } from '@prisma/client';
 import { prisma } from '../prisma';
 import { v4 as generateUUID } from 'uuid';
 import { getPupilGradeAsString } from '../pupil';
@@ -14,7 +14,7 @@ import { DAZ } from '../util/subjectsutils';
 
 const logger = getLogger('Match');
 
-export async function createMatch(pupil: Pupil, student: Student, pool: ConcreteMatchPool) {
+export async function createMatch(pupil: Pupil, student: Student, pool: ConcreteMatchPool): Promise<Match> {
     const uuid = generateUUID();
 
     // Refetch match request count to reduce the likelihood of race conditions

--- a/common/match/pool.ts
+++ b/common/match/pool.ts
@@ -1,5 +1,5 @@
 import { prisma } from '../prisma';
-import type { Prisma, pupil as Pupil, student as Student } from '@prisma/client';
+import type { Prisma, pupil as Pupil, student as Student, match as Match } from '@prisma/client';
 import { createMatch } from './create';
 import { assertExists } from '../util/basic';
 import { getLogger } from '../logger/logger';
@@ -21,7 +21,7 @@ export interface MatchPool {
     readonly name: string;
     studentsToMatch: (toggles: readonly Toggle[]) => Prisma.studentWhereInput;
     pupilsToMatch: (toggles: readonly Toggle[]) => Prisma.pupilWhereInput;
-    readonly createMatch: (pupil: Pupil, student: Student, pool: MatchPool) => Promise<any | never>;
+    readonly createMatch: (pupil: Pupil, student: Student, pool: MatchPool) => Promise<Match>;
     readonly toggles: readonly Toggle[];
     // There are a few well known toggles:
     //  "skip-interest-confirmation" -> do not exclude pupils that have not confirmed their interest
@@ -392,19 +392,27 @@ export async function runMatching(poolName: string, apply: boolean, _toggles: st
 
     if (apply) {
         const startCommit = Date.now();
+        const createdMatches: Match[] = [];
+
         for (const match of matches) {
-            await pool.createMatch(match.pupil, match.student, pool);
+            createdMatches.push(await pool.createMatch(match.pupil, match.student, pool));
         }
 
         timing.commit = Date.now() - startCommit;
         logger.info(`MatchingPool(${pool.name}) created ${matches.length} matches in ${timing.matching}ms`);
 
-        await prisma.match_pool_run.create({
+        const run = await prisma.match_pool_run.create({
             data: {
                 matchingPool: pool.name,
                 matchesCreated: matches.length,
                 stats,
             },
+        });
+
+        // After creating matches and the match run, link them together
+        await prisma.match.updateMany({
+            data: { matchPoolRunId: run.id },
+            where: { id: { in: createdMatches.map((it) => it.id) } },
         });
     }
 

--- a/prisma/migrations/20250102153056_drop_match_source/migration.sql
+++ b/prisma/migrations/20250102153056_drop_match_source/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `source` on the `match` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "match" DROP COLUMN "source";
+
+-- DropEnum
+DROP TYPE "match_source_enum";

--- a/prisma/migrations/20250102153441_link_match_to_matchpoolrun/migration.sql
+++ b/prisma/migrations/20250102153441_link_match_to_matchpoolrun/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "match" ADD COLUMN     "matchPoolRunId" INTEGER;
+
+-- AddForeignKey
+ALTER TABLE "match" ADD CONSTRAINT "match_matchPoolRunId_fkey" FOREIGN KEY ("matchPoolRunId") REFERENCES "match_pool_run"("id") ON DELETE NO ACTION ON UPDATE NO ACTION;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -491,6 +491,10 @@ model match {
 
   learning_topics learning_topic[]
 
+  // For "automatic matches", stores the Match Run that created this match (since 01/2025)
+  matchPoolRunId Int?
+  matchPoolRun match_pool_run? @relation(fields: [matchPoolRunId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+
   // Pupils never get matched to the same Student again,
   // if they want to continue their match we reactivate the existing match instead
   @@unique([studentId, pupilId], name: "UQ_MATCH", map: "UQ_MATCH")
@@ -1010,6 +1014,8 @@ model match_pool_run {
   matchingPool   String   @db.VarChar
   matchesCreated Int
   stats          Json     @db.Json
+
+  matches        match[]
 }
 
 // A Secret allows a User to log in, i.e. a Token sent to the user via Email or their Password

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -473,9 +473,6 @@ model match {
   followUpToPupilMail   Boolean            @default(false)
   followUpToStudentMail Boolean            @default(false)
 
-  // DEPRECATED: In the early days, matching was done offline and the data was imported into the DB
-  source match_source_enum @default(matchedinternal)
-
   // FirstMatchRequest - createdAt gives a rough estimate how long a student / pupil had to wait for a match
   // As a user can create multiple match requests, and we do not know which match request lead to which match,
   // we store the time of the first match request. So this can be seen as an upper boundary, but the average user
@@ -1175,13 +1172,6 @@ enum log_logtype_enum {
   pupilInterestConfirmationRequestReminderSent
   pupilInterestConfirmationRequestStatusChange
   skippedCoC
-}
-
-// DEPRECATED
-enum match_source_enum {
-  imported
-  matchedexternal
-  matchedinternal
 }
 
 // DEPRECATED


### PR DESCRIPTION
Add foreign key relationship between match and match run to track all matches that were created at once,
 additionally drop Match.source as it is unused since 4 years + misleading.