### PR TITLE
fix: Expire screener token

### DIFF
--- a/graphql/screener/mutations.ts
+++ b/graphql/screener/mutations.ts
@@ -43,7 +43,10 @@ export class MutateScreenerResolver {
             },
         });
 
-        const token = await createToken(userForScreener(screener));
+        const expiresAt = new Date();
+        expiresAt.setDate(expiresAt.getDate() + 7);
+
+        const token = await createToken(userForScreener(screener), expiresAt);
 
         log.info(`Admin created Screener(${screener.id}) and retrieved a login token`, data);
 


### PR DESCRIPTION
When creating a screener the token created lives forever which is a security problem (especially as it is shared with the user creating the screener account). Now it expires after one week, the screener should set their password in the meantime.

resolves https://github.com/corona-school/project-user/issues/1233