### PR TITLE
Feat: Integrate students in the Hausaufgabenhilfe

### DIFF
--- a/common/appointment/create.ts
+++ b/common/appointment/create.ts
@@ -131,6 +131,7 @@ export function canCreateGroupAppointment(subcourse: Subcourse, hasInstructors: 
 
 export const createGroupAppointments = async (subcourseId: number, appointmentsToBeCreated: AppointmentCreateGroupInput[], organizer: Student) => {
     const participants = await prisma.subcourse_participants_pupil.findMany({ where: { subcourseId: subcourseId }, select: { pupil: true } });
+    const mentors = await prisma.subcourse_mentors_student.findMany({ where: { subcourseId: subcourseId }, select: { student: true } });
     const instructors = await prisma.subcourse_instructors_student.findMany({ where: { subcourseId: subcourseId }, select: { student: true } });
     const subcourse = await prisma.subcourse.findUnique({ where: { id: subcourseId }, include: { course: true } });
     const lastAppointment = await prisma.lecture.findFirst({ where: { subcourseId }, orderBy: { createdAt: 'desc' }, select: { override_meeting_link: true } });
@@ -162,7 +163,7 @@ export const createGroupAppointments = async (subcourseId: number, appointmentsT
                     subcourseId: appointmentToBeCreated.subcourseId,
                     appointmentType: lecture_appointmenttype_enum.group,
                     organizerIds: instructors.map((i) => userForStudent(i.student).userID),
-                    participantIds: participants.map((p) => userForPupil(p.pupil).userID),
+                    participantIds: [...participants.map((p) => userForPupil(p.pupil).userID), ...mentors.map((m) => userForStudent(m.student).userID)],
                     zoomMeetingId,
                     override_meeting_link: (appointmentToBeCreated.meetingLink ?? lastAppointment?.override_meeting_link) || null,
                 },

--- a/common/appointment/participants.ts
+++ b/common/appointment/participants.ts
@@ -44,12 +44,14 @@ export async function addGroupAppointmentsParticipant(subcourseId: number, userI
         await prisma.lecture.update({ where: { id: lecture.id }, data: { participantIds: { push: userId } } });
         logger.info(`User(${userId}) added as participant of Appointment(${lecture.id}) of Subcourse(${subcourseId})`);
 
-        await Notification.actionTakenAt(
-            new Date(lecture.start),
-            user,
-            'pupil_group_appointment_starts',
-            await getContextForGroupAppointmentReminder(lecture, subcourse, subcourse.course)
-        );
+        if (user.pupilId) {
+            await Notification.actionTakenAt(
+                new Date(lecture.start),
+                user,
+                'pupil_group_appointment_starts',
+                await getContextForGroupAppointmentReminder(lecture, subcourse, subcourse.course)
+            );
+        }
     }
 }
 

--- a/common/courses/filters.ts
+++ b/common/courses/filters.ts
@@ -1,5 +1,11 @@
 import { Prisma, pupil as Pupil, student as Student } from '@prisma/client';
 
+export function isMentoredBy(student: Student) {
+    return {
+        subcourse_mentors_student: { some: { studentId: { equals: student.id } } },
+    };
+}
+
 export function instructedBy(student: Student) {
     return {
         subcourse_instructors_student: { some: { studentId: { equals: student.id } } },

--- a/common/courses/participants.ts
+++ b/common/courses/participants.ts
@@ -1,4 +1,4 @@
-import { course as Course, subcourse as Subcourse, pupil as Pupil } from '@prisma/client';
+import { course as Course, subcourse as Subcourse, pupil as Pupil, student as Student } from '@prisma/client';
 import { getLogger } from '../logger/logger';
 import { prisma } from '../prisma';
 import moment from 'moment';
@@ -65,6 +65,10 @@ export async function isParticipant(subcourse: Subcourse, pupil: Pupil) {
             where: { pupilId: pupil.id, subcourseId: subcourse.id },
         })) > 0
     );
+}
+
+export async function isMentor(subcourseId: number, studentId: number) {
+    return (await prisma.subcourse_mentors_student.count({ where: { subcourseId, studentId } })) > 0;
 }
 
 export async function isOnWaitingList(subcourse: Subcourse, pupil: Pupil) {
@@ -198,6 +202,27 @@ export async function couldJoinSubcourse(subcourse: Subcourse, pupil: Pupil): Pr
     return { allowed: true };
 }
 
