### PR TITLE
fix: Invalid Zoom Meeting Id

### DIFF
--- a/common/util/error.ts
+++ b/common/util/error.ts
@@ -18,3 +18,11 @@ export const TooLateError = createClientError('TOO_LATE');
 export const CapacityReachedError = createClientError('CAPACITY_REACHED');
 export const PrerequisiteError = createClientError('PREREQUISITE');
 export const NotAllowedError = createClientError('NOT_ALLOWED');
+
+export class ZoomError extends Error {
+    constructor(public readonly message: string, public readonly status: number, public readonly code?: number) {
+        super(message);
+        this.status = status;
+        this.code = code;
+    }
+}

--- a/common/zoom/scheduled-meeting.ts
+++ b/common/zoom/scheduled-meeting.ts
@@ -7,6 +7,7 @@ import { lecture as Appointment } from '@prisma/client';
 import { prisma } from '../prisma';
 import moment from 'moment';
 import assert from 'assert';
+import { ZoomError } from '../util/error';
 
 const logger = getLogger('Zoom Meeting');
 
@@ -119,7 +120,8 @@ async function getZoomMeeting(appointment: Appointment): Promise<ZoomMeeting> {
     );
 
     if (!response.ok) {
-        throw new Error(`Zoom - failed to get meeting with ${response.status} ${await response.text()}`);
+        const error = await response.json();
+        throw new ZoomError(`Zoom - failed to get meeting with ${response.status} ${error.message}`, response.status, error.code);
     }
 
     const meeting = (await response.json()) as ZoomMeeting;

--- a/graphql/appointment/fields.ts
+++ b/graphql/appointment/fields.ts
@@ -209,9 +209,6 @@ export class ExtendedFieldsLectureResolver {
                 logger.error(`Zoom Meeting Id (${appointment.zoomMeetingId}) expired or deleted`);
                 await deleteZoomMeeting(appointment);
                 await createZoomMeetingForAppointment(await getLecture(appointment.id));
-                if (isAppointmentOrganizer) {
-                    return await getZoomUrl(user, await getLecture(appointment.id));
-                }
             }
         }
 
@@ -220,7 +217,7 @@ export class ExtendedFieldsLectureResolver {
             logger.info(`Admin requested zoom meeting url`);
             return zoomMeeting.join_url;
         }
-        return await getZoomUrl(user, appointment);
+        return await getZoomUrl(user, await getLecture(appointment.id));
     }
 
     @FieldResolver((returns) => Match, { nullable: true })

--- a/graphql/appointment/fields.ts
+++ b/graphql/appointment/fields.ts
@@ -3,15 +3,19 @@ import { Arg, Authorized, Ctx, Field, FieldResolver, Int, ObjectType, Query, Res
 import { Lecture as Appointment, lecture_appointmenttype_enum, Match, Subcourse } from '../generated';
 import { GraphQLContext } from '../context';
 import { getSessionStudent, getUserForSession, isElevated, isSessionStudent } from '../authentication';
-import { Deprecated, getMatch, getSubcourse } from '../util';
+import { Deprecated, getLecture, getMatch, getSubcourse } from '../util';
 import { LimitEstimated } from '../complexity';
 import { prisma } from '../../common/prisma';
 import { getUserTypeAndIdForUserId, getUsers, getUser } from '../../common/user';
 import { GraphQLJSON } from 'graphql-scalars';
-import { getZoomMeeting } from '../../common/zoom/scheduled-meeting';
+import { deleteZoomMeeting, getZoomMeeting } from '../../common/zoom/scheduled-meeting';
 import { UserType } from '../types/user';
 import { getZoomUrl } from '../../common/zoom/user';
 import { getLogger } from '../../common/logger/logger';
+import moment from 'moment';
+import { getAppointmentEnd } from '../../common/appointment/util';
+import { ZoomError } from '../../common/util/error';
+import { createZoomMeetingForAppointment } from '../../common/appointment/create';
 
 const logger = getLogger('Appointment Fields');
 
@@ -181,6 +185,34 @@ export class ExtendedFieldsLectureResolver {
         if (!appointment.zoomMeetingId) {
             logger.info(`No zoom meeting id exist for appointment id ${appointment.id}`);
             return null;
+        }
+
+        const isAppointmentOrganizer = appointment.organizerIds.includes(user.userID);
+        const isAppointmentCanceled = appointment.isCanceled;
+        // Hasn't ended yet - This includes the duration of the meeting
+        const isAppointmentInTheFuture = moment().isSameOrBefore(getAppointmentEnd(appointment));
+        const isOrganizerOrAdmin = isAppointmentOrganizer || isAdmin;
+
+        // If any of these we just use the previous logic
+        if (!isOrganizerOrAdmin || !isAppointmentInTheFuture || isAppointmentCanceled) {
+            return await getZoomUrl(user, appointment);
+        }
+
+        try {
+            // Asking Zoom for the meeting details is the only way to verify if Zoom recognizes the meetingId we have
+            await getZoomMeeting(appointment);
+        } catch (error) {
+            const zoomError = error as ZoomError;
+            // If for some reason this meeting is now expired/deleted according to zoom (which shouldn't be the case)
+            // We just try to recreate it.
+            if (zoomError?.status === 404 && zoomError?.code === 3001) {
+                logger.error(`Zoom Meeting Id (${appointment.zoomMeetingId}) expired or deleted`);
+                await deleteZoomMeeting(appointment);
+                await createZoomMeetingForAppointment(await getLecture(appointment.id));
+                if (isAppointmentOrganizer) {
+                    return await getZoomUrl(user, await getLecture(appointment.id));
+                }
+            }
         }
 
         if (isAdmin) {

--- a/graphql/appointment/mutations.ts
+++ b/graphql/appointment/mutations.ts
@@ -217,6 +217,8 @@ export class MutateAppointmentResolver {
                 logger.error(`Zoom Meeting Id (${appointment.zoomMeetingId}) expired or deleted`);
                 await deleteZoomMeeting(appointment);
                 await createZoomMeetingForAppointment(await getLecture(appointment.id));
+            } else {
+                throw error;
             }
         }
 


### PR DESCRIPTION
## Ticket

Resolves https://github.com/corona-school/project-user/issues/1395

## What was done?

Added a patch for those rare cases where Zoom doesn't recognize a `meetingId` they gave us. As explained in the ticket, we are trying to recreate a Zoom meeting only if

- The user is the owner of the appointment (?) or admin
- The appointment is not canceled
- The appointment has not yet ended
- There is a ZoomMeetingId
- Zoom doesn't recognize the ZoomMeetingId we have