### PR TITLE
Feat: Add learning offer constraints

### DIFF
--- a/common/courses/participants.ts
+++ b/common/courses/participants.ts
@@ -1,4 +1,4 @@
-import { course as Course, subcourse as Subcourse, pupil as Pupil, student as Student } from '@prisma/client';
+import { course as Course, subcourse as Subcourse, pupil as Pupil, student as Student, course_category_enum } from '@prisma/client';
 import { getLogger } from '../logger/logger';
 import { prisma } from '../prisma';
 import * as Notification from '../notification';
@@ -119,6 +119,7 @@ export async function leaveSubcourseWaitinglist(subcourse: Subcourse, pupil: Pup
 }
 
 type CourseDecision =
+    | 'offer-restriction'
     | 'not-participant'
     | 'no-lectures'
     | 'subcourse-full'
@@ -195,6 +196,10 @@ export async function couldJoinSubcourse(subcourse: Subcourse, pupil: Pupil): Pr
     }
     if (subcourse.maxGrade && pupilGrade > subcourse.maxGrade) {
         return { allowed: false, reason: 'grade-to-high' };
+    }
+    const course = await prisma.course.findUnique({ where: { id: subcourse.courseId } });
+    if (pupil.learningOfferConstraints.includes('ONLY_DAZ_COURSES') && course.category !== course_category_enum.language) {
+        return { allowed: false, reason: 'offer-restriction' };
     }
 
     return { allowed: true };

--- a/common/match/request.ts
+++ b/common/match/request.ts
@@ -1,4 +1,4 @@
-import { pupil as Pupil, student as Student, pupil_registrationsource_enum as RegistrationSource } from '@prisma/client';
+import { pupil as Pupil, student as Student, pupil_registrationsource_enum as RegistrationSource, course_subject_enum } from '@prisma/client';
 import { getLogger } from '../../common/logger/logger';
 import { prisma } from '../prisma';
 import { assertAllowed, Decision } from '../util/decision';
@@ -60,8 +60,14 @@ export async function createPupilMatchRequest(pupil: Pupil, adminOverride = fals
     if (!adminOverride) {
         assertAllowed(await canPupilRequestMatch(pupil));
     }
-    if (!parseSubjectString(pupil.subjects).length) {
+    const subjects = parseSubjectString(pupil.subjects);
+    if (!subjects.length) {
         throw new PrerequisiteError('Subjects must be selected before creating a match request');
+    }
+
+    const subjectsIncludeDaz = subjects.some((subject) => subject.name === course_subject_enum.Deutsch_als_Zweitsprache);
+    if (pupil.learningOfferConstraints.includes('DAZ_SUBJECT_REQUIRED_FOR_MATCHING') && !subjectsIncludeDaz) {
+        throw new PrerequisiteError('DAZ must be selected as a subject to request a match');
     }
 
     const result = await prisma.pupil.update({

--- a/graphql/authorizations.ts
+++ b/graphql/authorizations.ts
@@ -442,6 +442,7 @@ export const authorizationModelEnhanceMap: ModelsEnhanceMap = {
             referredById: adminOrOwner,
             emailOwner: adminOrOwnerOrScreener,
             age: adminOrOwnerOrScreener,
+            learningOfferConstraints: adminOrOwnerOrScreener,
         }),
     },
 

--- a/graphql/pupil/mutations.ts
+++ b/graphql/pupil/mutations.ts
@@ -10,6 +10,7 @@ import { getSessionPupil, getSessionScreener, getSessionUser, isAdmin, isElevate
 import { Subject } from '../types/subject';
 import {
     gender_enum as Gender,
+    learning_offer_constraints_enum as LearningOfferConstraintsEnum,
     Prisma,
     PrismaClient,
     pupil as Pupil,
@@ -110,6 +111,9 @@ export class PupilUpdateInput {
 
     @Field((type) => Boolean, { nullable: true })
     isParticipant?: boolean;
+
+    @Field((type) => [LearningOfferConstraintsEnum], { nullable: true })
+    learningOfferConstraints?: LearningOfferConstraintsEnum[];
 }
 
 @InputType()
@@ -159,6 +163,7 @@ export async function updatePupil(
         age,
         isPupil,
         isParticipant,
+        learningOfferConstraints,
     } = update;
 
     if (registrationSource != undefined && !isElevated(context)) {
@@ -193,6 +198,10 @@ export async function updatePupil(
         throw new PrerequisiteError('isParticipant may only be changed by elevated users');
     }
 
+    if (learningOfferConstraints !== undefined && !isElevated(context)) {
+        throw new PrerequisiteError('learningOfferConstraints may only be changed by elevated users');
+    }
+
     let dbSchool: School | undefined;
     try {
         dbSchool = await findOrCreateSchool(school);
@@ -225,6 +234,7 @@ export async function updatePupil(
             age: ensureNoNull(age),
             isPupil,
             isParticipant,
+            learningOfferConstraints: ensureNoNull(learningOfferConstraints),
         },
         where: { id: pupil.id },
     });

--- a/graphql/subcourse/fields.ts
+++ b/graphql/subcourse/fields.ts
@@ -111,6 +111,13 @@ export class ExtendedFieldsSubcourseResolver {
                         AND: [{ minGrade: { lte: pupilGrade }, maxGrade: { gte: pupilGrade } }],
                     });
                 }
+                if (pupil.learningOfferConstraints.includes('ONLY_DAZ_COURSES')) {
+                    filters.push({
+                        course: {
+                            category: 'language',
+                        },
+                    });
+                }
             }
         }
 

