### PR TITLE
Hotfix: Expose Zoom Meeting Password

### DIFF
--- a/common/zoom/scheduled-meeting.ts
+++ b/common/zoom/scheduled-meeting.ts
@@ -33,6 +33,7 @@ export type ZoomMeeting = {
     settings: {
         alternative_hosts: string;
     };
+    encrypted_password?: string;
 };
 
 export type ZoomMeetings = {

--- a/common/zoom/scheduled-meeting.ts
+++ b/common/zoom/scheduled-meeting.ts
@@ -1,5 +1,5 @@
 import { getAccessToken } from './authorization';
-import { ZoomUser } from './user';
+import type { ZoomUser } from './user';
 import { getLogger } from '../logger/logger';
 import zoomRetry from './retry';
 import { addHost, assureZoomFeatureActive, isZoomFeatureActive, removeHost } from './util';

--- a/graphql/appointment/fields.ts
+++ b/graphql/appointment/fields.ts
@@ -189,6 +189,18 @@ export class ExtendedFieldsLectureResolver {
         return await getZoomUrl(user, appointment);
     }
 
+    // HOTFIX: During some time, many zoom meetings were created requiring a password
+    // For most meetings, this should not be the case and this should return null.
+    @FieldResolver((returns) => String, { nullable: true })
+    @Authorized(Role.ADMIN, Role.APPOINTMENT_PARTICIPANT, Role.OWNER)
+    async zoomMeetingPassword(@Ctx() context: GraphQLContext, @Root() appointment: Required<Appointment>) {
+        if (!appointment.zoomMeetingId) {
+            return null;
+        }
+        const zoomMeeting = await getZoomMeeting(appointment);
+        return zoomMeeting.encrypted_password ?? null;
+    }
+
     @FieldResolver((returns) => Match, { nullable: true })
     @Authorized(Role.OWNER, Role.APPOINTMENT_PARTICIPANT, Role.ADMIN)
     async match(@Root() appointment: Appointment) {


### PR DESCRIPTION
## Ticket

Resolves https://github.com/corona-school/project-user/issues/1460

## What was done?

- Added a resolver for the Zoom meeting password. This will be used on our Zoom component view on the frontend
- Included the Meeting password (if any) in the `zoomMeetingUrl` resolver

In the meantime, I changed the settings again to not require a password since this feature wasn't built with that in mind so I'm not sure what other things it could break. 👀.

All of this is pretty weird. The only thing I could find was this post https://devforum.zoom.us/t/passcode-wrong-error/59739, but it wasn't entirely clear why it happened