### PR TITLE
fix: Instant certificates for users without lectures

### DIFF
--- a/common/certificate/index.ts
+++ b/common/certificate/index.ts
@@ -141,7 +141,7 @@ export async function createInstantCertificate(requester: Student, lang: Languag
             matchAppointmentsCount,
             courseParticipantsCount,
             courseAppointmentsCount,
-            totalAppointmentsDuration: totalAppointmentsDuration._sum.duration,
+            totalAppointmentsDuration: totalAppointmentsDuration._sum.duration ?? 0,
         },
         include: { student: true },
     });


### PR DESCRIPTION
## What was done?

- Added a default value for non-nullable field during creation