### PR TITLE
fix: Validate demand field

### DIFF
--- a/common/match/pool.ts
+++ b/common/match/pool.ts
@@ -536,7 +536,7 @@ export function getPoolStatistics(pool: MatchPool): Promise<MatchPoolStatistics>
         const lastMonth = matchesByMonth.slice(-2)[0];
         const subjectDemand = Object.entries(lastMonth?.subjects ?? {}).map(([subject, { fulfilled, offered, requested, requestedMandatory }]) => ({
             subject,
-            demand: requested / offered,
+            demand: offered > 0 ? requested / offered : null,
             offered: offered,
             requested: requested,
             requestedMandatory: isNaN(requestedMandatory) ? null : requestedMandatory,


### PR DESCRIPTION
## What was done?

Fixed error `Float cannot represent non numeric value: Infinity`When visiting statistics page on Retool