### PR TITLE
Feat: Track appointments attendance

### DIFF
--- a/common/achievement/evaluate.spec.ts
+++ b/common/achievement/evaluate.spec.ts
@@ -291,6 +291,7 @@ function createLecture({ start }: { start: Date }): lecture {
         organizerIds: [],
         participantIds: [],
         declinedBy: [],
+        joinedBy: [],
         zoomMeetingId: null,
         zoomMeetingReport: [],
         instructorId: null,

--- a/common/appointment/tracking.ts
+++ b/common/appointment/tracking.ts
@@ -11,7 +11,13 @@ const logger = getLogger('Appointment Tracking');
 // To track achievements we trigger actions whenever a user
 // joins an appointment meeting
 export async function trackUserJoinAppointmentMeeting(user: User, appointment: Appointment) {
-    // All actions in this file utilize the actionTakenAt funxtion to track each action.
+    const hasJoined = appointment.joinedBy.includes(user.userID);
+
+    if (!hasJoined) {
+        await prisma.lecture.update({ where: { id: appointment.id }, data: { joinedBy: { push: user.userID } } });
+    }
+
+    // All actions in this file utilize the actionTakenAt function to track each action.
     // This approach serves as a workaround to avoid complications arising from overlapping appointments.
     //
     // Occasionally, it's possible to join an appointment way ahead of its scheduled start time.

--- a/graphql/authorizations.ts
+++ b/graphql/authorizations.ts
@@ -592,6 +592,7 @@ export const authorizationModelEnhanceMap: ModelsEnhanceMap = {
             participantIds: adminOrOwner,
             organizerIds: adminOrOwner,
             declinedBy: participantOrOwnerOrAdmin,
+            joinedBy: participantOrOwnerOrAdmin,
             zoomMeetingId: participantOrOwnerOrAdmin,
             zoomMeetingReport: adminOrOwner,
             override_meeting_link: participantOrOwnerOrAdmin,

--- a/prisma/migrations/20250314151207_add_joined_by_column_to_the_lecture_table/migration.sql
+++ b/prisma/migrations/20250314151207_add_joined_by_column_to_the_lecture_table/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "lecture" ADD COLUMN     "joinedBy" TEXT[] DEFAULT ARRAY[]::TEXT[];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -385,6 +385,8 @@ model lecture {
   participantIds        String[]                     @default([])
   // A subset of organizerIds and participantIds that have declined the appointment:
   declinedBy            String[]                     @default([])
+  // A subset of UserIDs of users that joined the meeting
+  joinedBy              String[]                     @default([])
   // A Zoom Meeting might be attached to an Appointment (unless Zoom is turned off):
   zoomMeetingId         String?                      @db.VarChar
   // When an organizer leaves a Zoom Meeting, we collect a Zoom Meeting Report from the API:


### PR DESCRIPTION
## Ticket

Resolves https://github.com/corona-school/project-user/issues/1456

## What was done?

- Add a new `joinedBy` column in the `lecture` table
- Update the `trackUserJoinAppointmentMeeting` function to save when a user joins an appointment