### PR TITLE
Feat: Add pupil email owner field

### DIFF
--- a/common/pupil/registration.ts
+++ b/common/pupil/registration.ts
@@ -13,6 +13,7 @@ import {
     pupil_schooltype_enum as SchoolType,
     Prisma,
     PrismaClient,
+    pupil_email_owner_enum as PupilEmailOwner,
 } from '@prisma/client';
 import { logTransaction } from '../transactionlog/log';
 import { PrerequisiteError, RedundantError } from '../util/error';
@@ -25,6 +26,7 @@ import { getLogger } from '../logger/logger';
 export interface RegisterPupilData {
     firstname: string;
     lastname: string;
+    emailOwner: PupilEmailOwner;
     email: string;
     newsletter: boolean;
     school?: CreateSchoolArgs;
@@ -66,6 +68,7 @@ export async function registerPupil(data: RegisterPupilData, noEmail = false, pr
 
     const pupil = await prismaInstance.pupil.create({
         data: {
+            emailOwner: data.emailOwner,
             email: data.email.toLowerCase(),
             firstname: data.firstname,
             lastname: data.lastname,

--- a/graphql/authorizations.ts
+++ b/graphql/authorizations.ts
@@ -429,6 +429,7 @@ export const authorizationModelEnhanceMap: ModelsEnhanceMap = {
             descriptionForScreening: onlyAdminOrScreener,
             hasSpecialNeeds: onlyAdminOrScreener,
             onlyMatchWith: onlyAdminOrScreener,
+            emailOwner: adminOrOwnerOrScreener,
         }),
     },
 

--- a/graphql/types/enums.ts
+++ b/graphql/types/enums.ts
@@ -15,8 +15,13 @@ import {
     course_category_enum as CourseCategory,
     pupil_screening_status_enum as PupilScreeningStatus,
     gender_enum as Gender,
+    pupil_email_owner_enum as PupilEmailOwner,
 } from '@prisma/client';
 import { LoginOption } from '../../common/secret';
+
+registerEnumType(PupilEmailOwner, {
+    name: 'PupilEmailOwner',
+});
 
 registerEnumType(SchoolType, {
     name: 'SchoolType',

--- a/graphql/types/userInputs.ts
+++ b/graphql/types/userInputs.ts
@@ -10,6 +10,7 @@ import {
     pupil_state_enum as State,
     student_module_enum as TeacherModule,
     school as School,
+    pupil_email_owner_enum as PupilEmailOwner,
 } from '@prisma/client';
 import { ValidateEmail } from '../validators';
 import { BecomeTutorData, RegisterStudentData } from '../../common/student/registration';
@@ -59,6 +60,9 @@ export class RegisterPupilInput implements RegisterPupilData {
     @Field((type) => String)
     @MaxLength(100)
     lastname: string;
+
+    @Field((type) => PupilEmailOwner)
+    emailOwner: PupilEmailOwner;
 
     @Field((type) => String)
     @ValidateEmail()

--- a/integration-tests/01_user.ts
+++ b/integration-tests/01_user.ts
@@ -35,6 +35,7 @@ export async function createNewPupil() {
             meRegisterPupil(data: {
                 firstname: "firstname:${userRandom}"
                 lastname: "lastname:${userRandom}"
+                emailOwner: pupil
                 email: "test+${userRandom}@lern-fair.de"
                 newsletter: true
                 registrationSource: normal
@@ -53,6 +54,7 @@ export async function createNewPupil() {
             meRegisterPupil(data: {
                 firstname: "firstname:${userRandom}"
                 lastname: "lastname:${userRandom}"
+                emailOwner: pupil
                 email: "TEST+${userRandom}@lern-fair.de"
                 newsletter: true
                 registrationSource: normal
@@ -130,6 +132,7 @@ export const pupilTwo = test('Register Pupil', async () => {
             meRegisterPupil(data: {
                 firstname: "firstname:${userRandom}"
                 lastname: "lastname:${userRandom}"
+                emailOwner: pupil
                 email: "test+${userRandom}@lern-fair.de"
                 newsletter: true
                 registrationSource: normal
@@ -148,6 +151,7 @@ export const pupilTwo = test('Register Pupil', async () => {
             meRegisterPupil(data: {
                 firstname: "firstname:${userRandom}"
                 lastname: "lastname:${userRandom}"
+                emailOwner: pupil
                 email: "TEST+${userRandom}@lern-fair.de"
                 newsletter: true
                 registrationSource: normal

--- a/integration-tests/11_registerPlusMany.ts
+++ b/integration-tests/11_registerPlusMany.ts
@@ -115,6 +115,7 @@ void test('Plus pupil batch registration', async () => {
                     email: "test+${runId}+p1@lern-fair.de",
                     register: {
                         email: "test+differentEmail@lern-fair.de",
+                        emailOwner: pupil,
                         firstname: "f${userRandom()}",
                         lastname: "l${userRandom()}",
                         newsletter: false,
@@ -128,6 +129,7 @@ void test('Plus pupil batch registration', async () => {
                     email: "test+${runId}+p2@lern-fair.de",
                     register: {
                         email: "test+${runId}+p2@lern-fair.de",
+                        emailOwner: pupil,
                         firstname: "f${userRandom()}",
                         lastname: "l${userRandom()}",
                         newsletter: false,
@@ -149,6 +151,7 @@ void test('Plus pupil batch registration', async () => {
                     email: "test+${runId}+p2@lern-fair.de ",
                     register: {
                         email: "test+${runId}+p2@lern-fair.de",
+                        emailOwner: pupil,
                         firstname: "*updatedF*",
                         lastname: "*updatedL*",
                         newsletter: false,
@@ -183,6 +186,7 @@ void test('Plus pupil batch registration', async () => {
                     email: "test+${runId}+p?@@lern-fair.de",
                     register: {
                         email: "test+${runId}+p?@@lern-fair.de",
+                        emailOwner: pupil,
                         firstname: "f${userRandom()}",
                         lastname: "l${userRandom()}",
                         newsletter: false,

--- a/prisma/migrations/20250107131743_add_pupil_email_owner/migration.sql
+++ b/prisma/migrations/20250107131743_add_pupil_email_owner/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "pupil_email_owner_enum" AS ENUM ('pupil', 'parent', 'supportPerson', 'unknown');
+
+-- AlterTable
+ALTER TABLE "pupil" ADD COLUMN     "emailOwner" "pupil_email_owner_enum" NOT NULL DEFAULT 'unknown';

--- a/prisma/migrations/20250107131743_add_pupil_email_owner/migration.sql
+++ b/prisma/migrations/20250107131743_add_pupil_email_owner/migration.sql
@@ -1,5 +1,5 @@
 -- CreateEnum
-CREATE TYPE "pupil_email_owner_enum" AS ENUM ('pupil', 'parent', 'supportPerson', 'unknown');
+CREATE TYPE "pupil_email_owner_enum" AS ENUM ('pupil', 'parent', 'other', 'unknown');
 
 -- AlterTable
 ALTER TABLE "pupil" ADD COLUMN     "emailOwner" "pupil_email_owner_enum" NOT NULL DEFAULT 'unknown';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1559,6 +1559,6 @@ enum gender_enum {
 enum pupil_email_owner_enum {
   pupil
   parent
-  supportPerson
+  other
   unknown
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -493,7 +493,7 @@ model match {
 
   // For "automatic matches", stores the Match Run that created this match (since 01/2025)
   matchPoolRunId Int?
-  matchPoolRun match_pool_run? @relation(fields: [matchPoolRunId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  matchPoolRun   match_pool_run? @relation(fields: [matchPoolRunId], references: [id], onDelete: NoAction, onUpdate: NoAction)
 
   // Pupils never get matched to the same Student again,
   // if they want to continue their match we reactivate the existing match instead
@@ -716,6 +716,9 @@ model pupil {
   descriptionForScreening                      String                                         @default("") @db.VarChar
   // Screeners provide future matches tips or information about the pupil to help improve the collaboration
   descriptionForMatch                          String                                         @default("") @db.VarChar
+  // Sometimes pupils, specially younger ones, are registered with the email of a support person (parent, teacher, etc...)
+  // Here we specify who is the owner of this email
+  emailOwner                                   pupil_email_owner_enum                         @default(unknown)
 }
 
 // To only match active users, we sent interest confirmation requests to pupils before matching them
@@ -1015,7 +1018,7 @@ model match_pool_run {
   matchesCreated Int
   stats          Json     @db.Json
 
-  matches        match[]
+  matches match[]
 }
 
 // A Secret allows a User to log in, i.e. a Token sent to the user via Email or their Password
@@ -1551,4 +1554,11 @@ enum gender_enum {
   male
   female
   other
+}
+
+enum pupil_email_owner_enum {
+  pupil
+  parent
+  supportPerson
+  unknown
 }

--- a/seed-db.ts
+++ b/seed-db.ts
@@ -29,6 +29,7 @@ import {
     student as Student,
     course_subject_enum,
     learning_assignment_status,
+    pupil_email_owner_enum,
 } from '@prisma/client';
 import { importAchievements } from './seed-achievements';
 
@@ -51,6 +52,7 @@ const createPupil = async ({ includePassword = true, ...data }: CreatePupilArgs)
             schooltype: 'gymnasium',
             state: 'be',
         },
+        emailOwner: pupil_email_owner_enum.pupil,
     });
     await _createFixedToken(userForPupil(pupil), `authtokenP${pupil.id}`);
     if (includePassword) {


### PR DESCRIPTION
## Ticket

Resolves https://github.com/corona-school/project-user/issues/1386

## What was done?

- Added a new `emailOwner` field on the pupil
- Updated pupil registration input data
- Adjusted tests & seed data