### PR TITLE
fix: Use Appointment title or Course title as zoom appointment topic/agenda

### DIFF
--- a/common/appointment/create.ts
+++ b/common/appointment/create.ts
@@ -174,7 +174,11 @@ export const createGroupAppointments = async (
             let zoomMeetingId: string | null;
 
             if (hosts != null) {
-                const videoChat = await createZoomMeetingForAppointmentWithHosts(hosts, appointmentToBeCreated, true);
+                const videoChat = await createZoomMeetingForAppointmentWithHosts(
+                    hosts,
+                    { ...appointmentToBeCreated, title: appointmentToBeCreated.title || subcourse.course.name },
+                    true
+                );
                 logger.info(`Zoom - Created meeting ${videoChat.id} for subcourse ${subcourseId}`);
                 zoomMeetingId = videoChat.id.toString();
             }
@@ -261,7 +265,7 @@ const createZoomMeetingForAppointmentWithHosts = async (
     isCourse: boolean
 ) => {
     try {
-        const newVideoChat = await createZoomMeeting(hosts, appointment.start, appointment.duration, isCourse);
+        const newVideoChat = await createZoomMeeting(hosts, appointment.start, appointment.duration, isCourse, appointment.title || 'Lern-Fair Termin');
         return newVideoChat;
     } catch (error) {
         throw new Error(`Zoom - Error while creating zoom meeting: ${error}`);

--- a/common/zoom/scheduled-meeting.ts
+++ b/common/zoom/scheduled-meeting.ts
@@ -49,7 +49,7 @@ const zoomUsersUrl = 'https://api.zoom.us/v2/users';
 const zoomMeetingUrl = 'https://api.zoom.us/v2/meetings';
 const zoomMeetingReportUrl = 'https://api.zoom.us/v2/report/meetings';
 
-const createZoomMeeting = async (zoomUsers: ZoomUser[], startTime: Date, duration: number, isCourse: boolean): Promise<ZoomMeeting> => {
+const createZoomMeeting = async (zoomUsers: ZoomUser[], startTime: Date, duration: number, isCourse: boolean, name: string): Promise<ZoomMeeting> => {
     assureZoomFeatureActive();
 
     const { access_token } = await getAccessToken();
@@ -71,7 +71,8 @@ const createZoomMeeting = async (zoomUsers: ZoomUser[], startTime: Date, duratio
                     'Content-Type': 'application/json',
                 },
                 body: JSON.stringify({
-                    agenda: 'My Meeting',
+                    topic: name,
+                    agenda: name,
                     default_password: false,
                     duration: duration,
                     start_time: start,


### PR DESCRIPTION
Mostly for the Hausaufgabenhilfe. I think for most of the users this is quite irrelevant