### PR TITLE
fix: Do not expose supported hours if referred users is less than 2

### DIFF
--- a/common/user/index.ts
+++ b/common/user/index.ts
@@ -94,6 +94,13 @@ export async function getReferredStudentsAndPupils(userId: string): Promise<{ st
 export async function getTotalSupportedHours(userId: string): Promise<number> {
     const { students, pupils } = await getReferredStudentsAndPupils(userId);
 
+    // Provide k-anonymity (k = 2) - if only one user or two users was referred, do not show
+    // the supported hours
+    const referredUsers = students.length + pupils.length;
+    if (referredUsers <= 2) {
+        return 0;
+    }
+
     const studentLectures = await prisma.lecture.findMany({
         where: {
             organizerIds: {

--- a/graphql/user/fields.ts
+++ b/graphql/user/fields.ts
@@ -125,7 +125,7 @@ export class UserFieldsResolver {
         return count;
     }
 
-    @FieldResolver((returns) => Int, { description: 'Total hours supported by referred students/pupils' })
+    @FieldResolver((returns) => Int, { description: 'Total hours supported by referred students/pupils - 0 if less than 3 users were referred for privacy' })
     @Authorized(Role.OWNER, Role.ADMIN)
     async supportedHours(@Root() user: User): Promise<number> {
         const totalHours = await getTotalSupportedHours(user.userID);


### PR DESCRIPTION
It's nice that this was considered in the UI, but is still exposed to the user at the API. If we implement 2-anonymity, let's do it all the way.