### PR TITLE
Fix: Instant Certs: only count lectures that are in the past, add date variable, friendly date formatting

### DIFF
--- a/common/certificate/index.ts
+++ b/common/certificate/index.ts
@@ -251,7 +251,7 @@ export async function getConfirmationPage(certificateId: string, lang: Language,
         const verificationTemplate = loadTemplate('verifiedInstantCertificatePage', lang);
         return verificationTemplate({
             NAMESTUDENT: certificate.student?.firstname + ' ' + certificate.student?.lastname,
-            STARTDATE: certificate.startDate,
+            STARTDATE: moment(certificate.startDate).format('D.M.YYYY'),
             MATCHES_COUNT: certificate.matchesCount,
             MATCH_APPOINTMENTS_COUNT: certificate.matchAppointmentsCount,
             COURSE_PARTICIPANTS_COUNT: certificate.courseParticipantsCount,

--- a/common/certificate/index.ts
+++ b/common/certificate/index.ts
@@ -457,7 +457,6 @@ async function createInstantPDFBinary(certificate: InstantCertificate & { studen
     if (process.env.ENV == 'dev') {
         name = `[TEST] ${name}`;
     }
-    console.log(`VERIFICATION ${link}`);
     const result = template({
         NAMESTUDENT: name,
         STARTDATE: moment(certificate.startDate).format('D.M.YYYY'),

--- a/common/certificate/index.ts
+++ b/common/certificate/index.ts
@@ -257,6 +257,7 @@ export async function getConfirmationPage(certificateId: string, lang: Language,
             COURSE_PARTICIPANTS_COUNT: certificate.courseParticipantsCount,
             COURSE_APPOINTMENTS_COUNT: certificate.courseAppointmentsCount,
             TOTAL_APPOINTMENTS_DURATION: certificate.totalAppointmentsDuration,
+            DATUMHEUTE: moment(certificate.createdAt).format('D.M.YYYY'),
         });
     }
 }
@@ -462,6 +463,7 @@ async function createInstantPDFBinary(certificate: InstantCertificate & { studen
         COURSE_PARTICIPANTS_COUNT: certificate.courseParticipantsCount,
         COURSE_APPOINTMENTS_COUNT: certificate.courseAppointmentsCount,
         TOTAL_APPOINTMENTS_DURATION: certificate.totalAppointmentsDuration,
+        DATUMHEUTE: moment().format('D.M.YYYY'),
         QR_CODE: await QRCode.toDataURL(link),
     });
     return await generatePDFFromHTML(result, {

--- a/common/certificate/index.ts
+++ b/common/certificate/index.ts
@@ -457,7 +457,7 @@ async function createInstantPDFBinary(certificate: InstantCertificate & { studen
     }
     const result = template({
         NAMESTUDENT: name,
-        STARTDATE: certificate.startDate,
+        STARTDATE: moment(certificate.startDate).format('D.M.YYYY'),
         MATCHES_COUNT: certificate.matchesCount,
         MATCH_APPOINTMENTS_COUNT: certificate.matchAppointmentsCount,
         COURSE_PARTICIPANTS_COUNT: certificate.courseParticipantsCount,

--- a/common/certificate/index.ts
+++ b/common/certificate/index.ts
@@ -86,7 +86,7 @@ export async function getCertificatePDF(certificateId: string, requestor: Studen
 
 export async function createInstantCertificate(requester: Student, lang: Language): Promise<{ pdf: Buffer; certificate: InstantCertificate }> {
     const matchesCountPromise = prisma.match.count({ where: { studentId: requester.id } });
-    const matchAppointmentsCountPromise = prisma.lecture.count({ where: { match: { studentId: requester.id } } });
+    const matchAppointmentsCountPromise = prisma.lecture.count({ where: { match: { studentId: requester.id }, start: { lt: new Date() } } });
     const uniqueCourseParticipantsPromise = prisma.subcourse_participants_pupil.groupBy({
         by: ['pupilId'],
         where: {
@@ -103,10 +103,12 @@ export async function createInstantCertificate(requester: Student, lang: Languag
                 cancelled: false,
                 subcourse_instructors_student: { some: { studentId: requester.id } },
             },
+            start: { lt: new Date() },
         },
     });
     const totalAppointmentsDurationPromise = prisma.lecture.aggregate({
         where: {
+            start: { lt: new Date() },
             OR: [
                 {
                     subcourse: {
@@ -455,6 +457,7 @@ async function createInstantPDFBinary(certificate: InstantCertificate & { studen
     if (process.env.ENV == 'dev') {
         name = `[TEST] ${name}`;
     }
+    console.log(`VERIFICATION ${link}`);
     const result = template({
         NAMESTUDENT: name,
         STARTDATE: moment(certificate.startDate).format('D.M.YYYY'),


### PR DESCRIPTION
- only count lectures that are in the past
- add date variable so our template renders correctly
- friendly date formatting