### PR TITLE
ci: upgrade actions packages

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -33,15 +33,15 @@ jobs:
                 options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: ${{ matrix.node-version }}
 
             - name: Cache dependencies
               id: cache
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                   path: ./node_modules
                   key: modules-${{ hashFiles('package-lock.json') }}
@@ -79,14 +79,14 @@ jobs:
         runs-on: ubuntu-20.04
 
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v3
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
               with:
                   node-version: '18.x'
 
             - name: Cache dependencies
               id: cache
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                   path: ./node_modules
                   key: modules-${{ hashFiles('package-lock.json') }}


### PR DESCRIPTION
Resolves

https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down