### PR TITLE
feat: Invalidate screenings when pupils request a second match

### DIFF
--- a/common/match/request.ts
+++ b/common/match/request.ts
@@ -70,30 +70,27 @@ export async function createPupilMatchRequest(pupil: Pupil, adminOverride = fals
 
     await Notification.actionTaken(userForPupil(pupil), 'tutee_match_requested', {});
 
-    const isFirstScreening =
-        (await prisma.pupil_screening.count({
-            where: {
-                pupilId: pupil.id,
-            },
-        })) === 1;
+    const hasActiveMatch = (await prisma.match.count({ where: { pupilId: pupil.id, dissolved: false } })) > 0;
 
-    // Invalidation for match request doesn't apply when there is only one screening.
-    if (!isFirstScreening) {
-        // If the last successful screening, wasn't in the last four months, then invalidate all the screenings.
-        const screening = await prisma.pupil_screening.findFirst({
-            where: {
-                pupilId: pupil.id,
-                status: 'success',
-                invalidated: false,
-                createdAt: {
-                    gte: moment().subtract(4, 'months').toDate(),
-                },
+    const screeningInTheLastFourMonths = await prisma.pupil_screening.findFirst({
+        where: {
+            pupilId: pupil.id,
+            status: 'success',
+            invalidated: false,
+            createdAt: {
+                gte: moment().subtract(4, 'months').toDate(),
             },
-            orderBy: {
-                createdAt: 'desc',
-            },
-        });
-        if (!screening) {
+        },
+        orderBy: {
+            createdAt: 'desc',
+        },
+    });
+
+    // Invalidation doesn't apply when admins/screeners are creating the match request
+    if (!adminOverride) {
+        // If the last successful screening, wasn't in the last four months.
+        // OR if the user is requesting a second match, then invalidate all the screenings.
+        if (!screeningInTheLastFourMonths || hasActiveMatch) {
             await invalidateAllScreeningsOfPupil(pupil.id);
         }
     }

--- a/common/match/request.ts
+++ b/common/match/request.ts
@@ -70,24 +70,23 @@ export async function createPupilMatchRequest(pupil: Pupil, adminOverride = fals
 
     await Notification.actionTaken(userForPupil(pupil), 'tutee_match_requested', {});
 
-    const hasActiveMatch = (await prisma.match.count({ where: { pupilId: pupil.id, dissolved: false } })) > 0;
-
-    const screeningInTheLastFourMonths = await prisma.pupil_screening.findFirst({
-        where: {
-            pupilId: pupil.id,
-            status: 'success',
-            invalidated: false,
-            createdAt: {
-                gte: moment().subtract(4, 'months').toDate(),
-            },
-        },
-        orderBy: {
-            createdAt: 'desc',
-        },
-    });
-
     // Invalidation doesn't apply when admins/screeners are creating the match request
     if (!adminOverride) {
+        const hasActiveMatch = (await prisma.match.count({ where: { pupilId: pupil.id, dissolved: false } })) > 0;
+
+        const screeningInTheLastFourMonths = await prisma.pupil_screening.findFirst({
+            where: {
+                pupilId: pupil.id,
+                status: 'success',
+                invalidated: false,
+                createdAt: {
+                    gte: moment().subtract(4, 'months').toDate(),
+                },
+            },
+            orderBy: {
+                createdAt: 'desc',
+            },
+        });
         // If the last successful screening, wasn't in the last four months.
         // OR if the user is requesting a second match, then invalidate all the screenings.
         if (!screeningInTheLastFourMonths || hasActiveMatch) {


### PR DESCRIPTION
## Ticket

Resolves https://github.com/corona-school/project-user/issues/1521

## What was done?

- Invalidate pupil screenings when a second match is requested
- Add an exception when admins/screeners are the ones creating it