### PR TITLE
Feat: Include calendar preferences in matching algo

### DIFF
--- a/common/match/matching.spec.ts
+++ b/common/match/matching.spec.ts
@@ -58,6 +58,17 @@ const requestFive = {
         { name: 'Deutsch', mandatory: false },
     ],
     requestAt: new Date(0),
+    calendarPreferences: {
+        weeklyAvailability: {
+            monday: [{ from: 600, to: 660 }],
+            tuesday: [],
+            wednesday: [],
+            thursday: [],
+            friday: [],
+            saturday: [],
+            sunday: [],
+        },
+    },
 };
 
 const requestSix = {
@@ -76,6 +87,29 @@ const requestSeven = {
     subjects: [{ name: 'Mathematik' }, { name: 'Deutsch' }],
     requestAt: new Date(0),
     hasSpecialNeeds: true,
+};
+
+const requestEight = {
+    grade: 10,
+    pupilId: 8,
+    state: 'at' as const,
+    subjects: [{ name: 'Mathematik' }, { name: 'Deutsch' }],
+    requestAt: new Date(0),
+    calendarPreferences: {
+        weeklyAvailability: {
+            monday: [
+                { from: 1080, to: 1140 },
+                { from: 1140, to: 1200 },
+                { from: 1200, to: 1260 },
+            ],
+            tuesday: [],
+            wednesday: [],
+            thursday: [],
+            friday: [],
+            saturday: [],
+            sunday: [],
+        },
+    },
 };
 
 const offerOne = {
@@ -121,6 +155,31 @@ const offerFive = {
     requestAt: new Date(0),
     gender: 'female' as const,
     hasSpecialExperience: true,
+};
+
+const offerSix = {
+    studentId: 6,
+    state: 'bw' as const,
+    subjects: [
+        { name: 'Deutsch', grade: { min: 1, max: 10 } },
+        { name: 'Mathematik', mandatory: false, grade: { min: 1, max: 10 } },
+    ],
+    requestAt: new Date(0),
+    calendarPreferences: {
+        weeklyAvailability: {
+            monday: [
+                { from: 1080, to: 1140 },
+                { from: 1140, to: 1200 },
+                { from: 1200, to: 1260 },
+            ],
+            tuesday: [],
+            wednesday: [],
+            thursday: [],
+            friday: [],
+            saturday: [],
+            sunday: [],
+        },
+    },
 };
 
 describe('Matching Score Basics', () => {
@@ -189,4 +248,14 @@ describe('Special Needs Constraint', () => {
     test('', [requestSeven], [offerFour], []);
     // Offer experience -> Match
     test('', [requestSeven], [offerFive], [{ request: requestSeven, offer: offerFive }]);
+});
+
+describe('Weekly Availability Constraint', () => {
+    // For now if only one has availability set, then it's not a constraint to create the match
+    test('', [requestFive], [offerFive], [{ request: requestFive, offer: offerFive }]);
+
+    // Availability mismatch (both set) -> No Match
+    test('', [requestFive], [offerSix], []);
+    // // Availability match (both set) -> Match
+    test('', [requestEight], [offerSix], [{ request: requestEight, offer: offerSix }]);
 });

--- a/common/util/calendarPreferences.ts
+++ b/common/util/calendarPreferences.ts
@@ -33,7 +33,7 @@ export const getOverlappingHoursCount = (availabilityA: WeeklyAvailability, avai
                 const overlapDuration = overlapEnd - overlapStart;
 
                 if (overlapDuration >= 60) {
-                    count += 1;
+                    count += overlapDuration / 60;
                 }
             }
         }

--- a/common/util/calendarPreferences.ts
+++ b/common/util/calendarPreferences.ts
@@ -1,4 +1,46 @@
-import { Day, DayAvailabilitySlot, WeeklyAvailability } from '../../graphql/types/calendarPreferences';
+import { Day, DAYS, DayAvailabilitySlot, WeeklyAvailability } from '../../graphql/types/calendarPreferences';
+
+const mergeSlots = (slots: DayAvailabilitySlot[]) => {
+    slots.sort((a, b) => a.from - b.from);
+
+    const merged = [];
+    for (const slot of slots) {
+        const last = merged[merged.length - 1];
+
+        if (last && slot.from <= last.to) {
+            merged[merged.length - 1] = {
+                from: last.from,
+                to: Math.max(last.to, slot.to),
+            };
+        } else {
+            merged.push({ ...slot });
+        }
+    }
+
+    return merged;
+};
+
+export const getOverlappingHoursCount = (availabilityA: WeeklyAvailability, availabilityB: WeeklyAvailability) => {
+    let count = 0;
+    for (const day of DAYS) {
+        const slotsA = mergeSlots(availabilityA[day] || []);
+        const slotsB = mergeSlots(availabilityB[day] || []);
+
+        for (const slotA of slotsA) {
+            for (const slotB of slotsB) {
+                const overlapStart = Math.max(slotA.from, slotB.from);
+                const overlapEnd = Math.min(slotA.to, slotB.to);
+                const overlapDuration = overlapEnd - overlapStart;
+
+                if (overlapDuration >= 60) {
+                    count += 1;
+                }
+            }
+        }
+    }
+
+    return count;
+};
 
 export const getMatchAvailabilityFromPerspective = (myAvailability: WeeklyAvailability, learningPartnerAvailability: WeeklyAvailability) => {
     const matchAvailability: WeeklyAvailability = {

--- a/graphql/types/calendarPreferences.ts
+++ b/graphql/types/calendarPreferences.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';
 import { Field, InputType, ObjectType } from 'type-graphql';
 
 export type Day = 'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday' | 'saturday' | 'sunday';


### PR DESCRIPTION
## Ticket

https://github.com/corona-school/project-user/issues/1499

## What was done?

- Added a function to get the amount of overlapping hours from two availabilities
- Updated the matching algo to consider calendar availability
- Updated tests