### PR TITLE
fix: Unread notifications query performance

### DIFF
--- a/graphql/user/fields.ts
+++ b/graphql/user/fields.ts
@@ -160,8 +160,8 @@ export class UserFieldsResolver {
                     message_translation: {
                         some: {},
                     },
+                    NOT: { disabledChannels: { has: NotificationChannelEnum.inapp } },
                 },
-                NOT: { notification: { disabledChannels: { has: NotificationChannelEnum.inapp } } },
             });
         }
 


### PR DESCRIPTION
Prisma generates a stupid SQL query for the filter:

... AND ("id" IN (<subquery>)) AND NOT ("id" IN(<subquery>)) ...

which it seems PostgreSQL fails to optimize. Maybe by restructuring the filter, Prisma generates a better query which PostgreSQL can optimize?