### PR TITLE
Feat: Zoom Webhook

### DIFF
--- a/common/achievement/evaluate.spec.ts
+++ b/common/achievement/evaluate.spec.ts
@@ -307,6 +307,7 @@ function createLecture({ start }: { start: Date }): lecture {
         instructorScreeningId: null,
         pupilScreeningId: null,
         tutorScreeningId: null,
+        actualDuration: null,
     };
 }
 

--- a/common/zoom/scheduled-meeting.ts
+++ b/common/zoom/scheduled-meeting.ts
@@ -45,6 +45,28 @@ export type ZoomMeetings = {
     meetings: ZoomMeeting[];
 };
 
+export type ZoomMeetingParticipant = {
+    id: string;
+    name: string;
+    user_id: string;
+    registrant_id: string;
+    user_email: string;
+    join_time: string;
+    leave_time: string;
+    duration: number;
+    failover: boolean;
+    status: string;
+    internal_user: boolean;
+};
+
+export type ZoomMeetingReport = {
+    next_page_token: string;
+    page_count: number;
+    page_size: number;
+    total_records: number;
+    participants: ZoomMeetingParticipant[];
+};
+
 const zoomUsersUrl = 'https://api.zoom.us/v2/users';
 const zoomMeetingUrl = 'https://api.zoom.us/v2/meetings';
 const zoomMeetingReportUrl = 'https://api.zoom.us/v2/report/meetings';
@@ -182,7 +204,7 @@ const deleteZoomMeeting = async (appointment: Appointment): Promise<void> => {
     logger.info(`Zoom - The Zoom Meeting ${appointment.zoomMeetingId} was deleted.`);
 };
 
