### PR TITLE
Feat: Update when to invalidate pupil screenings

### DIFF
--- a/common/match/create.ts
+++ b/common/match/create.ts
@@ -8,7 +8,6 @@ import { getJitsiTutoringLink, getMatchHash, getOverlappingSubjects } from './ut
 import { getLogger } from '../../common/logger/logger';
 import { PrerequisiteError } from '../util/error';
 import type { ConcreteMatchPool } from './pool';
-import { invalidateAllScreeningsOfPupil } from '../pupil/screening';
 import { userForPupil, userForStudent } from '../user';
 import { DAZ } from '../util/subjectsutils';
 
@@ -56,7 +55,6 @@ export async function createMatch(pupil: Pupil, student: Student, pool: Concrete
         },
     });
 
-    await invalidateAllScreeningsOfPupil(pupil.id);
     await removeInterest(pupil);
 
     const callURL = getJitsiTutoringLink(match);

--- a/common/match/dissolve.ts
+++ b/common/match/dissolve.ts
@@ -84,7 +84,7 @@ export async function dissolveMatch(
     }
 
     // If the student dissolved the match for personal issues or ghosting, invalidate all screenings of the pupil
-    if ((dissolvedBy === dissolved_by_enum.student && dissolveReasons.includes('personalIssues')) || dissolveReasons.includes('ghosted')) {
+    if (dissolvedBy === dissolved_by_enum.student && (dissolveReasons.includes('personalIssues') || dissolveReasons.includes('ghosted'))) {
         await invalidateAllScreeningsOfPupil(pupil.id);
     }
 

--- a/common/match/dissolve.ts
+++ b/common/match/dissolve.ts
@@ -9,6 +9,7 @@ import { canRemoveZoomLicense, getMatchHash } from './util';
 import { deleteZoomMeeting } from '../zoom/scheduled-meeting';
 import { deleteZoomUser } from '../zoom/user';
 import moment from 'moment';
+import { invalidateAllScreeningsOfPupil } from '../pupil/screening';
 
 const logger = getLogger('Match');
 
@@ -80,6 +81,11 @@ export async function dissolveMatch(
     } else {
         await Notification.actionTaken(userForStudent(student), 'tutor_match_dissolved_mature', { pupil, matchHash, matchDate, uniqueId });
         await Notification.actionTaken(userForPupil(pupil), 'tutee_match_dissolved_mature', { student, matchHash, matchDate, uniqueId });
+    }
+
+    // If the student dissolved the match for personal issues or ghosting, invalidate all screenings of the pupil
+    if ((dissolvedBy === dissolved_by_enum.student && dissolveReasons.includes('personalIssues')) || dissolveReasons.includes('ghosted')) {
+        await invalidateAllScreeningsOfPupil(pupil.id);
     }
 
     if (dissolver && dissolver.email === student.email) {

--- a/common/match/request.ts
+++ b/common/match/request.ts
@@ -76,8 +76,6 @@ export async function deletePupilMatchRequest(pupil: Pupil) {
         },
     });
 
-    await invalidateAllScreeningsOfPupil(pupil.id);
-
     if (result.openMatchRequestCount === 0) {
         await Notification.actionTaken(userForPupil(pupil), 'tutee_match_request_revoked', {});
     }

--- a/common/match/request.ts
+++ b/common/match/request.ts
@@ -6,6 +6,7 @@ import { RedundantError } from '../util/error';
 import { invalidateAllScreeningsOfPupil } from '../pupil/screening';
 import * as Notification from '../notification';
 import { userForPupil, userForStudent } from '../user';
+import moment from 'moment';
 
 const logger = getLogger('Match');
 
@@ -60,6 +61,23 @@ export async function createPupilMatchRequest(pupil: Pupil, adminOverride = fals
     }
 
     await Notification.actionTaken(userForPupil(pupil), 'tutee_match_requested', {});
+
+    // If the last successful screening, wasn't in the last four months, then invalidate all the screenings.
+    const screening = await prisma.pupil_screening.findFirst({
+        where: {
+            pupilId: pupil.id,
+            status: 'success',
+            createdAt: {
+                gte: moment().subtract(4, 'months').toDate(),
+            },
+        },
+        orderBy: {
+            createdAt: 'desc',
+        },
+    });
+    if (!screening) {
+        await invalidateAllScreeningsOfPupil(pupil.id);
+    }
 
     logger.info(`Created match request for Pupil(${pupil.id}), now has ${result.openMatchRequestCount} requests, was admin: ${adminOverride}`);
 }

--- a/common/match/request.ts
+++ b/common/match/request.ts
@@ -67,6 +67,7 @@ export async function createPupilMatchRequest(pupil: Pupil, adminOverride = fals
         where: {
             pupilId: pupil.id,
             status: 'success',
+            invalidated: false,
             createdAt: {
                 gte: moment().subtract(4, 'months').toDate(),
             },

--- a/common/notification/hooks.ts
+++ b/common/notification/hooks.ts
@@ -46,8 +46,10 @@ registerStudentHook(
 
 import { deletePupilMatchRequest } from '../match/request';
 import { deactivatePupil } from '../pupil/activation';
+import { invalidateAllScreeningsOfPupil } from '../pupil/screening';
 registerPupilHook('revoke-pupil-match-request', 'Match Request is taken back, pending Pupil Screenings are invalidated', async (pupil) => {
     await deletePupilMatchRequest(pupil);
+    await invalidateAllScreeningsOfPupil(pupil.id);
 });
 
 registerPupilHook('deactivate-pupil', 'Account gets deactivated, matches are dissolved, courses are left', async (pupil) => {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -988,7 +988,7 @@ model pupil_screening {
   createdAt   DateTime                    @default(now()) @db.Timestamp(6)
   updatedAt   DateTime                    @default(now()) @updatedAt @db.Timestamp(6)
   status      pupil_screening_status_enum @default(pending)
-  // invalidated when a Match is created or the Match Request is revoked
+  // invalidated when a student dissolves a match due to Ghosting / Personal Issues, OR if the last successful screening is older than 4 months (calculated at time of requesting a new match)
   invalidated Boolean                     @default(false)
   comment     String?                     @db.VarChar
   pupilId     Int?


### PR DESCRIPTION
## Ticket

Resolves https://github.com/corona-school/project-user/issues/1477

## What was done?

Updated when we invalidate pupil screenings.

- **Before:** After a match is created / a Pupil match request is revoked
- **After:** When a HuH dissolves a match due to Ghosting / Personal Issues, OR if the last successful screening is older than 4 months _(calculated at time of requesting a new match)_