### PR TITLE
fix: Allow Subcourse instructors to always add pupils to their courses

### DIFF
--- a/graphql/subcourse/mutations.ts
+++ b/graphql/subcourse/mutations.ts
@@ -327,7 +327,8 @@ export class MutateSubcourseResolver {
         }
 
         // Joining the subcourse will automatically remove the pupil from the waitinglist
-        await joinSubcourse(subcourse, pupil, true, /* notifyIfFull */ false);
+        // Not strict: Allow Subcourse Owners to add users regardless of the course settings (they could edit the settings anyways)
+        await joinSubcourse(subcourse, pupil, /* strict */ false, /* notifyIfFull */ false);
         logger.info(`Pupil(${pupilId}) joined Subcourse(${subcourseId}) from waitinglist`);
         return true;
     }
@@ -358,7 +359,9 @@ export class MutateSubcourseResolver {
                 include: { lecture: true, subcourse_instructors_student: false },
             });
         }
-        await joinSubcourse(subcourse, pupil, true, /* notifyIfFull */ false);
+
+        // Not strict: Allow Subcourse Owners to add users regardless of the course settings (they could edit the settings anyways)
+        await joinSubcourse(subcourse, pupil, /* strict */ false, /* notifyIfFull */ false);
         logger.info(`Pupil(${pupilId}) joined Subcourse(${subcourseId}) from prospects`);
         return true;
     }


### PR DESCRIPTION
Previously this was "strict", i.e. enforcing course settings, correct grade, etc. As course instructors easily can weaken these settings to add pupils, it does not make sense to apply these restrictions to them. Now instructors can add pupils in the same way admins can (as long as they are on the waiting list or prospects).