### PR TITLE
Feat: Save subjects information on match table

### DIFF
--- a/common/achievement/evaluate.spec.ts
+++ b/common/achievement/evaluate.spec.ts
@@ -270,6 +270,7 @@ function createTestMatch({ lectures }: { lectures: lecture[] }): MatchWithLectur
         studentId: null,
         pupilId: null,
         matchPoolRunId: null,
+        subjectsAtMatchingTime: [],
     };
 }
 

--- a/common/match/util.ts
+++ b/common/match/util.ts
@@ -32,14 +32,23 @@ export function getOverlappingSubjects(pupil: Pupil, student: Student) {
 
     const tuteeGrade = pupil.grade === null ? null : gradeAsInt(pupil.grade);
 
-    return pupilSubjects.filter((pupilSubject) =>
-        studentSubjects.some(
-            (studentSubject) =>
-                studentSubject.name === pupilSubject.name &&
-                (studentSubject.grade?.min ?? DEFAULT_TUTORING_GRADERESTRICTIONS.MIN) <= tuteeGrade &&
-                tuteeGrade <= (studentSubject.grade?.max ?? DEFAULT_TUTORING_GRADERESTRICTIONS.MAX)
-        )
-    );
+    return pupilSubjects
+        .map((pupilSubject) => {
+            const matchingStudentSubject = studentSubjects.find(
+                (studentSubject) =>
+                    studentSubject.name === pupilSubject.name &&
+                    (studentSubject.grade?.min ?? DEFAULT_TUTORING_GRADERESTRICTIONS.MIN) <= tuteeGrade &&
+                    tuteeGrade <= (studentSubject.grade?.max ?? DEFAULT_TUTORING_GRADERESTRICTIONS.MAX)
+            );
+            if (matchingStudentSubject) {
+                return {
+                    ...pupilSubject,
+                    grade: matchingStudentSubject.grade,
+                };
+            }
+            return null;
+        })
+        .filter((subject) => !!subject);
 }
 
 // Used for showing Questionnaires to users and associate the ones of a match

--- a/graphql/match/fields.ts
+++ b/graphql/match/fields.ts
@@ -10,6 +10,7 @@ import { GraphQLContext } from '../context';
 import { Chat } from '../chat/fields';
 import { getMatcheeConversation } from '../../common/chat';
 import { getAppointmentsForMatch, getEdgeMatchAppointmentId } from '../../common/appointment/get';
+import { parseSubjectString } from '../../common/util/subjectsutils';
 
 @Resolver((of) => Match)
 export class ExtendedFieldsMatchResolver {
@@ -45,9 +46,11 @@ export class ExtendedFieldsMatchResolver {
     @Authorized(Role.ADMIN, Role.SCREENER, Role.OWNER)
     @LimitEstimated(1)
     async subjectsFormatted(@Root() match: Match) {
+        if (match.subjectsAtMatchingTime.length) {
+            return parseSubjectString(JSON.stringify(match.subjectsAtMatchingTime));
+        }
         const student = await getStudent(match.studentId);
         const pupil = await getPupil(match.pupilId);
-
         return getOverlappingSubjects(pupil, student);
     }
 

--- a/prisma/migrations/20250606074613_add_subjects_information_on_match_table/migration.sql
+++ b/prisma/migrations/20250606074613_add_subjects_information_on_match_table/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "match" ADD COLUMN     "subjectsAtMatchingTime" JSON[] DEFAULT ARRAY[]::JSON[];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -454,15 +454,16 @@ model match {
   // has only one match request at a time anyways
   studentFirstMatchRequest DateTime? @db.Timestamp(6)
   pupilFirstMatchRequest   DateTime? @db.Timestamp(6)
-
+  // JSON with the format: [{ name: "Deutsch", minGrade: 1, maxGrade: 10, pupilGrade: 5, mandatory: true }]
+  subjectsAtMatchingTime   Json[]    @default([]) @db.Json
   // Since the introduction of Match Pools we also track whether a match was created for Lern-Fair Now or Lern-Fair Plus.
   // Previously one could not distinguish plus and now matches
-  matchPool String?   @db.VarChar
-  studentId Int?
-  pupilId   Int?
-  pupil     pupil?    @relation(fields: [pupilId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "FK_38770d911dab69557a913812f3f")
-  student   student?  @relation(fields: [studentId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "FK_89d8d61ff2bcae46513788416e4")
-  lecture   lecture[]
+  matchPool                String?   @db.VarChar
+  studentId                Int?
+  pupilId                  Int?
+  pupil                    pupil?    @relation(fields: [pupilId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "FK_38770d911dab69557a913812f3f")
+  student                  student?  @relation(fields: [studentId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "FK_89d8d61ff2bcae46513788416e4")
+  lecture                  lecture[]
 
   learning_topics learning_topic[]
 


### PR DESCRIPTION
## Ticket

https://github.com/corona-school/project-user/issues/1482 (Partially)

## What was done?

- Added a `subjectsAtMatchingTime` on the match table
- Adjusted the getOverlappingSubjects function to include the grade range from `studentSubject`
- Use the new property on the subjectsFormatted resolver when available