### PR TITLE
Fix: Prevent creating new appointment for cancelled courses

### DIFF
--- a/common/appointment/create.ts
+++ b/common/appointment/create.ts
@@ -15,7 +15,6 @@ import { PrerequisiteError, RedundantError } from '../../common/util/error';
 import { getContextForGroupAppointmentReminder, getContextForMatchAppointmentReminder } from './util';
 import { getNotificationContextForSubcourse } from '../../common/courses/notifications';
 import { Decision } from '../util/decision';
-import { hasIn } from 'lodash';
 
 const logger = getLogger();
 

--- a/common/appointment/create.ts
+++ b/common/appointment/create.ts
@@ -1,7 +1,7 @@
 import { Field, InputType, Int } from 'type-graphql';
 import { prisma } from '../prisma';
 import assert from 'assert';
-import { Lecture, lecture_appointmenttype_enum } from '../../graphql/generated';
+import { Lecture, lecture_appointmenttype_enum, Subcourse } from '../../graphql/generated';
 import { createZoomMeeting, getZoomMeetingReport } from '../zoom/scheduled-meeting';
 import { getOrCreateZoomUser, getZoomUrl, ZoomUser } from '../zoom/user';
 import { lecture as Appointment, lecture_appointmenttype_enum as AppointmentType, student as Student } from '@prisma/client';
@@ -14,6 +14,8 @@ import { getMatch, getPupil, getStudent } from '../../graphql/util';
 import { PrerequisiteError, RedundantError } from '../../common/util/error';
 import { getContextForGroupAppointmentReminder, getContextForMatchAppointmentReminder } from './util';
 import { getNotificationContextForSubcourse } from '../../common/courses/notifications';
+import { Decision } from '../util/decision';
+import { hasIn } from 'lodash';
 
 const logger = getLogger();
 
@@ -116,13 +118,27 @@ export const createMatchAppointments = async (matchId: number, appointmentsToBeC
     return createdMatchAppointments;
 };
 
+export function canCreateGroupAppointment(subcourse: Subcourse, hasInstructors: boolean): Decision {
+    if (subcourse.cancelled) {
+        return { allowed: false, reason: 'course-cancelled' };
+    }
+
+    if (!hasInstructors) {
+        return { allowed: false, reason: 'no-instructors' };
+    }
+
+    return { allowed: true };
+}
+
 export const createGroupAppointments = async (subcourseId: number, appointmentsToBeCreated: AppointmentCreateGroupInput[], organizer: Student) => {
     const participants = await prisma.subcourse_participants_pupil.findMany({ where: { subcourseId: subcourseId }, select: { pupil: true } });
     const instructors = await prisma.subcourse_instructors_student.findMany({ where: { subcourseId: subcourseId }, select: { student: true } });
     const subcourse = await prisma.subcourse.findUnique({ where: { id: subcourseId }, include: { course: true } });
     const lastAppointment = await prisma.lecture.findFirst({ where: { subcourseId }, orderBy: { createdAt: 'desc' }, select: { override_meeting_link: true } });
-
-    assert(instructors.length > 0, `No instructors found for subcourse ${subcourseId} there must be at least one organizer for an appointment`);
+    const { allowed, reason } = canCreateGroupAppointment(subcourse, instructors.length > 0);
+    if (!allowed) {
+        throw new Error(`Cannot create group appointment for Subcourse(${subcourse.id}) reason: ${reason}`);
+    }
 
     // we don't want to create a Zoom meeting if there's an override_meeting_link specified in the last appointment
     let hosts: ZoomUser[] | null = null;

--- a/common/courses/filters.ts
+++ b/common/courses/filters.ts
@@ -29,6 +29,12 @@ export function excludePastSubcourses(): Prisma.subcourseWhereInput {
     };
 }
 
+export function excludeCancelledSubcourses(): Prisma.subcourseWhereInput {
+    return {
+        cancelled: false,
+    };
+}
+
 export function onlyPastSubcourses(): Prisma.subcourseWhereInput {
     const prevDay = new Date();
     prevDay.setDate(prevDay.getDate() - 1);

--- a/graphql/student/fields.ts
+++ b/graphql/student/fields.ts
@@ -23,7 +23,7 @@ import { strictUserSearch, userSearch } from '../../common/user/search';
 import { Instructor } from '../types/instructor';
 import { GraphQLContext } from '../context';
 import { predictedHookActionDate } from '../../common/notification';
-import { excludePastSubcourses, instructedBy } from '../../common/courses/filters';
+import { excludeCancelledSubcourses, excludePastSubcourses, instructedBy } from '../../common/courses/filters';
 import { Prisma } from '@prisma/client';
 import assert from 'assert';
 import { isSessionStudent } from '../authentication';
@@ -158,12 +158,17 @@ export class ExtendFieldsStudentResolver {
     async subcoursesInstructing(
         @Root() student: Required<Student>,
         @Arg('excludePast', { nullable: true }) excludePast?: boolean,
+        @Arg('excludeCancelled', { nullable: true }) excludeCancelled?: boolean,
         @Arg('search', { nullable: true }) search?: string
     ) {
         const filters: Prisma.subcourseWhereInput[] = [instructedBy(student)];
 
         if (excludePast) {
             filters.push(excludePastSubcourses());
+        }
+
+        if (excludeCancelled) {
+            filters.push(excludeCancelledSubcourses());
         }
 
         if (search) {


### PR DESCRIPTION
## Ticket

Resolves https://github.com/corona-school/project-user/issues/1392

## What was done?

- Add validation to prevent adding appointments to a cancelled course
- Add a filter to exclude cancelled courses from `subcoursesInstructing` query _(To be used in the frontend PR part of this same issue)_