### PR TITLE
Hotfix: Zoom mess

### DIFF
--- a/common/appointment/update.ts
+++ b/common/appointment/update.ts
@@ -115,7 +115,7 @@ export async function updateAppointment(
         }
     }
     const zoomUpdate = {
-        start: newStart,
+        startTime: newStart,
         duration: newDuration,
         endDate: lastDate,
     };

--- a/common/zoom/scheduled-meeting.ts
+++ b/common/zoom/scheduled-meeting.ts
@@ -235,7 +235,7 @@ const updateZoomMeeting = async (meetingId: string, update: { startTime?: Date; 
     if (update.duration) {
         body.duration = update.duration;
     }
-    if (update.organizers) {
+    if (update.organizers !== undefined) {
         body.settings = {
             alternative_hosts: update.organizers,
         };

--- a/integration-tests/07_course.ts
+++ b/integration-tests/07_course.ts
@@ -479,7 +479,7 @@ void test('Add / Remove another instructor', async () => {
     expectFetch({
         url: 'https://api.zoom.us/v2/meetings/10',
         method: 'PATCH',
-        body: `{"start_time":"*","timezone":"Europe/Berlin","settings":{"alternative_hosts":"${instructor2.email.toLowerCase()}"}}`,
+        body: `{"timezone":"Europe/Berlin","settings":{"alternative_hosts":"${instructor2.email.toLowerCase()}"}}`,
         responseStatus: 200,
         response: '{}',
     });
@@ -518,7 +518,7 @@ void test('Add / Remove another instructor', async () => {
     expectFetch({
         url: 'https://api.zoom.us/v2/meetings/10',
         method: 'PATCH',
-        body: '{"start_time":"*","timezone":"Europe/Berlin","settings":{"alternative_hosts":""}}',
+        body: '{"timezone":"Europe/Berlin","settings":{"alternative_hosts":""}}',
         responseStatus: 200,
         response: '{}',
     });

--- a/integration-tests/08_appointments.ts
+++ b/integration-tests/08_appointments.ts
@@ -179,7 +179,7 @@ const updatedAppointments = test('Update an appointment', async () => {
     expectFetch({
         url: 'https://api.zoom.us/v2/meetings/10',
         method: 'PATCH',
-        body: '{"start_time":"*","duration":120,"timezone":"Europe/Berlin","settings":{}}',
+        body: '{"timezone":"Europe/Berlin","start_time":"*","duration":120}',
         responseStatus: 200,
         response: {},
     });


### PR DESCRIPTION
## Ticket

 Resolves https://github.com/corona-school/project-user/issues/1522

## What was done?

- Updated the `updateZoomMeeting` so it doesn't break all the Zoom appointments for a course after adding/removing an instructor.
- Fix the reschedule functionality so it actually reschedules the meeting in Zoom and it doesn't get deleted by them