### PR TITLE
feat: Add receivedScreeningSuggestions resolver

### DIFF
--- a/graphql/pupil/fields.ts
+++ b/graphql/pupil/fields.ts
@@ -29,7 +29,7 @@ import { subcourseSearch } from '../../common/courses/search';
 @Resolver((of) => Pupil)
 export class ExtendFieldsPupilResolver {
     @FieldResolver((type) => UserType)
-    @Authorized(Role.ADMIN, Role.OWNER)
+    @Authorized(Role.ADMIN, Role.OWNER, Role.PUPIL_SCREENER)
     user(@Root() pupil: Required<Pupil>) {
         return userForPupil(pupil);
     }

--- a/graphql/student/fields.ts
+++ b/graphql/student/fields.ts
@@ -64,7 +64,7 @@ export class ExtendFieldsStudentResolver {
     }
 
     @FieldResolver((type) => UserType)
-    @Authorized(Role.ADMIN, Role.OWNER)
+    @Authorized(Role.ADMIN, Role.OWNER, Role.STUDENT_SCREENER)
     user(@Root() student: Required<Student>) {
         return userForStudent(student);
     }

--- a/graphql/user/fields.ts
+++ b/graphql/user/fields.ts
@@ -164,6 +164,22 @@ export class UserFieldsResolver {
         });
     }
 
+    @FieldResolver((returns) => [ConcreteNotification])
+    @Authorized(Role.SCREENER, Role.ADMIN)
+    async receivedScreeningSuggestions(@Root() user: User): Promise<ConcreteNotification[]> {
+        return await prisma.concrete_notification.findMany({
+            orderBy: [{ sentAt: 'desc' }],
+            where: {
+                userId: user.userID,
+                state: ConcreteNotificationState.SENT,
+                notification: {
+                    onActions: { has: 'screening_suggestion' },
+                },
+            },
+            include: { notification: true },
+        });
+    }
+
     @FieldResolver((returns) => Date, { nullable: true })
     @Authorized(Role.OWNER, Role.ADMIN)
     async lastTimeCheckedNotifications(@Root() user: User): Promise<Date | null> {


### PR DESCRIPTION
## Ticket

Part of https://github.com/corona-school/project-user/issues/1425

## What was done?

- Allow screeners to see what suggestions were already sent to a pupil/student