### PR TITLE
Fix: Keep one active Calendly event

### DIFF
--- a/common/calendly/index.ts
+++ b/common/calendly/index.ts
@@ -1,4 +1,5 @@
 import moment from 'moment-timezone';
+import 'moment/locale/de';
 import { getLogger } from '../logger/logger';
 import { addPupilScreening } from '../pupil/screening';
 import { getPupil, getUserByEmail, User } from '../user';
@@ -144,7 +145,7 @@ const getEventOrganizer = async (event: CalendlyEvent) => {
 };
 
 const formatAppointmentDate = (date: string) => {
-    return moment.tz(date, 'Europe/Berlin').utc().format('dddd DD. MMM, HH:mm');
+    return moment.tz(date, 'Europe/Berlin').format('dddd DD. MMM, HH:mm');
 };
 
 const onEventInviteeCreated = async (event: CalendlyEvent) => {

--- a/common/calendly/index.ts
+++ b/common/calendly/index.ts
@@ -112,6 +112,10 @@ const getEventOrganizer = async (event: CalendlyEvent) => {
     const [membership] = event.payload.scheduled_event.event_memberships;
     try {
         const user = await getUserByEmail(membership.user_email);
+        if (!user.screenerId) {
+            logger.warn(`User with email ${membership.user_email} does not have a screener ID.`);
+            return null;
+        }
         return user;
     } catch (error) {
         logger.warn(`Failed to get screener from calendly event: ${membership.user_email}`, error);


### PR DESCRIPTION
## Ticket

Resolves https://github.com/corona-school/project-user/issues/1501

## What was done?

- Added a validation to prevent multiple active Calendly events
- Allow obtaining appointments from disputed screenings
- Allow obtaining only ongoing appointments or in the future