### PR TITLE
fix: Include 'dispute' status when fetching pupil screenings

### DIFF
--- a/common/calendly/index.ts
+++ b/common/calendly/index.ts
@@ -139,7 +139,7 @@ const onEventInviteeCreated = async (event: CalendlyEvent) => {
         let screening = await prisma.pupil_screening.findFirst({
             where: {
                 pupilId: user.pupilId,
-                status: 'pending',
+                status: { in: ['pending', 'dispute'] },
                 invalidated: false,
             },
         });


### PR DESCRIPTION
## Description

In some cases, screenings don't approve/reject, but they leave the screening in a disputed state, waiting for something to happen from the user side. (e.g, move to a country, do another screening with the parents/sibling, etc...).
With this, I'm also including that dispute status when checking if a pupil has a valid on-going screening