+export async function joinSubcourseAsMentor(subcourse: Subcourse, student: Student) {
+    const course = await prisma.course.findFirst({ where: { id: subcourse.courseId } });
+    if (course.category !== 'homework_help') {
+        throw new Error('Only homework_help courses allow mentors');
+    }
+    const insertion = await prisma.subcourse_mentors_student.create({
+        data: {
+            studentId: student.id,
+            subcourseId: subcourse.id,
+        },
+    });
+
+    if (insertion === null) {
+        throw new Error('Failed to join Subcourse as mentor');
+    }
+
+    const user = userForStudent(student);
+    await logTransaction('mentorJoinedCourse', user, { subcourseID: subcourse.id });
+    await addGroupAppointmentsParticipant(subcourse.id, user.userID);
+}
+
 export async function joinSubcourse(subcourse: Subcourse, pupil: Pupil, strict: boolean, notifyIfFull = true): Promise<void> {
     const canJoin = await canJoinSubcourse(subcourse, pupil);
 
@@ -318,6 +343,22 @@ export async function leaveSubcourse(subcourse: Subcourse, pupil: Pupil) {
         // This will check if there are pupils on the waiting list, and short circuit if not
         await fillSubcourse(subcourse);
     }
+}
+
+export async function mentorLeaveSubcourse(subcourse: Subcourse, student: Student) {
+    const deletion = await prisma.subcourse_mentors_student.deleteMany({
+        where: {
+            subcourseId: subcourse.id,
+            studentId: student.id,
+        },
+    });
+    const studentUser = userForStudent(student);
+    await removeGroupAppointmentsParticipant(subcourse.id, studentUser.userID);
+    if (deletion.count === 0) {
+        throw new RedundantError(`Failed to leave Subcourse as the Student is not a mentor`);
+    }
+    logger.info(`Student(${student.id}) left Subcourse(${subcourse.id})`);
+    await logTransaction('mentorLeftCourse', studentUser, { subcourseID: subcourse.id });
 }
 
 export async function fillSubcourse(subcourse: Subcourse) {

--- a/common/courses/participants.ts
+++ b/common/courses/participants.ts
@@ -207,16 +207,12 @@ export async function joinSubcourseAsMentor(subcourse: Subcourse, student: Stude
     if (course.category !== 'homework_help') {
         throw new Error('Only homework_help courses allow mentors');
     }
-    const insertion = await prisma.subcourse_mentors_student.create({
+    await prisma.subcourse_mentors_student.create({
         data: {
             studentId: student.id,
             subcourseId: subcourse.id,
         },
     });
-
-    if (insertion === null) {
-        throw new Error('Failed to join Subcourse as mentor');
-    }
 
     const user = userForStudent(student);
     await logTransaction('mentorJoinedCourse', user, { subcourseID: subcourse.id });

--- a/common/transactionlog/log.ts
+++ b/common/transactionlog/log.ts
@@ -32,11 +32,12 @@ type LogData<Type extends LogType> = {
     cancelledCourse: { id: number };
     cancelledSubcourse: { id: number };
     createdCourseAttendanceLog: { courseAttendanceLog: CourseAttendanceLog };
-    contactMentor: { category: any; text: string; subject?: string };
     bbbMeeting: { bbbMeeting: BBBMeeting };
     contactExpert: { emailText: string; subject?: string };
     participantJoinedCourse: { subcourseID: number };
     participantLeftCourse: { subcourseID: number };
+    mentorJoinedCourse: { subcourseID: number };
+    mentorLeftCourse: { subcourseID: number };
     participantJoinedWaitingList: { courseID: number };
     participantLeftWaitingList: { courseID: number };
     userAccessedCourseWhileAuthenticated: { course: number };

--- a/common/user/index.ts
+++ b/common/user/index.ts
@@ -25,6 +25,13 @@ export type User = {
 };
 export const userSelection = { id: true, firstname: true, lastname: true, email: true, active: true, lastLogin: true };
 
+export function getPupilsIds(userIds: string[]) {
+    return userIds.filter((id) => {
+        const [type] = getUserTypeAndIdForUserId(id);
+        return type === 'pupil';
+    });
+}
+
 export function getUserTypeAndIdForUserId(userId: string): [type: UserTypes, id: number] {
     const validTypes = ['student', 'pupil', 'screener', 'admin'];
     const [type, id] = userId.split('/');
@@ -138,7 +145,7 @@ export async function getTotalSupportedHours(userId: string): Promise<number> {
     }, 0);
 
     const totalPupilDuration = pupilLectures.reduce((acc, lecture) => {
-        const actualParticipants = lecture.participantIds.filter((id) => pupils.includes(id) && !lecture.declinedBy.includes(id));
+        const actualParticipants = getPupilsIds(lecture.participantIds).filter((id) => pupils.includes(id) && !lecture.declinedBy.includes(id));
         const participantCount = actualParticipants.length;
         return acc + lecture.duration * participantCount;
     }, 0);

--- a/common/user/roles.ts
+++ b/common/user/roles.ts
@@ -42,6 +42,8 @@ export enum Role {
     STATE_PUPIL = 'STATE_PUPIL',
     /* User is a pupil and participant of a specific subcourse */
     SUBCOURSE_PARTICIPANT = 'SUBCOURSE_PARTICIPANT',
+    /* User is a student and mentor of a specific subcourse */
+    SUBCOURSE_MENTOR = 'SUBCOURSE_MENTOR',
     /* User is a pupil and participant of a specific appointment */
     APPOINTMENT_PARTICIPANT = 'APPOINTMENT_PARTICIPANT',
     /**

--- a/common/zoom/scheduled-meeting.ts
+++ b/common/zoom/scheduled-meeting.ts
@@ -83,6 +83,19 @@ const createZoomMeeting = async (zoomUsers: ZoomUser[], startTime: Date, duratio
                     settings: {
                         alternative_hosts: combinedAlternativeHosts,
                         alternative_hosts_email_notification: false,
+                        breakout_room: {
+                            enabled: true,
+                            rooms: [
+                                {
+                                    name: 'SuS warteraum',
+                                    participants: ['test+dev+p1@lern-fair.de'],
+                                },
+                                {
+                                    name: 'HuH Warteraum',
+                                    participants: ['test+dev+s4@lern-fair.de'],
+                                },
+                            ],
+                        },
                     },
                 }),
             }),

--- a/common/zoom/scheduled-meeting.ts
+++ b/common/zoom/scheduled-meeting.ts
@@ -83,19 +83,6 @@ const createZoomMeeting = async (zoomUsers: ZoomUser[], startTime: Date, duratio
                     settings: {
                         alternative_hosts: combinedAlternativeHosts,
                         alternative_hosts_email_notification: false,
-                        breakout_room: {
-                            enabled: true,
-                            rooms: [
-                                {
-                                    name: 'SuS warteraum',
-                                    participants: ['test+dev+p1@lern-fair.de'],
-                                },
-                                {
-                                    name: 'HuH Warteraum',
-                                    participants: ['test+dev+s4@lern-fair.de'],
-                                },
-                            ],
-                        },
                     },
                 }),
             }),

--- a/graphql/authorizations.ts
+++ b/graphql/authorizations.ts
@@ -19,8 +19,8 @@ import assert from 'assert';
 import { getLogger } from '../common/logger/logger';
 import { isOwnedBy, ResolverModel, ResolverModelNames } from './ownership';
 import { AuthenticationError, ForbiddenError } from './error';
-import { isParticipant } from '../common/courses/participants';
-import { getPupil } from './util';
+import { isMentor, isParticipant } from '../common/courses/participants';
+import { getPupil, getStudent } from './util';
 import { Role } from '../common/user/roles';
 import { isDev, isTest } from '../common/util/environment';
 import { isAppointmentParticipant } from '../common/appointment/participants';
@@ -221,11 +221,20 @@ const entityRoles: EntityRole[] = [
                 const pupil = await getPupil(context.user.pupilId);
                 return await isParticipant(root, pupil);
             }
-
             return false;
         },
     },
-
+    {
+        role: Role.SUBCOURSE_MENTOR,
+        async hasRole(context, modelName, root) {
+            assert(modelName === 'Subcourse', 'Type must be a Subcourse to determine subcourse participant role');
+            if (context.user.studentId) {
+                const student = await getStudent(context.user.studentId);
+                return await isMentor(root.id, student.id);
+            }
+            return false;
+        },
+    },
     {
         role: Role.APPOINTMENT_PARTICIPANT,
         async hasRole(context, modelName, root) {
@@ -246,7 +255,7 @@ const onlyOwner = [Authorized(Role.OWNER)];
 const nobody = [Authorized(Role.NOBODY)];
 const everyone = [Authorized(Role.UNAUTHENTICATED)];
 const participantOrOwnerOrAdmin = [Authorized(Role.ADMIN, Role.APPOINTMENT_PARTICIPANT, Role.OWNER)];
-const subcourseParticipantOrOwner = [Authorized(Role.SUBCOURSE_PARTICIPANT, Role.OWNER)];
+const subcourseParticipantOrOwner = [Authorized(Role.SUBCOURSE_PARTICIPANT, Role.SUBCOURSE_MENTOR, Role.OWNER)];
 
 /* Utility to ensure that field authorizations are present except for the public fields listed */
 const withPublicFields = <Entity = 'never', PublicFields extends keyof Entity = never>(otherFields: {
@@ -313,6 +322,7 @@ export const authorizationEnhanceMap: Required<ResolversEnhanceMap> = {
     },
     Subcourse_promotion: allAdmin,
     Subcourse_instructors_student: allAdmin,
+    Subcourse_mentors_student: allAdmin,
     Subcourse_participants_pupil: allAdmin,
     Concrete_notification: allAdmin,
     Course_guest: allAdmin,
@@ -456,6 +466,7 @@ export const authorizationModelEnhanceMap: ModelsEnhanceMap = {
             participation_certificate: nobody,
             instant_certificate: nobody,
             subcourse_instructors_student: nobody,
+            subcourse_mentors_student: nobody,
             course: nobody,
             course_guest: nobody,
             course_instructors_student: nobody,
@@ -527,6 +538,7 @@ export const authorizationModelEnhanceMap: ModelsEnhanceMap = {
             course_participation_certificate: nobody,
             lecture: nobody,
             subcourse_instructors_student: nobody,
+            subcourse_mentors_student: nobody,
             subcourse_participants_pupil: nobody,
             _count: nobody,
             alreadyPromoted: adminOrOwner,

--- a/graphql/student/fields.ts
+++ b/graphql/student/fields.ts
@@ -156,6 +156,7 @@ export class ExtendFieldsStudentResolver {
     }
 
     @LimitEstimated(10)
+    @Authorized(Role.ADMIN, Role.OWNER, Role.SUBCOURSE_MENTOR)
     @FieldResolver((type) => [Subcourse])
     @ImpliesRoleOnResult(Role.SUBCOURSE_MENTOR, Role.OWNER)
     async subcoursesMentoring(

--- a/graphql/subcourse/fields.ts
+++ b/graphql/subcourse/fields.ts
@@ -1,7 +1,7 @@
 import { course_coursestate_enum as CourseState, Prisma, subcourse } from '@prisma/client';
 import { canCancel, canDeleteSubcourse, canEditSubcourse, canPublish } from '../../common/courses/states';
 import { Arg, Authorized, Ctx, Field, FieldResolver, Int, ObjectType, Query, Resolver, Root } from 'type-graphql';
-import { canJoinSubcourse, couldJoinSubcourse, isParticipant } from '../../common/courses/participants';
+import { canJoinSubcourse, couldJoinSubcourse, isParticipant, isMentor as isSubcourseMentor } from '../../common/courses/participants';
 import { prisma } from '../../common/prisma';
 import { getSessionPupil, getSessionStudent, isElevated, isSessionPupil, isSessionStudent } from '../authentication';
 import { Role } from '../authorizations';
@@ -465,6 +465,17 @@ export class ExtendedFieldsSubcourseResolver {
 
         const student = await getSessionStudent(context, studentId);
         return (await prisma.subcourse_instructors_student.count({ where: { subcourseId: subcourse.id, studentId: student.id } })) > 0;
+    }
+
+    @FieldResolver((returns) => Boolean)
+    @Authorized(Role.UNAUTHENTICATED)
+    async isMentor(@Ctx() context: GraphQLContext, @Root() subcourse: Subcourse, @Arg('studentId', { nullable: true }) studentId: number) {
+        if (!isElevated(context) && !isSessionStudent(context)) {
+            return false;
+        }
+
+        const student = await getSessionStudent(context, studentId);
+        return isSubcourseMentor(subcourse.id, student.id);
     }
 
     @FieldResolver((returns) => Boolean)

--- a/graphql/subcourse/mutations.ts
+++ b/graphql/subcourse/mutations.ts
@@ -272,7 +272,7 @@ export class MutateSubcourseResolver {
         const subcourse = await getSubcourse(subcourseId);
         await hasAccess(context, 'Subcourse', subcourse);
         // Make sure that only Admins/Owners can remove other mentors from the course
-        const isOwner = context.user.roles.includes(Role.OWNER) && !!studentId;
+        const isOwner = studentId && (await prisma.subcourse_instructors_student.count({ where: { subcourseId, studentId: context.user.studentId } })) > 0;
         const student = await (isOwner ? getStudent(studentId) : getSessionStudent(context, studentId));
         const studentUser = userForStudent(student);
         await mentorLeaveSubcourse(subcourse, student);

--- a/graphql/subcourse/mutations.ts
+++ b/graphql/subcourse/mutations.ts
@@ -2,7 +2,15 @@ import * as TypeGraphQL from 'type-graphql';
 import { Arg, Authorized, Ctx, InputType, Int, Mutation, Resolver } from 'type-graphql';
 import { removeGroupAppointmentsOrganizer, removeGroupAppointmentsParticipant } from '../../common/appointment/participants';
 import { contactInstructors, contactParticipants } from '../../common/courses/contact';
-import { fillSubcourse, joinSubcourse, joinSubcourseWaitinglist, leaveSubcourse, leaveSubcourseWaitinglist } from '../../common/courses/participants';
+import {
+    fillSubcourse,
+    joinSubcourse,
+    joinSubcourseAsMentor,
+    joinSubcourseWaitinglist,
+    leaveSubcourse,
+    leaveSubcourseWaitinglist,
+    mentorLeaveSubcourse,
+} from '../../common/courses/participants';
 import { addSubcourseInstructor, cancelSubcourse, deleteSubcourse, editSubcourse, publishSubcourse } from '../../common/courses/states';
 import { getLogger } from '../../common/logger/logger';
 import { prisma } from '../../common/prisma';
@@ -237,6 +245,51 @@ export class MutateSubcourseResolver {
         const subcourse = await getSubcourse(subcourseId);
         await joinSubcourse(subcourse, pupil, true);
         logger.info(`Pupil(${pupilId}) joined Subcourse(${subcourseId})`);
+        return true;
+    }
+
+    @Mutation((returns) => Boolean)
+    @Authorized(Role.ADMIN, Role.STUDENT, Role.COURSE_SCREENER)
+    async subcourseJoinAsMentor(
+        @Ctx() context: GraphQLContext,
+        @Arg('subcourseId') subcourseId: number,
+        @Arg('studentId', { nullable: true }) studentId?: number
+    ): Promise<boolean> {
+        const student = await getSessionStudent(context, studentId);
+        const subcourse = await getSubcourse(subcourseId);
+        await joinSubcourseAsMentor(subcourse, student);
+        logger.info(`Student(${studentId}) joined Subcourse(${subcourseId}) as mentor`);
+        return true;
+    }
+
+    @Mutation((returns) => Boolean)
+    @AuthorizedDeferred(Role.ADMIN, Role.SUBCOURSE_MENTOR)
+    async subcourseMentorLeave(
+        @Ctx() context: GraphQLContext,
+        @Arg('subcourseId') subcourseId: number,
+        @Arg('studentId', { nullable: true }) studentId?: number
+    ): Promise<boolean> {
+        const subcourse = await getSubcourse(subcourseId);
+        await hasAccess(context, 'Subcourse', subcourse);
+        // Make sure that only Admins/Owners can remove other mentors from the course
+        if (context.user.studentId && studentId && context.user.studentId !== studentId) {
+            logger.warn(`User tried to remove other mentor from course`, {
+                requestedStudentId: studentId,
+                actualStudentId: context.user.studentId,
+                user: context.user.userID,
+            });
+            return false;
+        }
+
+        const student = await getStudent(studentId || context.user.studentId);
+        const studentUser = userForStudent(student);
+
+        await mentorLeaveSubcourse(subcourse, student);
+        await removeGroupAppointmentsParticipant(subcourse.id, studentUser.userID);
+        if (subcourse.conversationId) {
+            await removeParticipantFromCourseChat(studentUser, subcourse.conversationId);
+        }
+        logger.info(`Student(${studentId}) left Subcourse(${subcourseId})`);
         return true;
     }
 

--- a/linter/graphql-undeferred-impossible.js
+++ b/linter/graphql-undeferred-impossible.js
@@ -33,7 +33,7 @@ module.exports = {
                     return;
                 }
 
-                const needsToBeDeferred = (undeferredAuth ?? deferredAuth).expression.arguments.some((it) => ['OWNER', 'SUBCOURSE_PARTICIPANT'].includes(it.property.name));
+                const needsToBeDeferred = (undeferredAuth ?? deferredAuth).expression.arguments.some((it) => ['OWNER', 'SUBCOURSE_PARTICIPANT', 'SUBCOURSE_MENTOR'].includes(it.property.name));
 
                 if (undeferredAuth && needsToBeDeferred) {
                     context.report({

--- a/prisma/migrations/20250312104151_add_subcourse_mentors_student_table/migration.sql
+++ b/prisma/migrations/20250312104151_add_subcourse_mentors_student_table/migration.sql
@@ -1,0 +1,30 @@
+/*
+  Warnings:
+
+  - The values [contactMentor] on the enum `log_logtype_enum` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "log_logtype_enum_new" AS ENUM ('misc', 'verificationRequets', 'verified', 'matchDissolve', 'fetchedFromWix', 'deActivate', 'updatePersonal', 'updateSubjects', 'accessedByScreener', 'updatedByScreener', 'updateStudentDescription', 'createdCourse', 'certificateRequest', 'cocCancel', 'cancelledCourse', 'cancelledSubcourse', 'createdCourseAttendanceLog', 'bbbMeeting', 'participantJoinedCourse', 'participantLeftCourse', 'mentorJoinedCourse', 'mentorLeftCourse', 'participantJoinedWaitingList', 'participantLeftWaitingList', 'userAccessedCourseWhileAuthenticated', 'instructorIssuedCertificate', 'pupilInterestConfirmationRequestSent', 'pupilInterestConfirmationRequestReminderSent', 'pupilInterestConfirmationRequestStatusChange', 'skippedCoC');
+ALTER TABLE "log" ALTER COLUMN "logtype" DROP DEFAULT;
+ALTER TABLE "log" ALTER COLUMN "logtype" TYPE "log_logtype_enum_new" USING ("logtype"::text::"log_logtype_enum_new");
+ALTER TYPE "log_logtype_enum" RENAME TO "log_logtype_enum_old";
+ALTER TYPE "log_logtype_enum_new" RENAME TO "log_logtype_enum";
+DROP TYPE "log_logtype_enum_old";
+ALTER TABLE "log" ALTER COLUMN "logtype" SET DEFAULT 'misc';
+COMMIT;
+
+-- CreateTable
+CREATE TABLE "subcourse_mentors_student" (
+    "subcourseId" INTEGER NOT NULL,
+    "studentId" INTEGER NOT NULL,
+
+    CONSTRAINT "subcourse_mentors_student_pkey" PRIMARY KEY ("subcourseId","studentId")
+);
+
+-- AddForeignKey
+ALTER TABLE "subcourse_mentors_student" ADD CONSTRAINT "subcourse_mentors_student_subcourseId_fkey" FOREIGN KEY ("subcourseId") REFERENCES "subcourse"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "subcourse_mentors_student" ADD CONSTRAINT "subcourse_mentors_student_studentId_fkey" FOREIGN KEY ("studentId") REFERENCES "student"("id") ON DELETE NO ACTION ON UPDATE NO ACTION;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -855,8 +855,9 @@ model subcourse_promotion {
   subcourseId Int
 }
 
-// For now only used on the Hausaufgabenhilfe. These students are the volunteers that support pupils in the course.
-// They don't own the course/subcourse (so, no edition rights) and shouldn't count as course participants (e.g maxParticipants)
+// These students only support pupils in the course. They don't own the course/subcourse (so, no edition rights)
+// They can join/leave courses that allow mentors (For now only used the Hausaufgabenhilfe)
+// They don't count as course participants (e.g for maxParticipants, referrals, etc...)
 model subcourse_mentors_student {
   subcourseId Int
   studentId   Int

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -681,29 +681,29 @@ model school {
 // Historically there was a dedicated Screening Tool were screeners could log in.
 // Nowadays Screenings are done via Retool, with the Default Screener
 model screener {
-  id                           Int                          @id(map: "PK_3a023b02ed01df4a6956af1ea94") @default(autoincrement())
-  createdAt                    DateTime                     @default(now()) @db.Timestamp(6)
-  updatedAt                    DateTime                     @default(now()) @updatedAt @db.Timestamp(6)
-  firstname                    String?                      @db.VarChar
-  lastname                     String?                      @db.VarChar
-  active                       Boolean                      @default(true)
-  email                        String                       @unique(map: "IDX_29a6207bc70a2b9e6731d66bcf") @db.VarChar
-  verifiedAt                   DateTime?                    @db.Timestamp(6)
-  isRedacted                   Boolean                      @default(false)
-  lastTimeCheckedNotifications DateTime?                    @default(dbgenerated("'1970-01-01 00:00:00'::timestamp without time zone")) @db.Timestamp(6)
-  notificationPreferences      Json?                        @db.Json
-  lastLogin                    DateTime?                    @default(now()) @db.Timestamp(6)
+  id                           Int                    @id(map: "PK_3a023b02ed01df4a6956af1ea94") @default(autoincrement())
+  createdAt                    DateTime               @default(now()) @db.Timestamp(6)
+  updatedAt                    DateTime               @default(now()) @updatedAt @db.Timestamp(6)
+  firstname                    String?                @db.VarChar
+  lastname                     String?                @db.VarChar
+  active                       Boolean                @default(true)
+  email                        String                 @unique(map: "IDX_29a6207bc70a2b9e6731d66bcf") @db.VarChar
+  verifiedAt                   DateTime?              @db.Timestamp(6)
+  isRedacted                   Boolean                @default(false)
+  lastTimeCheckedNotifications DateTime?              @default(dbgenerated("'1970-01-01 00:00:00'::timestamp without time zone")) @db.Timestamp(6)
+  notificationPreferences      Json?                  @db.Json
+  lastLogin                    DateTime?              @default(now()) @db.Timestamp(6)
   // DEPRECATED, Use Secret instead
-  password                     String                       @db.VarChar
-  verified                     Boolean?                     @default(false)
+  password                     String                 @db.VarChar
+  verified                     Boolean?               @default(false)
   // DEPRECATED:
-  oldNumberID                  Int?                         @unique(map: "UQ_96dc11de485d62615e78a875293")
+  oldNumberID                  Int?                   @unique(map: "UQ_96dc11de485d62615e78a875293")
   instructor_screening         instructor_screening[]
   screenings                   screening[]
-  is_trusted                   Boolean                      @default(false)
-  is_student_screener          Boolean                      @default(false)
-  is_pupil_screener            Boolean                      @default(false)
-  is_course_screener           Boolean                      @default(false)
+  is_trusted                   Boolean                @default(false)
+  is_student_screener          Boolean                @default(false)
+  is_pupil_screener            Boolean                @default(false)
+  is_course_screener           Boolean                @default(false)
 }
 
 // A Screening for Students that want to tutor pupils
@@ -774,28 +774,28 @@ model student {
   sentInstructorScreeningReminderCount      Int                      @default(0)
   lastSentInstructorScreeningInvitationDate DateTime?                @db.Timestamp(6)
 
-  lastUpdatedSettingsViaBlocker        DateTime?                              @db.Timestamp(6)
+  lastUpdatedSettingsViaBlocker    DateTime?                          @db.Timestamp(6)
   // The registration form used to register the user, mainly used to find Lern-Fair Plus students
-  registrationSource                   student_registrationsource_enum        @default(normal)
-  aboutMe                              String                                 @default("") @db.VarChar
+  registrationSource               student_registrationsource_enum    @default(normal)
+  aboutMe                          String                             @default("") @db.VarChar
   // Currently only Students can create Appointments with a Zoom Meeting, for that they need a Zoom Account:
-  zoomUserId                           String?                                @db.VarChar
-  certificate_of_conduct               certificate_of_conduct?
-  course                               course[]
-  course_guest                         course_guest[]
-  course_instructors_student           course_instructors_student[]
-  course_participation_certificate     course_participation_certificate[]
-  instructor_screening                 instructor_screening?
-  jufo_verification_transmission       jufo_verification_transmission?
-  lecture                              lecture[]
-  match                                match[]
-  participation_certificate            participation_certificate[]
-  instant_certificate                  instant_certificate[]
-  remission_request                    remission_request?
-  screening                            screening?
-  subcourse_instructors_student        subcourse_instructors_student[]
+  zoomUserId                       String?                            @db.VarChar
+  certificate_of_conduct           certificate_of_conduct?
+  course                           course[]
+  course_guest                     course_guest[]
+  course_instructors_student       course_instructors_student[]
+  course_participation_certificate course_participation_certificate[]
+  instructor_screening             instructor_screening?
+  jufo_verification_transmission   jufo_verification_transmission?
+  lecture                          lecture[]
+  match                            match[]
+  participation_certificate        participation_certificate[]
+  instant_certificate              instant_certificate[]
+  remission_request                remission_request?
+  screening                        screening?
+  subcourse_instructors_student    subcourse_instructors_student[]
   // Should stay null for users who where registered before the onboarding got added
-  hasDoneEthicsOnboarding              Boolean?
+  hasDoneEthicsOnboarding          Boolean?
 
   cooperationID           Int?
   cooperation             cooperation? @relation(fields: [cooperationID], references: [id])
@@ -809,7 +809,8 @@ model student {
   gender                  gender_enum?
 
   // The referring user's type and ID, e.g., "pupil/5", "student/3"
-  referredById String? @db.VarChar
+  referredById              String?                     @db.VarChar
+  subcourse_mentors_student subcourse_mentors_student[]
 }
 
 // A concrete course with participants, each course might have multiple subcourses with different instructors
@@ -843,6 +844,7 @@ model subcourse {
   subcourse_participants_pupil     subcourse_participants_pupil[]
   waiting_list_enrollment          waiting_list_enrollment[]
   subcourse_promotions             subcourse_promotion[]
+  subcourse_mentors_student        subcourse_mentors_student[]
 }
 
 model subcourse_promotion {
@@ -851,6 +853,17 @@ model subcourse_promotion {
   type        subcourse_promotion_type_enum
   subcourse   subcourse                     @relation(fields: [subcourseId], references: [id], onDelete: Cascade)
   subcourseId Int
+}
+
+// For now only used on the Hausaufgabenhilfe. These students are the volunteers that support pupils in the course.
+// They don't own the course/subcourse (so, no edition rights) and shouldn't count as course participants (e.g maxParticipants)
+model subcourse_mentors_student {
+  subcourseId Int
+  studentId   Int
+  subcourse   subcourse @relation(fields: [subcourseId], references: [id], onDelete: Cascade)
+  student     student   @relation(fields: [studentId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+
+  @@id([subcourseId, studentId])
 }
 
 // This is redundant with the Appointment.organizerIds of the appointments attached to the Subcourse and should generally be in sync
@@ -1043,10 +1056,11 @@ enum log_logtype_enum {
   cancelledCourse
   cancelledSubcourse
   createdCourseAttendanceLog
-  contactMentor
   bbbMeeting
   participantJoinedCourse
   participantLeftCourse
+  mentorJoinedCourse
+  mentorLeftCourse
   participantJoinedWaitingList
   participantLeftWaitingList
   userAccessedCourseWhileAuthenticated
@@ -1385,6 +1399,7 @@ enum dissolve_reason {
   other // "Sonstiges"
   unknown // legacy data which we can't map anymore
 }
+
 enum gender_enum {
   male
   female

--- a/seed-db.ts
+++ b/seed-db.ts
@@ -716,12 +716,11 @@ void (async function setupDevDB() {
         outline: 'Hausaufgabenhilfe',
         description:
             'Wenn du Hilfe bei deinen Schulaufgaben brauchst und dir Zuhause niemand helfen kann, dann helfen wir dir. Montag bis Donnerstag von 17-18 Uhr sind wir auf Zoom. \n\nBitte bringe deine Aufgaben mit, die du am Bildschirm zeigen kannst. \nZum Beispiel: \n- Deine Hausaufgaben \n- Übungsaufgaben für eine Klassenarbeit \n- Aufgaben, die du im Unterricht nicht verstanden hast',
-        category: CourseCategory.focus,
+        category: CourseCategory.homework_help,
         state: CourseState.allowed,
-        course_tags_course_tag: { create: { courseTagId: keepAtIt.id } },
         maxParticipants: 1000,
-        instructors: [student1, student2, student3, student4, student5],
-        participants: [pupil1, pupil2, pupil3, pupil4, pupil5, pupil6, pupil7, pupil8, pupil9, pupil10],
+        instructors: [student1, student2, student3, student5],
+        participants: [pupil1, pupil2, pupil3, pupil5, pupil6, pupil7, pupil8, pupil9, pupil10],
         lectures: { amount: 15, intervalInDays: 7, startOffsetInDays: -14 },
     });
 


### PR DESCRIPTION
## Ticket

Partially resolves https://github.com/corona-school/project-user/issues/1428

## What was done?

- Added a new `subcourse_mentors_student` table where students can sign up to help on a course
- Added a new `SUBCOURSE_MENTOR` role
- Added mutations to allow students to join/leave courses that allow mentors _(only the Hausaufgabenhilfe for now)_

**Notes:**
- Mentors don't have edition rights over the course/subcourse
- The role isn't tied to having a specific screening
- Mentors can join/leave a course
- Mentors don't count as subcourse participants (only those who are learning do)
- Mentors don't auto-join the course chat / shouldn't receive notifications about the course. As this is mainly targeted at integrating the Hausaufgabenhilfe, the communication for that is for now handled a bit differently