### PR TITLE
Feat: Add calendly webhook

### DIFF
--- a/common/calendly/index.ts
+++ b/common/calendly/index.ts
@@ -1,0 +1,274 @@
+import moment from 'moment';
+import { getLogger } from '../logger/logger';
+import { addPupilScreening } from '../pupil/screening';
+import { getPupil, getUserByEmail } from '../user';
+import { prisma } from '../prisma';
+import { DEFAULT_SCREENER_NUMBER_ID } from '../util/screening';
+
+const logger = getLogger('Calendly');
+
+export interface CalendlyEventPayload {
+    cancel_url: string;
+    created_at: string;
+    email: string;
+    event: string;
+    first_name: string;
+    name: string;
+    reschedule_url: string;
+    rescheduled: boolean;
+    scheduled_event: ScheduledEvent;
+    status: string;
+    timezone: string;
+    updated_at: string;
+    uri: string;
+}
+
+export interface CalendlyEvent {
+    created_at: string;
+    created_by: string;
+    event: 'invitee.created' | 'invitee.canceled' | 'invitee_no_show.created' | 'invitee_no_show.deleted';
+    payload: CalendlyEventPayload;
+}
+
+export interface ScheduledEvent {
+    created_at: string;
+    end_time: string;
+    event_type: string;
+    name: string;
+    start_time: string;
+    status: string;
+    updated_at: string;
+    uri: string;
+    join_url: string;
+    cancellation?: {
+        canceled_by: string;
+        canceler_type: 'invitee' | string;
+        created_at: string;
+        reason: string;
+    };
+    location?: {
+        data: {
+            id: number;
+        };
+        join_url: string;
+        type: 'zoom' | string;
+    };
+}
+
+export const getCalendlyScheduledEvent = async (eventUrl: string) => {
+    const response = await fetch(eventUrl, {
+        method: 'GET',
+        headers: {
+            Authorization: `Bearer ${process.env.CALENDLY_ACCESS_TOKEN}`,
+            'Content-Type': 'application/json',
+        },
+    });
+
+    if (!response.ok) {
+        const errorText = `Failed to fetch Calendly event: ${response.statusText}`;
+        logger.error(errorText);
+        throw new Error(errorText);
+    }
+
+    const envelope = await response.json();
+    const scheduledEvent = envelope.resource as ScheduledEvent;
+    return {
+        ...scheduledEvent,
+        join_url: scheduledEvent?.location?.join_url,
+    };
+};
+
+const onEventInviteeCreated = async (event: CalendlyEvent) => {
+    const user = await getUserByEmail(event.payload.email);
+    const newAppointmentComment = `[System]: Der Termin wurde am ${moment(event.payload.created_at).format('D.M.YYYY, HH:mm')} erstellt und findet am ${moment(
+        event.payload.scheduled_event.start_time
+    ).format('D.M.YYYY, HH:mm')} statt.`;
+
+    if (user.pupilId) {
+        // Check if there is already a valid screening
+        let screening = await prisma.pupil_screening.findFirst({
+            where: {
+                pupilId: user.pupilId,
+                status: 'pending',
+                invalidated: false,
+            },
+        });
+        // If there is a screening, just update the comment
+        // This should cover the case where the matching algo invites a pupil to a screening
+        if (screening) {
+            await prisma.pupil_screening.update({
+                where: { id: screening.id },
+                data: {
+                    comment: `${screening.comment}\n${newAppointmentComment}`,
+                },
+            });
+        } else {
+            const pupil = await getPupil(user);
+            screening = await addPupilScreening(pupil, { comment: newAppointmentComment, status: 'pending' }, true);
+        }
+        const appointment = await prisma.screening_appointment.create({
+            data: {
+                eventUrl: event.payload.scheduled_event.uri,
+                joinUrl: event.payload.scheduled_event.location?.join_url,
+                startAt: new Date(event.payload.scheduled_event.start_time),
+                pupilScreeningId: screening.id,
+            },
+        });
+        logger.info(`Created ScreeningAppointment(${appointment.id}) for Screening(${screening.id})`);
+        return;
+    }
+
+    if (user.studentId) {
+        // If the student already completed a screening, we won't attach the screening appointment to it
+        const hadTutorScreening =
+            (await prisma.screening.count({
+                where: {
+                    studentId: user.studentId,
+                    status: { in: ['rejection', 'success'] },
+                },
+            })) > 0;
+        const hadInstructorScreening =
+            (await prisma.instructor_screening.count({
+                where: {
+                    studentId: user.studentId,
+                    status: { in: ['rejection', 'success'] },
+                },
+            })) > 0;
+
+        // Create or "update" the screenings
+        const tutorScreening = await prisma.screening.upsert({
+            where: {
+                studentId: user.studentId,
+            },
+            create: {
+                screenerId: DEFAULT_SCREENER_NUMBER_ID,
+                studentId: user.studentId,
+                comment: newAppointmentComment,
+                status: 'pending',
+            },
+            // If there was already a screening we don't do anything here
+            update: {},
+        });
+        const instructorScreening = await prisma.instructor_screening.upsert({
+            where: {
+                studentId: user.studentId,
+            },
+            create: {
+                screenerId: DEFAULT_SCREENER_NUMBER_ID,
+                studentId: user.studentId,
+                comment: newAppointmentComment,
+                status: 'pending',
+            },
+            // If there was already a screening we don't do anything here
+            update: {},
+        });
+
+        const appointment = await prisma.screening_appointment.create({
+            data: {
+                eventUrl: event.payload.scheduled_event.uri,
+                joinUrl: event.payload.scheduled_event.location?.join_url,
+                startAt: new Date(event.payload.scheduled_event.start_time),
+                instructorScreeningId: !hadInstructorScreening ? instructorScreening.id : undefined,
+                tutorScreeningId: !hadTutorScreening ? tutorScreening.id : undefined,
+            },
+        });
+        logger.info(`Created ScreeningAppointment(${appointment.id}) for Student(${user.studentId})`);
+        return;
+    }
+};
+
+const onEventInviteeCanceled = async (event: CalendlyEvent) => {
+    const appointment = await prisma.screening_appointment.findFirst({
+        where: {
+            eventUrl: event.payload.scheduled_event.uri,
+        },
+        include: {
+            pupilScreening: true,
+            instructorScreening: true,
+            tutorScreening: true,
+        },
+    });
+    if (!appointment) {
+        logger.warn(`No ScreeningAppointment found for event URL: ${event.payload.scheduled_event.uri}`);
+        return;
+    }
+
+    await prisma.screening_appointment.update({
+        where: { id: appointment.id },
+        data: {
+            cancelledAt: new Date(event.payload.scheduled_event.cancellation?.created_at),
+            cancellationReason: event.payload.scheduled_event.cancellation?.reason,
+        },
+    });
+
+    if (appointment.pupilScreeningId) {
+        const screening = await prisma.pupil_screening.findFirst({
+            where: {
+                pupilId: appointment.pupilScreening.pupilId,
+                invalidated: false,
+            },
+        });
+        await prisma.pupil_screening.update({
+            where: { id: screening.id },
+            data: {
+                comment: `${screening.comment}\n[System]: Der Termin wurde am ${moment(event.payload.scheduled_event.cancellation?.created_at).format(
+                    'D.M.YYYY, HH:mm'
+                )} abgesagt. Grund: ${event.payload.scheduled_event.cancellation?.reason}`,
+            },
+        });
+        logger.info(`Updated Screening(${screening.id}) for Pupil(${screening.pupilId}) after screening appointment was canceled`);
+    }
+
+    if (appointment.tutorScreeningId) {
+        const screening = await prisma.screening.findFirst({
+            where: {
+                id: appointment.tutorScreeningId,
+            },
+        });
+        await prisma.screening.update({
+            where: { id: screening.id },
+            data: {
+                comment: `${screening.comment}\n[System]: Der Termin wurde am ${moment(event.payload.scheduled_event.cancellation?.created_at).format(
+                    'D.M.YYYY, HH:mm'
+                )} abgesagt. Grund: ${event.payload.scheduled_event.cancellation?.reason}`,
+            },
+        });
+        logger.info(`Updated Screening(${screening.id}) for Student(${screening.studentId}) after screening appointment was canceled`);
+    }
+
+    if (appointment.instructorScreeningId) {
+        const screening = await prisma.instructor_screening.findFirst({
+            where: {
+                id: appointment.instructorScreeningId,
+            },
+        });
+        await prisma.instructor_screening.update({
+            where: { id: screening.id },
+            data: {
+                comment: `${screening.comment}\n[System]: Der Termin wurde am ${moment(event.payload.scheduled_event.cancellation?.created_at).format(
+                    'D.M.YYYY, HH:mm'
+                )} abgesagt. Grund: ${event.payload.scheduled_event.cancellation?.reason}`,
+            },
+        });
+        logger.info(`Updated Screening(${screening.id}) for Student(${screening.studentId}) after screening appointment was canceled`);
+    }
+};
+
+export const onEvent = (event: CalendlyEvent) => {
+    logger.info(`Handling Calendly Event(${event.event})`, event);
+    switch (event.event) {
+        case 'invitee.created':
+            return onEventInviteeCreated(event);
+        case 'invitee.canceled':
+            return onEventInviteeCanceled(event);
+        case 'invitee_no_show.created':
+            // We don't handle this for now
+            break;
+        case 'invitee_no_show.deleted':
+            // We don't handle this for now
+            break;
+        default:
+            logger.warn(`Unknown Calendly event type: ${event.event}`, event);
+            break;
+    }
+};

