### PR TITLE
fix: Handle user retrieval error in invitee created event

### DIFF
--- a/common/calendly/index.ts
+++ b/common/calendly/index.ts
@@ -126,7 +126,7 @@ const onEventInviteeCreated = async (event: CalendlyEvent) => {
     } catch (error) {
         // If user wasn't found we can just "fail silently" here as probably the user entered a different email
         // which we can't prevent from calendly ...
-        logger.warn('Error getting user from Calendly event');
+        logger.warn(`Error getting user from Calendly Event(${event.payload.scheduled_event.uri})`);
         return;
     }
     const screener = await getEventOrganizer(event);


### PR DESCRIPTION
## What was done?

- I added a missing handler in case the user from the Calendly event is not found.