### PR TITLE
Fix logic in matching getViableUsers for test.*@lern-fair.de accounts

### DIFF
--- a/common/match/pool.ts
+++ b/common/match/pool.ts
@@ -55,7 +55,7 @@ const getViableUsers = (toggles: string[]) => {
     /* On production we want to avoid that our testusers test+prod-...@lern-fair.de
     are accidentally matched to real users */
     if (!isDev) {
-        viableUsers.email = { not: { startsWith: 'test', endsWith: '@lern-fair.de' } };
+        viableUsers.NOT = [{ email: { startsWith: 'test', endsWith: '@lern-fair.de' } }];
     }
 
     return viableUsers;


### PR DESCRIPTION
It turns out that if you specify multiple `NestedStringFilter`s inside the `not` filter, they get ORed instead of ANDed.

Previously we had `viable = !(startsWith("test") || endsWith("@lern-fair.de"))` = `!startsWith("test") && !endsWith("@lern-fair.de")`
We want: `viable = !(startsWith("test") && endsWith("@lern-fair.de")` = `!startsWith("test") || !endsWith("@lern-fair.de")`.