-const getZoomMeetingReport = async (meetingId: string) => {
+const getZoomMeetingReport = async (meetingId: string): Promise<ZoomMeetingReport | null> => {
     assureZoomFeatureActive();
 
     const { access_token } = await getAccessToken('report:read:admin');

--- a/common/zoom/webhook.ts
+++ b/common/zoom/webhook.ts
@@ -1,0 +1,161 @@
+import { lecture as Appointment } from '@prisma/client';
+import { trackUserJoinAppointmentMeeting } from '../appointment/tracking';
+import { getLogger } from '../logger/logger';
+import { prisma } from '../prisma';
+import { getUser } from '../user';
+import { getZoomMeetingReport } from './scheduled-meeting';
+
+interface ZoomMeetingEndedEvent {
+    event: 'meeting.ended';
+    event_ts: number;
+    payload: {
+        account_id: string;
+        object: {
+            id: string;
+            uuid: string;
+            host_id: string;
+            host_email: string;
+            topic: string;
+            type: number;
+            start_time: string;
+            timezone: string;
+            duration: number;
+            end_time: string;
+        };
+    };
+}
+
+interface ZoomMeetingParticipantJoinedEvent {
+    event: 'meeting.participant_joined';
+    event_ts: number;
+    payload: {
+        account_id: string;
+        object: {
+            id: string;
+            uuid: string;
+            host_id: string;
+            topic: string;
+            type: number;
+            start_time: string;
+            timezone: string;
+            duration: number;
+            participant: {
+                user_id: string;
+                user_name: string;
+                id: string;
+                participant_uuid: string;
+                date_time: string;
+                email: string;
+                registrant_id: string;
+                participant_user_id: string;
+                customer_key: string;
+                phone_number: string;
+            };
+        };
+    };
+}
+
+type ZoomEvent = ZoomMeetingEndedEvent | ZoomMeetingParticipantJoinedEvent;
+const logger = getLogger('ZoomWebhook');
+const validEventTypes = ['meeting.ended', 'meeting.participant_joined'];
+
+export const onEvent = async (zoomEvent: ZoomEvent) => {
+    // Discard event if it's not configured
+    if (!validEventTypes.includes(zoomEvent.event)) {
+        logger.debug(`Discarding event type: ${zoomEvent.event}`);
+        return;
+    }
+
+    // For now we'll only consider match appointments.
+    const appointment = await prisma.lecture.findFirst({ where: { appointmentType: 'match', zoomMeetingId: zoomEvent.payload.object.id } });
+    // We don't care about appointments we don't recognize / types we don't support yet.
+    if (!appointment) {
+        logger.debug(`No appointment found for Zoom Meeting ID: ${zoomEvent.payload.object.id}`);
+        return;
+    }
+
+    logger.info(`Handling ZoomEvent(${zoomEvent.event})`, zoomEvent);
+    try {
+        switch (zoomEvent.event) {
+            case 'meeting.ended':
+                return await onEventMeetingEnded(zoomEvent, appointment);
+            case 'meeting.participant_joined':
+                return await onEventMeetingParticipantJoined(zoomEvent, appointment);
+            default:
+                logger.warn(`Unknown Zoom event type: ${(zoomEvent as any)?.event}`, zoomEvent);
+                break;
+        }
+    } catch (error) {
+        logger.error(`Error handling ZoomEvent(${zoomEvent.event}) ${error.message}`, error);
+    }
+};
+
+const getOverlapInSeconds = (intervalsA: { start: Date; end: Date }[], intervalsB: { start: Date; end: Date }[]) => {
+    let total = 0;
+
+    for (const a of intervalsA) {
+        for (const b of intervalsB) {
+            const start = Math.max(a.start.getTime(), b.start.getTime());
+            const end = Math.min(a.end.getTime(), b.end.getTime());
+
+            if (end > start) {
+                total += (end - start) / 1000;
+            }
+        }
+    }
+
+    return total;
+};
+
+const onEventMeetingEnded = async (event: ZoomMeetingEndedEvent, appointment: Appointment) => {
+    const report = await getZoomMeetingReport(event.payload.object.id);
+    if (!report?.participants) {
+        return;
+    }
+
+    // Only students have a zoom account
+    const hostFragments = report.participants.filter((e) => !!e.id);
+    const guestFragments = report.participants.filter((e) => !e.id);
+
+    if (!hostFragments.length || !guestFragments.length) {
+        return;
+    }
+
+    // Users can have internet issues or other reason to reconnect and so have multiple join/leave times.
+    const hostIntervals = hostFragments
+        .filter((r) => r.status === 'in_meeting')
+        .map((r) => ({
+            start: new Date(r.join_time),
+            end: new Date(r.leave_time),
+        }));
+
+    const guestIntervals = guestFragments
+        .filter((r) => r.status === 'in_meeting')
+        .map((r) => ({
+            start: new Date(r.join_time),
+            end: new Date(r.leave_time),
+        }));
+
+    const sharedTime = getOverlapInSeconds(hostIntervals, guestIntervals);
+
+    if (!sharedTime) {
+        return;
+    }
+    await prisma.lecture.update({ where: { id: appointment.id }, data: { actualDuration: { increment: Math.ceil(sharedTime / 60) } } });
+};
+
+const onEventMeetingParticipantJoined = async (event: ZoomMeetingParticipantJoinedEvent, appointment: Appointment) => {
+    const pupilId = appointment.participantIds.find((id) => id.startsWith('pupil/'));
+    const studentId = appointment.organizerIds.find((id) => id.startsWith('student/'));
+    const participant = event.payload.object.participant;
+    if (participant.participant_user_id) {
+        // Only students have a zoomId
+        const user = await getUser(studentId);
+        await trackUserJoinAppointmentMeeting(user, appointment);
+        return;
+    }
+
+    // As pupils don't have a zoom account at all we have to assume that all guests are pupils ...
+    const pupil = await getUser(pupilId);
+    await trackUserJoinAppointmentMeeting(pupil, appointment);
+};

--- a/graphql/authorizations.ts
+++ b/graphql/authorizations.ts
@@ -654,6 +654,7 @@ export const authorizationModelEnhanceMap: ModelsEnhanceMap = {
             zoomMeetingReport: adminOrOwner,
             override_meeting_link: participantOrOwnerOrAdmin,
             eventUrl: adminOrOwner,
+            actualDuration: adminOrOwner,
         }),
     },
     Participation_certificate: {

--- a/prisma/migrations/20260619090930_add_actual_duration_field/migration.sql
+++ b/prisma/migrations/20260619090930_add_actual_duration_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "lecture" ADD COLUMN     "actualDuration" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -377,7 +377,10 @@ model lecture {
   createdAt             DateTime                     @default(now()) @db.Timestamp(6)
   updatedAt             DateTime                     @default(now()) @updatedAt @db.Timestamp(6)
   start                 DateTime                     @db.Timestamp(6)
+  // Scheduled duration of the appointment
   duration              Int // in minutes
+  // This is the duration in minutes in which the host + someone else were in the meeting together
+  actualDuration        Int                          @default(0) // in minutes
   title                 String?
   description           String?
   appointmentType       lecture_appointmenttype_enum @default(legacy)
@@ -648,7 +651,7 @@ model pupil {
 
   // Sometimes pupils, specially younger ones, are registered with the email of a support person (parent, teacher, etc...)
   // Here we specify who is the owner of this email
-  emailOwner            pupil_email_owner_enum      @default(unknown)
+  emailOwner               pupil_email_owner_enum            @default(unknown)
   learningOfferConstraints learning_offer_constraints_enum[] @default([])
 }
 
@@ -1011,8 +1014,8 @@ model important_information {
   language    important_information_language_enum   @default(de)
   ctaLabel    String?
   category    important_information_category_enum   @default(important)
-  activeFrom  DateTime?                              @db.Timestamp(6)
-  activeUntil DateTime?                              @db.Timestamp(6)
+  activeFrom  DateTime?                             @db.Timestamp(6)
+  activeUntil DateTime?                             @db.Timestamp(6)
 }
 
 // Before matching a pupil, in some match pools we ask them to do a screening beforehand:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -379,7 +379,7 @@ model lecture {
   start                 DateTime                     @db.Timestamp(6)
   // Scheduled duration of the appointment
   duration              Int // in minutes
-  // This is the duration in minutes in which the host + someone else were in the meeting together
+  // This is the duration in minutes in which the host + someone else were in the meeting together (Only set for match appointments)
   actualDuration        Int                          @default(0) // in minutes
   title                 String?
   description           String?

--- a/web/controllers/zoomController/index.ts
+++ b/web/controllers/zoomController/index.ts
@@ -1,0 +1,45 @@
+import { Request, Router } from 'express';
+import { getLogger } from '../../../common/logger/logger';
+import crypto from 'crypto';
+import { WithRawBody } from '../chatNotificationController/types';
+import { onEvent } from '../../../common/zoom/webhook';
+
+const logger = getLogger('ZoomWebhook');
+
+const webhookSigningKey = process.env.ZOOM_WEBHOOK_SECRET_TOKEN;
+
+export const zoomRouter = Router();
+
+zoomRouter.post('/event', async (req: WithRawBody<Request>, res) => {
+    logger.info('Request at /zoom/event');
+    try {
+        const message = `v0:${req.headers['x-zm-request-timestamp']}:${JSON.stringify(req.body)}`;
+
+        const hashForVerify = crypto.createHmac('sha256', webhookSigningKey).update(message).digest('hex');
+
+        const signature = `v0=${hashForVerify}`;
+
+        // Webhook request did not come from Zoom
+        if (req.headers['x-zm-signature'] !== signature) {
+            logger.warn('Invalid signature for Zoom webhook event');
+            return res.status(401).send({ error: 'Unauthorized' });
+        }
+
+        // Webhook request event type is a challenge-response check
+        if (req.body.event === 'endpoint.url_validation') {
+            const hashForValidate = crypto.createHmac('sha256', webhookSigningKey).update(req.body.payload.plainToken).digest('hex');
+
+            res.status(200);
+            res.json({
+                plainToken: req.body.payload.plainToken,
+                encryptedToken: hashForValidate,
+            });
+            return;
+        }
+        await onEvent(req.body);
+        res.status(200).send({ status: 'ok' });
+    } catch (error) {
+        logger.error(`Failed to handle zoom event: ${error.message}`, error);
+        res.status(500).send({ error: 'Internal Server Error' });
+    }
+});

--- a/web/controllers/zoomController/index.ts
+++ b/web/controllers/zoomController/index.ts
@@ -11,6 +11,9 @@ const webhookSigningKey = process.env.ZOOM_WEBHOOK_SECRET_TOKEN;
 export const zoomRouter = Router();
 
 zoomRouter.post('/event', async (req: WithRawBody<Request>, res) => {
+    if (!webhookSigningKey) {
+        return;
+    }
     logger.info('Request at /zoom/event');
     try {
         const message = `v0:${req.headers['x-zm-request-timestamp']}:${JSON.stringify(req.body)}`;

--- a/web/server.ts
+++ b/web/server.ts
@@ -20,6 +20,7 @@ import { chatNotificationRouter } from './controllers/chatNotificationController
 import { WithRawBody } from './controllers/chatNotificationController/types';
 import { metricsRouter } from '../common/logger/metrics';
 import { calendlyRouter } from './controllers/calendlyController';
+import { zoomRouter } from './controllers/zoomController';
 
 // ------------------ Setup Logging, Common Headers, Routes ----------------
 
@@ -106,6 +107,7 @@ export const server = (async function setupWebserver() {
     app.use('/api/chat', chatNotificationRouter);
     app.use('/metrics', metricsRouter);
     app.use('/api/calendly', calendlyRouter);
+    app.use('/api/zoom', zoomRouter);
 
     app.get('/:certificateId', (req, res, next) => {
         if (!req.subdomains.includes('verify')) {


### PR DESCRIPTION
## What was done?

- Added a new webhook to listen to zoom events `meeting.ended` and `meeting.participant_joined` to collect more accurate information about the lectures.
- Added a new `actualDuration` column to the `lecture` table to store the time that at least two users spent in the meeting. I thought about re-using our `duration` in this case but it wasn't that clean because we use it as a "scheduledDuration" to calculate when we expect the meeting to end ... but it might be longer / shorter than that.
- Track more reliably when a user joins an appointment. So we also cover the cases where the student sends the zoom link to the pupil via chat, whatsapp _(this one shouldn't even be a use case but whatever)_, etc...

For now we only care about match appointments as this is a more recurring issue/need with these appointments.