### PR TITLE
feat: change to 60 min the default ad-hoc meeting duration

### DIFF
--- a/common/appointment/create.ts
+++ b/common/appointment/create.ts
@@ -270,7 +270,7 @@ export async function createAdHocMeeting(matchId: number, user: User) {
             title: `Sofortbesprechung - ${pupil.firstname} und ${student.firstname} `,
             matchId: matchId,
             start: start,
-            duration: 30,
+            duration: 60,
             appointmentType: lecture_appointmenttype_enum.match,
         },
     ];


### PR DESCRIPTION
## Ticket

Resolves https://github.com/corona-school/project-user/issues/1447

## What was done?

- change to 60 min the default ad-hoc meeting duration

