### PR TITLE
fix: SSO_REGISTERING_USER is no longer its OWNER

### DIFF
--- a/common/user/roles.ts
+++ b/common/user/roles.ts
@@ -21,6 +21,9 @@ export enum Role {
     UNAUTHENTICATED = 'UNAUTHENTICATED',
     /* User owns the entity as defined in graphql/ownership */
     OWNER = 'OWNER',
+    /* Same as OWNER, but allows temporary users (i.e. without the USER Role) to hold it */
+    TEMPORARY_OWNER = 'TEMPORARY_OWNER',
+
     /* No one should have access */
     NOBODY = 'NOBODY',
 

--- a/graphql/authorizations.ts
+++ b/graphql/authorizations.ts
@@ -128,6 +128,17 @@ async function accessCheck(context: GraphQLContext, requiredRoles: Role[], model
         return true;
     }
 
+    // Do not allow access by unauthenticated users unless Role.UNAUTHENTICATED is explicitly in the authorized roles
+    if (context.user === UNAUTHENTICATED_USER) {
+        throw new AuthenticationError(`Missing Roles as an unauthenticated user, did you forget to log in?`);
+    }
+
+    // Do not allow access by e.g. SSO registering users unless the temporary user is explicitly allowed, or temporary ownership
+    // is used
+    if (!context.user.roles.includes(Role.USER) && !requiredRoles.includes(Role.TEMPORARY_OWNER)) {
+        throw new AuthenticationError(`Temporary user has no permission to perform this query`);
+    }
+
     // If access is not granted by a fixed role of the user, they might have access through an 'entity role',
     // i.e. they are the owner of the accessed course or a participant in a course
 
@@ -157,10 +168,6 @@ async function accessCheck(context: GraphQLContext, requiredRoles: Role[], model
                 return true;
             }
         }
-    }
-
-    if (context.user === UNAUTHENTICATED_USER) {
-        throw new AuthenticationError(`Missing Roles as an unauthenticated user, did you forget to log in?`);
     }
 
     throw new ForbiddenError(`Requiring one of the following roles: ${requiredRoles}`);
@@ -199,18 +206,24 @@ function storeDeterminedEntityRole(context: GraphQLContext, role: Role, root: an
     authLogger.debug(`Stored role ${role} on entity: ${hasRole}`);
 }
 
+async function hasOwnershipRole(context: GraphQLContext, modelName: ResolverModelNames, root: any) {
+    const ownershipCheck = isOwnedBy[modelName];
+    assert(!!ownershipCheck, `Entity ${modelName} must have ownership definition if Role.OWNER is used`);
+
+    const isOwner = await ownershipCheck(context.user, root);
+    authLogger.debug(`Ownership check, result: ${isOwner} for ${modelName}`, { root, user: context.user });
+
+    return isOwner;
+}
+
 const entityRoles: EntityRole[] = [
     {
         role: Role.OWNER,
-        async hasRole(context, modelName, root) {
-            const ownershipCheck = isOwnedBy[modelName];
-            assert(!!ownershipCheck, `Entity ${modelName} must have ownership definition if Role.OWNER is used`);
-
-            const isOwner = await ownershipCheck(context.user, root);
-            authLogger.debug(`Ownership check, result: ${isOwner} for ${modelName}`, { root, user: context.user });
-
-            return isOwner;
-        },
+        hasRole: hasOwnershipRole,
+    },
+    {
+        role: Role.TEMPORARY_OWNER,
+        hasRole: hasOwnershipRole,
     },
 
     {

--- a/graphql/user/fields.ts
+++ b/graphql/user/fields.ts
@@ -59,25 +59,29 @@ export class Contact {
 @Resolver((of) => UserType)
 export class UserFieldsResolver {
     @FieldResolver((returns) => String)
-    @Authorized(Role.USER, Role.SSO_REGISTERING_USER)
+    @Authorized(Role.USER, Role.TEMPORARY_OWNER)
     firstname(@Root() user: User): string {
         return user.firstname;
     }
 
     @FieldResolver((returns) => String)
-    @Authorized(Role.USER, Role.SSO_REGISTERING_USER)
+    @Authorized(Role.USER, Role.TEMPORARY_OWNER)
     lastname(@Root() user: User): string {
         return user.lastname;
     }
 
+    // NOTE: In the following we use TEMPORARY_OWNER instead of OWNER,
+    // as the frontend uses a global "GetUser" query for all users, regardless whether it is just a temporary user
+    // such as SSO_REGISTERING_USER or a real user, thus we allow this query, although it returns mostly nulls
+
     @FieldResolver((returns) => String)
-    @Authorized(Role.OWNER, Role.ADMIN, Role.SCREENER)
+    @Authorized(Role.TEMPORARY_OWNER, Role.ADMIN, Role.SCREENER)
     email(@Root() user: User): string {
         return user.email;
     }
 
     @FieldResolver((returns) => Pupil)
-    @Authorized(Role.OWNER, Role.ADMIN, Role.SCREENER)
+    @Authorized(Role.TEMPORARY_OWNER, Role.ADMIN, Role.SCREENER)
     async pupil(@Root() user: User): Promise<Pupil> {
         if (!user.pupilId) {
             return null;
@@ -87,7 +91,7 @@ export class UserFieldsResolver {
     }
 
     @FieldResolver((returns) => Student)
-    @Authorized(Role.OWNER, Role.ADMIN, Role.SCREENER)
+    @Authorized(Role.TEMPORARY_OWNER, Role.ADMIN, Role.SCREENER)
     async student(@Root() user: User): Promise<Student> {
         if (!user.studentId) {
             return null;
@@ -97,7 +101,7 @@ export class UserFieldsResolver {
     }
 
     @FieldResolver((returns) => Screener)
-    @Authorized(Role.OWNER, Role.ADMIN)
+    @Authorized(Role.TEMPORARY_OWNER, Role.ADMIN)
     async screener(@Root() user: User): Promise<Screener> {
         if (!user.screenerId) {
             return null;


### PR DESCRIPTION
Previously SSO_REGISTERING_USER (in case of link / register) would not include the USER role, however it would imply the OWNER role on the user entity. This means that the many resolvers guarded by OWNER could be run by such a temporary user. I am not certain that this correctly fails in all cases (in particular this runs into getUser(user.userID), which fails for a mock user-ID the sso user has), thus I entirely removed the OWNER role from such users by default, adding the TEMPORARY_OWNER role to allow the few cases where we want to allow this, i.e. the parts that are in the GetUser query the User-App uses globally

https://github.com/corona-school/project-user/issues/1488