--- a/graphql/types/enums.ts
+++ b/graphql/types/enums.ts
@@ -20,6 +20,7 @@ import {
     student_screening_status_enum as StudentScreeningStatus,
     student_jobstatus_enum as JobStatus,
     cooperation_type_enum as CooperationType,
+    learning_offer_constraints_enum as LearningOfferConstraintsEnum,
 } from '@prisma/client';
 import { LoginOption } from '../../common/secret';
 import { StudentScreeningType } from '../../common/student/screening';
@@ -98,3 +99,4 @@ registerEnumType(StudentScreeningType, { name: 'StudentScreeningType' });
 registerEnumType(AppointmentRole, { name: 'AppointmentRole' });
 registerEnumType(JobStatus, { name: 'StudentJobStatus' });
 registerEnumType(CooperationType, { name: 'CooperationType' });
+registerEnumType(LearningOfferConstraintsEnum, { name: 'LearningOfferConstraintsEnum' });

--- a/prisma/migrations/20260529113519_learning_offer_constraints/migration.sql
+++ b/prisma/migrations/20260529113519_learning_offer_constraints/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "learning_offer_constraints_enum" AS ENUM ('ONLY_DAZ_COURSES', 'DAZ_SUBJECT_REQUIRED_FOR_MATCHING');
+
+-- AlterTable
+ALTER TABLE "pupil" ADD COLUMN     "learningOfferConstraints" "learning_offer_constraints_enum"[] DEFAULT ARRAY[]::"learning_offer_constraints_enum"[];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -648,7 +648,8 @@ model pupil {
 
   // Sometimes pupils, specially younger ones, are registered with the email of a support person (parent, teacher, etc...)
   // Here we specify who is the owner of this email
-  emailOwner pupil_email_owner_enum @default(unknown)
+  emailOwner            pupil_email_owner_enum      @default(unknown)
+  learningOfferConstraints learning_offer_constraints_enum[] @default([])
 }
 
 // To only match active users, we sent interest confirmation requests to pupils before matching them
@@ -1601,4 +1602,9 @@ enum important_information_category_enum {
   holiday_info
   news
   important
+}
+
+enum learning_offer_constraints_enum {
+  ONLY_DAZ_COURSES
+  DAZ_SUBJECT_REQUIRED_FOR_MATCHING
 }


### PR DESCRIPTION
## Ticket

Resolves https://github.com/corona-school/project-user/issues/1595

## What was done?

- Added a new enum to set restrictions to the offers a pupil can access. For now only (and not so convinced with the naming yet ... ):
  - `ONLY_DAZ_COURSES`
  - `DAZ_SUBJECT_REQUIRED_FOR_MATCHING`
- Added validations for the constraints

NOTE: This wont't be used yet _(There is no UI for this)_, so we still can make changes before that.