### PR TITLE
Feat: privacy-conscious appointment stats

### DIFF
--- a/graphql/appointment/mutations.ts
+++ b/graphql/appointment/mutations.ts
@@ -8,7 +8,7 @@ import {
     createMatchAppointments,
     createZoomMeetingForAppointment,
     isAppointmentOneWeekLater,
-    saveZoomMeetingReport,
+    saveAppointmentStats,
 } from '../../common/appointment/create';
 import { GraphQLContext } from '../context';
 import { AuthorizedDeferred, hasAccess } from '../authorizations';
@@ -16,7 +16,7 @@ import { prisma } from '../../common/prisma';
 import { LectureWhereInput } from '../generated';
 import { Doc, getLecture, getStudent } from '../util';
 import { getLogger } from '../../common/logger/logger';
-import { deleteZoomMeeting, getZoomMeeting } from '../../common/zoom/scheduled-meeting';
+import { deleteZoomMeeting, getZoomMeeting, getZoomMeetingReport } from '../../common/zoom/scheduled-meeting';
 import { declineAppointment } from '../../common/appointment/decline';
 import { updateAppointment } from '../../common/appointment/update';
 import { cancelAppointment } from '../../common/appointment/cancel';
@@ -134,7 +134,14 @@ export class MutateAppointmentResolver {
     async appointmentSaveMeetingReport(@Ctx() context: GraphQLContext, @Arg('appointmentId') appointmentId: number) {
         const appointment = await getLecture(appointmentId);
         await hasAccess(context, 'Lecture', appointment);
-        await saveZoomMeetingReport(appointment);
+
+        const report = await getZoomMeetingReport(appointment.zoomMeetingId);
+        if (!report) {
+            logger.info(`Meeting report could not be saved for appointment (${appointment.id})`);
+            return;
+        }
+
+        await saveAppointmentStats(report, appointment);
 
         return true;
     }

--- a/jobs/list.ts
+++ b/jobs/list.ts
@@ -12,6 +12,7 @@ import deleteUnreachableAchievements from './periodic/delete-unreachable-achieve
 import { postStatisticsToSlack } from './slack-statistics';
 import notificationsEndedYesterday from './periodic/notification-courses-ended-yesterday';
 import { assignOriginalAchievement } from './manual/assign_original_achievement';
+import { populateAppointmentStats } from './manual/populate_appointment_stats';
 
 export const allJobs = {
     cleanupSecrets,
@@ -29,6 +30,7 @@ export const allJobs = {
     deleteUnreachableAchievements,
 
     assignOriginalAchievement,
+    populateAppointmentStats,
 
     // For Integration Tests only:
     NOTHING_DO_NOT_USE: async () => {

--- a/jobs/manual/populate_appointment_stats.ts
+++ b/jobs/manual/populate_appointment_stats.ts
@@ -1,0 +1,25 @@
+import { getLogger } from '../../common/logger/logger';
+import { prisma } from '../../common/prisma';
+import { saveAppointmentStats } from '../../common/appointment/create';
+
+const logger = getLogger();
+
+export async function populateAppointmentStats() {
+    logger.info('Populating appointment stats');
+    const zoomMeetingReports = await prisma.lecture.findMany({
+        where: {
+            zoomMeetingReport: { hasSome: true },
+        },
+        select: {
+            zoomMeetingReport: true,
+            id: true,
+        },
+    });
+
+    for (const lecture of zoomMeetingReports) {
+        const report = lecture.zoomMeetingReport as any;
+        await saveAppointmentStats(report, lecture);
+    }
+
+    logger.info('Appointment stats populated');
+}

--- a/prisma/migrations/20250316110212_minimal_appointment_stats/migration.sql
+++ b/prisma/migrations/20250316110212_minimal_appointment_stats/migration.sql
@@ -1,0 +1,24 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[appointmentStatsId]` on the table `lecture` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "lecture" ADD COLUMN     "appointmentStatsId" INTEGER;
+
+-- CreateTable
+CREATE TABLE "appointment_stats" (
+    "id" SERIAL NOT NULL,
+    "joinedPupilsCount" INTEGER NOT NULL,
+    "joinedStudentsCount" INTEGER NOT NULL,
+    "meetingDuration" INTEGER NOT NULL,
+
+    CONSTRAINT "appointment_stats_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "lecture_appointmentStatsId_key" ON "lecture"("appointmentStatsId");
+
+-- AddForeignKey
+ALTER TABLE "lecture" ADD CONSTRAINT "lecture_appointmentStatsId_fkey" FOREIGN KEY ("appointmentStatsId") REFERENCES "appointment_stats"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -370,36 +370,48 @@ model learning_note {
 // Then we evolved "Course Lectures" into "Appointments", were any group of users could meet together.
 // In the codebase we call this 'appointment' and also still 'lecture'
 model lecture {
-  id                    Int                          @id(map: "PK_2abef7c1e52b7b58a9f905c9643") @default(autoincrement())
-  createdAt             DateTime                     @default(now()) @db.Timestamp(6)
-  updatedAt             DateTime                     @default(now()) @updatedAt @db.Timestamp(6)
-  start                 DateTime                     @db.Timestamp(6)
-  duration              Int // in minutes
-  title                 String?
-  description           String?
-  appointmentType       lecture_appointmenttype_enum @default(legacy)
-  isCanceled            Boolean?                     @default(false)
+  id                Int                          @id(map: "PK_2abef7c1e52b7b58a9f905c9643") @default(autoincrement())
+  createdAt         DateTime                     @default(now()) @db.Timestamp(6)
+  updatedAt         DateTime                     @default(now()) @updatedAt @db.Timestamp(6)
+  start             DateTime                     @db.Timestamp(6)
+  duration          Int // in minutes
+  title             String?
+  description       String?
+  appointmentType   lecture_appointmenttype_enum @default(legacy)
+  isCanceled        Boolean?                     @default(false)
   // A set of UserIDs of users that can modify the appointment:
-  organizerIds          String[]                     @default([])
+  organizerIds      String[]                     @default([])
   // A set of UserIDs of users that only participate:
-  participantIds        String[]                     @default([])
+  participantIds    String[]                     @default([])
   // A subset of organizerIds and participantIds that have declined the appointment:
-  declinedBy            String[]                     @default([])
+  declinedBy        String[]                     @default([])
   // A Zoom Meeting might be attached to an Appointment (unless Zoom is turned off):
-  zoomMeetingId         String?                      @db.VarChar
+  zoomMeetingId     String?                      @db.VarChar
   // When an organizer leaves a Zoom Meeting, we collect a Zoom Meeting Report from the API:
-  zoomMeetingReport     Json[]                       @default([]) @db.Json
+  zoomMeetingReport Json[]                       @default([]) @db.Json
+
+  appointmentStatsId Int?               @unique
+  appointmentStats   appointment_stats? @relation(fields: [appointmentStatsId], references: [id], onDelete: Cascade)
+
   // DEPRECATED: This was used for Course Lectures before the evolution to Appointments. Use organizerIds instead
   instructorId          Int?
   // An Appointment might be related to a Subcourse or a Match - but it can also be a standalone meeting:
   subcourseId           Int?
   matchId               Int?
-  subcourse             subcourse?                   @relation(fields: [subcourseId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "FK_087916363d2c5b483701d505a07")
-  student               student?                     @relation(fields: [instructorId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "FK_2ca61c8451b53ad2da3c5f6432a")
-  match                 match?                       @relation(fields: [matchId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "FK_5829da504d003d9aa252856574e")
+  subcourse             subcourse?              @relation(fields: [subcourseId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "FK_087916363d2c5b483701d505a07")
+  student               student?                @relation(fields: [instructorId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "FK_2ca61c8451b53ad2da3c5f6432a")
+  match                 match?                  @relation(fields: [matchId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "FK_5829da504d003d9aa252856574e")
   course_attendance_log course_attendance_log[]
   // Support can set this if organizer prefers a different meeting platform over zoom; if this is set, don't create zoom meeting
   override_meeting_link String?
+}
+
+model appointment_stats {
+  id                  Int      @id @default(autoincrement())
+  joinedPupilsCount   Int
+  joinedStudentsCount Int
+  meetingDuration     Int
+  lecture             lecture?
 }
 
 // The Transaction Log is supposed to store a history of business transactions for a user,


### PR DESCRIPTION
Only save select Zoom data to our database.

This required some very hacky workaround because I wasn't sure how to identify pupils/students in the meeting report other than separating them by having an ID and not having an ID.

Closes https://github.com/corona-school/project-user/issues/1422