### PR TITLE
feat: Filter Calendly events that trigger the webhook logic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,3 +83,11 @@ REQUIRE_PUPIL_SCREENING=
 
 # Credential for the OpenAI API to use their LLMs
 OPENAI_API_KEY=
+
+# Credentials and Setup for the Calendly webhook
+CALENDLY_ACCESS_TOKEN=
+## Unique secret key shared between us and Calendly
+## https://developer.calendly.com/api-docs/ZG9jOjM2MzE2MDM4-webhook-signatures
+CALENDLY_WEBHOOK_SIGNING_KEY=
+## A list of event type UUIDs, separated by commas. The Calendly webhook will only trigger for these specific event types.
+CALENDLY_WEBHOOK_EVENT_TYPES=""

--- a/common/calendly/index.ts
+++ b/common/calendly/index.ts
@@ -306,6 +306,13 @@ const onEventInviteeCanceled = async (event: CalendlyEvent) => {
 };
 
 export const onEvent = (event: CalendlyEvent) => {
+    const validEventTypes = (process.env.CALENDLY_WEBHOOK_EVENT_TYPES ?? '').split(',').map((uuid) => `https://api.calendly.com/event_types/${uuid}`);
+    // Discard event if it's not configured
+    if (!validEventTypes.includes(event.payload.scheduled_event.event_type)) {
+        logger.debug(`Discarding event type: ${event.payload.scheduled_event.event_type}`);
+        return;
+    }
+
     logger.info(`Handling Calendly Event(${event.event})`, event);
     switch (event.event) {
         case 'invitee.created':

--- a/common/calendly/index.ts
+++ b/common/calendly/index.ts
@@ -305,8 +305,8 @@ const onEventInviteeCanceled = async (event: CalendlyEvent) => {
     }
 };
 
+const validEventTypes = (process.env.CALENDLY_WEBHOOK_EVENT_TYPES ?? '').split(',').map((uuid) => `https://api.calendly.com/event_types/${uuid}`);
 export const onEvent = (event: CalendlyEvent) => {
-    const validEventTypes = (process.env.CALENDLY_WEBHOOK_EVENT_TYPES ?? '').split(',').map((uuid) => `https://api.calendly.com/event_types/${uuid}`);
     // Discard event if it's not configured
     if (!validEventTypes.includes(event.payload.scheduled_event.event_type)) {
         logger.debug(`Discarding event type: ${event.payload.scheduled_event.event_type}`);


### PR DESCRIPTION
## Ticket

Resolves https://github.com/corona-school/project-user/issues/1487

## What was done?

- Added a filter to prevent events not related to screenings from triggering the webhook logic.
- Documented new env variables