--- a/common/pupil/screening.ts
+++ b/common/pupil/screening.ts
@@ -25,13 +25,14 @@ export async function addPupilScreening(pupil: Pupil, screening: PupilScreeningI
         throw new PrerequisiteError(`Pupil ${pupil.id} does not have a verified email`);
     }
 
-    await prisma.pupil_screening.create({ data: { ...screening, pupilId: pupil.id } });
+    const pupilScreening = await prisma.pupil_screening.create({ data: { ...screening, pupilId: pupil.id } });
 
     if (!silent) {
         await Notification.actionTaken(userForPupil(pupil), 'pupil_screening_add', {});
     }
 
     logger.info(`Added ${screening.status || 'pending'} screening for pupil ${pupil.id}`, screening);
+    return pupilScreening;
 }
 
 interface PupilScreeningUpdate {

--- a/graphql/authorizations.ts
+++ b/graphql/authorizations.ts
@@ -353,6 +353,7 @@ export const authorizationEnhanceMap: Required<ResolversEnhanceMap> = {
     Learning_assignment: allAdmin,
     Learning_note: allAdmin,
     Learning_topic: allAdmin,
+    Screening_appointment: allAdmin,
 };
 
 /* Some entities are generally accessible by multiple users, however some fields of them are
@@ -627,6 +628,11 @@ export const authorizationModelEnhanceMap: ModelsEnhanceMap = {
     Pupil_screening: {
         fields: {
             comment: onlyAdminOrScreener,
+        },
+    },
+    Screening_appointment: {
+        fields: {
+            eventUrl: onlyAdminOrScreener,
         },
     },
 };

--- a/graphql/instructor_screening/fields.ts
+++ b/graphql/instructor_screening/fields.ts
@@ -1,6 +1,6 @@
 import { prisma } from '../../common/prisma';
 import { Authorized, FieldResolver, Resolver, Root } from 'type-graphql';
-import { Screener, Instructor_screening as InstructorScreening } from '../generated';
+import { Screener, Instructor_screening as InstructorScreening, Screening_appointment as ScreeningAppointment } from '../generated';
 import { Role } from '../authorizations';
 
 @Resolver((of) => InstructorScreening)
@@ -9,5 +9,21 @@ export class ExtendedFieldsInstructorScreeningResolver {
     @Authorized(Role.ADMIN, Role.SCREENER)
     async screener(@Root() screening: InstructorScreening) {
         return await prisma.screener.findUnique({ where: { id: screening.screenerId } });
+    }
+
+    @FieldResolver((returns) => ScreeningAppointment, { nullable: true })
+    @Authorized(Role.ADMIN, Role.STUDENT_SCREENER, Role.OWNER)
+    async appointment(@Root() screening: ScreeningAppointment) {
+        const currentScreening = await prisma.instructor_screening.findFirst({
+            where: { id: screening.id },
+        });
+        const appointment = await prisma.screening_appointment.findFirst({
+            where: {
+                instructorScreeningId: currentScreening.id,
+                cancelledAt: { equals: null },
+            },
+        });
+
+        return appointment;
     }
 }

--- a/graphql/ownership.ts
+++ b/graphql/ownership.ts
@@ -48,4 +48,7 @@ export const isOwnedBy: { [Name in ResolverModelNames]?: (user: GraphQLUser, ent
         (note.assignmentId &&
             (await isOwnedBy['Learning_assignment'](user, await prisma.learning_assignment.findUniqueOrThrow({ where: { id: note.assignmentId } })))) ||
         (note.topicId && (await isOwnedBy['Learning_topic'](user, await prisma.learning_topic.findUniqueOrThrow({ where: { id: note.topicId } })))),
+    Screening: (user, screening) => user.studentId === screening.studentId,
+    Instructor_screening: (user, screening) => user.studentId === screening.studentId,
+    Pupil_screening: (user, screening) => user.pupilId === screening.pupilId,
 };

--- a/graphql/pupil_screening/fields.ts
+++ b/graphql/pupil_screening/fields.ts
@@ -1,5 +1,5 @@
 import { Authorized, FieldResolver, Resolver, Root } from 'type-graphql';
-import { Pupil, Pupil_screening as PupilScreening, Screener } from '../generated';
+import { Pupil, Pupil_screening as PupilScreening, Screener, Screening_appointment as ScreeningAppointment } from '../generated';
 import { Role } from '../../common/user/roles';
 import { prisma } from '../../common/prisma';
 
@@ -15,5 +15,25 @@ export class ExtendedFieldsPupil_screeningResolver {
     @Authorized(Role.ADMIN, Role.SCREENER)
     async screeners(@Root() screening: PupilScreening) {
         return await prisma.screener.findMany({ where: { id: { in: screening.screenerIds } } });
+    }
+
+    @FieldResolver((returns) => ScreeningAppointment, { nullable: true })
+    @Authorized(Role.ADMIN, Role.PUPIL_SCREENER, Role.OWNER)
+    async appointment(@Root() screening: PupilScreening) {
+        const currentScreening = await prisma.pupil_screening.findFirst({
+            where: {
+                invalidated: false,
+                id: screening.id,
+                status: { in: ['pending'] },
+            },
+        });
+        const appointment = await prisma.screening_appointment.findFirst({
+            where: {
+                pupilScreeningId: currentScreening.id,
+                cancelledAt: { equals: null },
+            },
+        });
+
+        return appointment;
     }
 }

--- a/graphql/tutor_screening/fields.ts
+++ b/graphql/tutor_screening/fields.ts
@@ -1,6 +1,6 @@
 import { prisma } from '../../common/prisma';
 import { Authorized, FieldResolver, Resolver, Root } from 'type-graphql';
-import { Screener, Screening } from '../generated';
+import { Screener, Screening, Screening_appointment as ScreeningAppointment } from '../generated';
 import { Role } from '../authorizations';
 
 @Resolver((of) => Screening)
@@ -9,5 +9,21 @@ export class ExtendedFieldsTutorScreeningResolver {
     @Authorized(Role.ADMIN, Role.SCREENER)
     async screener(@Root() screening: Screening) {
         return await prisma.screener.findUnique({ where: { id: screening.screenerId } });
+    }
+
+    @FieldResolver((returns) => ScreeningAppointment, { nullable: true })
+    @Authorized(Role.ADMIN, Role.STUDENT_SCREENER, Role.OWNER)
+    async appointment(@Root() screening: Screening) {
+        const currentScreening = await prisma.screening.findFirst({
+            where: { id: screening.id },
+        });
+        const appointment = await prisma.screening_appointment.findFirst({
+            where: {
+                tutorScreeningId: currentScreening.id,
+                cancelledAt: { equals: null },
+            },
+        });
+
+        return appointment;
     }
 }

--- a/prisma/migrations/20250411124956_add_screening_appointment_table/migration.sql
+++ b/prisma/migrations/20250411124956_add_screening_appointment_table/migration.sql
@@ -1,0 +1,25 @@
+-- CreateTable
+CREATE TABLE "screening_appointment" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "startAt" TIMESTAMP(6) NOT NULL,
+    "cancelledAt" TIMESTAMP(6),
+    "cancellationReason" VARCHAR,
+    "joinUrl" VARCHAR,
+    "eventUrl" VARCHAR,
+    "pupilScreeningId" INTEGER,
+    "tutorScreeningId" INTEGER,
+    "instructorScreeningId" INTEGER,
+
+    CONSTRAINT "screening_appointment_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "screening_appointment" ADD CONSTRAINT "screening_appointment_pupilScreeningId_fkey" FOREIGN KEY ("pupilScreeningId") REFERENCES "pupil_screening"("id") ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "screening_appointment" ADD CONSTRAINT "screening_appointment_tutorScreeningId_fkey" FOREIGN KEY ("tutorScreeningId") REFERENCES "screening"("id") ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "screening_appointment" ADD CONSTRAINT "screening_appointment_instructorScreeningId_fkey" FOREIGN KEY ("instructorScreeningId") REFERENCES "instructor_screening"("id") ON DELETE NO ACTION ON UPDATE NO ACTION;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1004,7 +1004,10 @@ model screening_appointment {
   startAt               DateTime              @db.Timestamp(6)
   cancelledAt           DateTime?             @db.Timestamp(6)
   cancellationReason    String?               @db.VarChar
+  // Where the appointment takes place, e.g. 'Zoom', 'Google Meets', etc...
   joinUrl               String?               @db.VarChar
+  // Calendly Event URL, we can use this go get additional information about the appointment
+  // For calendly, it's also kind of an id
   eventUrl              String?               @db.VarChar
   pupilScreeningId      Int?
   pupilScreening        pupil_screening?      @relation(fields: [pupilScreeningId], references: [id], onDelete: NoAction, onUpdate: NoAction)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -277,6 +277,7 @@ model instructor_screening {
   studentId             Int?                          @unique(map: "REL_e176665fa769d2e603d825f6fa")
   student               student?                      @relation(fields: [studentId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "FK_e176665fa769d2e603d825f6fa3")
   screener              screener?                     @relation(fields: [screenerId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "FK_ef1d3e862feda89b92fddcdbb34")
+  screening_appointment screening_appointment[]
 }
 
 // DEPRECATED: We once had a cooperation with Jugend Forscht ("jufo")
@@ -724,6 +725,7 @@ model screening {
   studentId             Int?                          @unique(map: "REL_dfb78fd7887c69e3c52e002083")
   screener              screener?                     @relation(fields: [screenerId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "FK_c0b20c6342ac95d3b66c31ac30e")
   student               student?                      @relation(fields: [studentId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "FK_dfb78fd7887c69e3c52e0020838")
+  screening_appointment screening_appointment[]
 }
 
 model student {
@@ -984,11 +986,29 @@ model pupil_screening {
 
   // During the Pupil Screening, various screeners are involved ('four eye principle')
   // This was not tracked before September 23
-  screenerIds           Int[]   @default([])
+  screenerIds           Int[]                   @default([])
   // This is a String and not an enum to be able to quickly support further values without a DB migration,
   // and to be able to cover 'Sonstiges'. In the Screening Tooling, we however always write the same strings into it,
   // so a COUNT(*) GROUP BY should work relatively well:
-  knowsCoronaSchoolFrom String? @db.VarChar
+  knowsCoronaSchoolFrom String?                 @db.VarChar
+  screening_appointment screening_appointment[]
+}
+
+model screening_appointment {
+  id                    Int                   @id() @default(autoincrement())
+  createdAt             DateTime              @default(now()) @db.Timestamp(6)
+  updatedAt             DateTime              @default(now()) @updatedAt @db.Timestamp(6)
+  startAt               DateTime              @db.Timestamp(6)
+  cancelledAt           DateTime?             @db.Timestamp(6)
+  cancellationReason    String?               @db.VarChar
+  joinUrl               String?               @db.VarChar
+  eventUrl              String?               @db.VarChar
+  pupilScreeningId      Int?
+  pupilScreening        pupil_screening?      @relation(fields: [pupilScreeningId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  tutorScreeningId      Int?
+  tutorScreening        screening?            @relation(fields: [tutorScreeningId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  instructorScreeningId Int?
+  instructorScreening   instructor_screening? @relation(fields: [instructorScreeningId], references: [id], onDelete: NoAction, onUpdate: NoAction)
 }
 
 // When a subcourse is already full, pupils can still enroll on a waiting list

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -994,6 +994,9 @@ model pupil_screening {
   screening_appointment screening_appointment[]
 }
 
+// Users need to go through a screening process before they can use the app. 
+// For this they have to book an appointment in Calendly.
+// The appointment is then automatically stored here via a webhook.
 model screening_appointment {
   id                    Int                   @id() @default(autoincrement())
   createdAt             DateTime              @default(now()) @db.Timestamp(6)

--- a/web/controllers/calendlyController/index.ts
+++ b/web/controllers/calendlyController/index.ts
@@ -1,7 +1,8 @@
-import { Router } from 'express';
+import { Request, Router } from 'express';
 import { getLogger } from '../../../common/logger/logger';
 import { CalendlyEvent, onEvent } from '../../../common/calendly';
 import crypto from 'crypto';
+import { WithRawBody } from '../chatNotificationController/types';
 
 const logger = getLogger('CalendlyWebhook');
 
@@ -9,7 +10,7 @@ const webhookSigningKey = process.env.CALENDLY_WEBHOOK_SIGNING_KEY;
 
 export const calendlyRouter = Router();
 
-calendlyRouter.post('/event', async (req, res) => {
+calendlyRouter.post('/event', async (req: WithRawBody<Request>, res) => {
     logger.info('Request at /calendly/event');
     try {
         const calendlySignature = req.get('Calendly-Webhook-Signature');
@@ -26,7 +27,7 @@ calendlyRouter.post('/event', async (req, res) => {
             res.status(401).send({ error: 'Unauthorized' });
             return;
         }
-        const data = t + '.' + JSON.stringify(req.body);
+        const data = t + '.' + req.rawBody;
         const expectedSignature = crypto.createHmac('sha256', webhookSigningKey).update(data, 'utf8').digest('hex');
         if (expectedSignature !== signature) {
             logger.error('Invalid Signature');

--- a/web/controllers/calendlyController/index.ts
+++ b/web/controllers/calendlyController/index.ts
@@ -1,0 +1,61 @@
+import { Router } from 'express';
+import { getLogger } from '../../../common/logger/logger';
+import { CalendlyEvent, onEvent } from '../../../common/calendly';
+import crypto from 'crypto';
+
+const logger = getLogger('CalendlyWebhook');
+
+const webhookSigningKey = process.env.CALENDLY_WEBHOOK_SIGNING_KEY;
+
+export const calendlyRouter = Router();
+
+calendlyRouter.post('/event', async (req, res) => {
+    logger.info('Request at /calendly/event');
+    try {
+        const calendlySignature = req.get('Calendly-Webhook-Signature');
+        if (!calendlySignature) {
+            logger.error('Invalid Signature');
+            res.status(401).send({ error: 'Unauthorized' });
+            return;
+        }
+        // Calendly Signatures documentation https://developer.calendly.com/api-docs/4c305798a61d3-webhook-signatures
+        const { t, signature } = calendlySignature.split(',').reduce(
+            (acc, currentValue) => {
+                const [key, value] = currentValue.split('=');
+
+                if (key === 't') {
+                    acc.t = value;
+                }
+
+                if (key === 'v1') {
+                    acc.signature = value;
+                }
+
+                return acc;
+            },
+            {
+                t: '',
+                signature: '',
+            }
+        );
+        if (!t || !signature) {
+            logger.error('Invalid Signature');
+            res.status(401).send({ error: 'Unauthorized' });
+            return;
+        }
+        const data = t + '.' + JSON.stringify(req.body);
+        const expectedSignature = crypto.createHmac('sha256', webhookSigningKey).update(data, 'utf8').digest('hex');
+        if (expectedSignature !== signature) {
+            logger.error('Invalid Signature');
+            res.status(401).send({ error: 'Unauthorized' });
+            return;
+        }
+
+        const event = req.body as CalendlyEvent;
+        await onEvent(event);
+        res.status(200).send({ status: 'ok' });
+    } catch (error) {
+        logger.error(`Failed to handle calendly event: ${error.message}`, error);
+        res.status(500).send({ error: 'Internal Server Error' });
+    }
+});

--- a/web/controllers/calendlyController/index.ts
+++ b/web/controllers/calendlyController/index.ts
@@ -19,25 +19,8 @@ calendlyRouter.post('/event', async (req, res) => {
             return;
         }
         // Calendly Signatures documentation https://developer.calendly.com/api-docs/4c305798a61d3-webhook-signatures
-        const { t, signature } = calendlySignature.split(',').reduce(
-            (acc, currentValue) => {
-                const [key, value] = currentValue.split('=');
+        const { t, v1: signature } = Object.fromEntries(calendlySignature.split(',').map((kv) => kv.split('=')));
 
-                if (key === 't') {
-                    acc.t = value;
-                }
-
-                if (key === 'v1') {
-                    acc.signature = value;
-                }
-
-                return acc;
-            },
-            {
-                t: '',
-                signature: '',
-            }
-        );
         if (!t || !signature) {
             logger.error('Invalid Signature');
             res.status(401).send({ error: 'Unauthorized' });

--- a/web/server.ts
+++ b/web/server.ts
@@ -19,6 +19,7 @@ import { convertCertificateLinkToApiLink } from '../common/certificate';
 import { chatNotificationRouter } from './controllers/chatNotificationController';
 import { WithRawBody } from './controllers/chatNotificationController/types';
 import { metricsRouter } from '../common/logger/metrics';
+import { calendlyRouter } from './controllers/calendlyController';
 
 // ------------------ Setup Logging, Common Headers, Routes ----------------
 
@@ -104,6 +105,7 @@ export const server = (async function setupWebserver() {
     app.use('/api/files', fileRouter);
     app.use('/api/chat', chatNotificationRouter);
     app.use('/metrics', metricsRouter);
+    app.use('/api/calendly', calendlyRouter);
 
     app.get('/:certificateId', (req, res, next) => {
         if (!req.subdomains.includes('verify')) {


### PR DESCRIPTION
## Ticket

Resolves https://github.com/corona-school/project-user/issues/1366 (backend part)

## What was done?

- Added a new endpoint for our Calendly webhook `/calendly/event`
- Added handlers for two events
  - `onEventInviteeCreated`: It creates pending screenings for the user (Pupil or Student) who scheduled the meeting via Calendly. We also save some of this information in a new `screening_appointment` table
  - `onEventInviteeCanceled`: For now, it marks the appointment as cancelled so the user in the UI can book another one. Additionally, it writes some logs on the screenings (like the reason for the cancellation).
  - Expose screening appointment information that we'll show on the Screening blockers.