### PR TITLE
feat: Add status column to students screenings

### DIFF
--- a/common/student/screening.ts
+++ b/common/student/screening.ts
@@ -1,4 +1,4 @@
-import { student as Student, screener as Screener, Prisma, PrismaClient } from '@prisma/client';
+import { student as Student, screener as Screener, Prisma, PrismaClient, student_screening_status_enum as ScreeningStatus } from '@prisma/client';
 import { prisma } from '../prisma';
 import * as Notification from '../notification';
 import { getLogger } from '../../common/logger/logger';
@@ -11,6 +11,7 @@ import { updateSessionRolesOfUser } from '../user/session';
 
 interface ScreeningInput {
     success: boolean;
+    status: ScreeningStatus;
     comment?: string;
     jobStatus?: screening_jobstatus_enum;
     knowsCoronaSchoolFrom?: string;

--- a/graphql/student/mutations.ts
+++ b/graphql/student/mutations.ts
@@ -23,6 +23,7 @@ import {
     student as Student,
     student_state_enum as State,
     student_languages_enum as Language,
+    student_screening_status_enum as StudentScreeningStatus,
     gender_enum as Gender,
     PrismaClient,
     Prisma,
@@ -61,6 +62,11 @@ export class ScreeningInput {
         nullable: true,
     })
     jobStatus?: screening_jobstatus_enum | undefined;
+
+    @Field((_type) => StudentScreeningStatus, {
+        nullable: true,
+    })
+    status: StudentScreeningStatus;
 
     @Field((_type) => String, {
         nullable: true,

--- a/graphql/types/enums.ts
+++ b/graphql/types/enums.ts
@@ -16,6 +16,7 @@ import {
     course_subject_enum,
     school_schooltype_enum,
     pupil_email_owner_enum as PupilEmailOwner,
+    student_screening_status_enum as StudentScreeningStatus,
 } from '@prisma/client';
 import { LoginOption } from '../../common/secret';
 
@@ -81,3 +82,5 @@ registerEnumType(school_schooltype_enum, {
     name: 'SchoolSchoolTypeEnum',
     description: 'The type of school',
 });
+
+registerEnumType(StudentScreeningStatus, { name: 'StudentScreeningStatus' });

--- a/prisma/migrations/20250407094956_add_student_screening_status_enum/migration.sql
+++ b/prisma/migrations/20250407094956_add_student_screening_status_enum/migration.sql
@@ -1,0 +1,8 @@
+-- CreateEnum
+CREATE TYPE "student_screening_status_enum" AS ENUM ('0', '1', '2', '3');
+
+-- AlterTable
+ALTER TABLE "instructor_screening" ADD COLUMN     "status" "student_screening_status_enum" NOT NULL DEFAULT '0';
+
+-- AlterTable
+ALTER TABLE "screening" ADD COLUMN     "status" "student_screening_status_enum" NOT NULL DEFAULT '0';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -263,20 +263,21 @@ model course_tags_course_tag {
 // If a Student wants to hold Courses, they are screened as Instructors by the Support Team
 // Durinng the Screening we also collect some additional user information
 model instructor_screening {
-  id                    Int                       @id(map: "PK_e29a51f8dce0a07d2e1dba73636") @default(autoincrement())
+  id                    Int                           @id(map: "PK_e29a51f8dce0a07d2e1dba73636") @default(autoincrement())
   success               Boolean
-  comment               String?                   @db.VarChar
+  status                student_screening_status_enum @default(pending)
+  comment               String?                       @db.VarChar
   jobStatus             screening_jobstatus_enum?
   // This is a String and not an enum to be able to quickly support further values without a DB migration,
   // and to be able to cover 'Sonstiges'. In the Screening Tooling, we however always write the same strings into it,
   // so a COUNT(*) GROUP BY should work relatively well:
-  knowsCoronaSchoolFrom String?                   @db.VarChar
-  createdAt             DateTime                  @default(now()) @db.Timestamp(6)
-  updatedAt             DateTime                  @default(now()) @updatedAt @db.Timestamp(6)
+  knowsCoronaSchoolFrom String?                       @db.VarChar
+  createdAt             DateTime                      @default(now()) @db.Timestamp(6)
+  updatedAt             DateTime                      @default(now()) @updatedAt @db.Timestamp(6)
   screenerId            Int?
-  studentId             Int?                      @unique(map: "REL_e176665fa769d2e603d825f6fa")
-  student               student?                  @relation(fields: [studentId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "FK_e176665fa769d2e603d825f6fa3")
-  screener              screener?                 @relation(fields: [screenerId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "FK_ef1d3e862feda89b92fddcdbb34")
+  studentId             Int?                          @unique(map: "REL_e176665fa769d2e603d825f6fa")
+  student               student?                      @relation(fields: [studentId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "FK_e176665fa769d2e603d825f6fa3")
+  screener              screener?                     @relation(fields: [screenerId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "FK_ef1d3e862feda89b92fddcdbb34")
 }
 
 // DEPRECATED: We once had a cooperation with Jugend Forscht ("jufo")
@@ -710,20 +711,21 @@ model screener {
 
 // A Screening for Students that want to tutor pupils
 model screening {
-  id                    Int                       @id(map: "PK_5111bc526c9133721aeffb9a578") @default(autoincrement())
+  id                    Int                           @id(map: "PK_5111bc526c9133721aeffb9a578") @default(autoincrement())
   success               Boolean
-  comment               String?                   @db.VarChar
+  status                student_screening_status_enum @default(pending)
+  comment               String?                       @db.VarChar
   jobStatus             screening_jobstatus_enum?
   // This is a String and not an enum to be able to quickly support further values without a DB migration,
   // and to be able to cover 'Sonstiges'. In the Screening Tooling, we however always write the same strings into it,
   // so a COUNT(*) GROUP BY should work relatively well:
-  knowsCoronaSchoolFrom String?                   @db.VarChar
-  createdAt             DateTime                  @default(now()) @db.Timestamp(6)
-  updatedAt             DateTime                  @default(now()) @updatedAt @db.Timestamp(6)
+  knowsCoronaSchoolFrom String?                       @db.VarChar
+  createdAt             DateTime                      @default(now()) @db.Timestamp(6)
+  updatedAt             DateTime                      @default(now()) @updatedAt @db.Timestamp(6)
   screenerId            Int?
-  studentId             Int?                      @unique(map: "REL_dfb78fd7887c69e3c52e002083")
-  screener              screener?                 @relation(fields: [screenerId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "FK_c0b20c6342ac95d3b66c31ac30e")
-  student               student?                  @relation(fields: [studentId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "FK_dfb78fd7887c69e3c52e0020838")
+  studentId             Int?                          @unique(map: "REL_dfb78fd7887c69e3c52e002083")
+  screener              screener?                     @relation(fields: [screenerId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "FK_c0b20c6342ac95d3b66c31ac30e")
+  student               student?                      @relation(fields: [studentId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "FK_dfb78fd7887c69e3c52e0020838")
 }
 
 model student {
@@ -1414,4 +1416,11 @@ enum pupil_email_owner_enum {
   parent
   other
   unknown
+}
+
+enum student_screening_status_enum {
+  pending   @map("0")
+  success   @map("1")
+  rejection @map("2")
+  missed    @map("3")
 }

--- a/seed-db.ts
+++ b/seed-db.ts
@@ -93,7 +93,7 @@ const createStudent = async ({ isInstructor = true, ...data }: CreateStudentArgs
         languages: data.languages,
         subjects: data.subjects,
     });
-    await addTutorScreening(screener, student, { success: true });
+    await addTutorScreening(screener, student, { success: true, status: 'success' });
     await prisma.student.update({ where: { id: student.id }, data: { hasDoneEthicsOnboarding: true } });
     if (isInstructor) {
         await becomeInstructor(student, {});
@@ -102,6 +102,7 @@ const createStudent = async ({ isInstructor = true, ...data }: CreateStudentArgs
             student,
             {
                 success: true,
+                status: 'success',
                 comment: 'Success',
             },
             false


### PR DESCRIPTION
## Ticket

The backend part of https://github.com/corona-school/project-user/issues/1464

## What was done?

- I added a new `status` column to the `screening` / `instructor_screening`, which is similar to how we do with the pupil screenings. This will allow for student screenings in pending or in missed statuses.
- Update mutations to start saving infos there. For now, only `success` / `rejection`

[Hier I wrote a query to populate this column for the existing screenings based on the `success` column](https://github.com/corona-school/dev-db/commit/2bacce1929203fcabf663371a529f40c98d844a5) (which will be deprecated/removed in future PRs)